### PR TITLE
added teams APIs, unified a method for user's organization and role checking

### DIFF
--- a/backend/aci/common/db/crud/__init__.py
+++ b/backend/aci/common/db/crud/__init__.py
@@ -1,3 +1,3 @@
-from . import organizations, users
+from . import organizations, teams, users
 
-__all__ = ["organizations", "users"]
+__all__ = ["organizations", "teams", "users"]

--- a/backend/aci/common/db/crud/organizations.py
+++ b/backend/aci/common/db/crud/organizations.py
@@ -68,6 +68,22 @@ def get_organization_members(
     )
 
 
+def is_user_in_organization(
+    db_session: Session,
+    organization_id: UUID,
+    user_id: UUID,
+) -> bool:
+    return (
+        db_session.query(OrganizationMembership)
+        .filter(
+            OrganizationMembership.organization_id == organization_id,
+            OrganizationMembership.user_id == user_id,
+        )
+        .first()
+        is not None
+    )
+
+
 def get_organization_membership(
     db_session: Session,
     organization_id: UUID,

--- a/backend/aci/common/db/crud/teams.py
+++ b/backend/aci/common/db/crud/teams.py
@@ -1,0 +1,90 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from aci.common.db.sql_models import Team, TeamMembership
+from aci.common.enums import TeamRole
+
+
+def create_team(
+    db_session: Session,
+    organization_id: UUID,
+    name: str,
+    description: str | None = None,
+) -> Team:
+    team = Team(organization_id=organization_id, name=name, description=description)
+    db_session.add(team)
+    db_session.flush()
+    db_session.refresh(team)
+    return team
+
+
+def get_teams_by_organization_id(
+    db_session: Session,
+    organization_id: UUID,
+) -> list[Team]:
+    return (
+        db_session.query(Team)
+        .filter(Team.organization_id == organization_id)
+        .order_by(Team.created_at.desc())
+        .all()
+    )
+
+
+def get_team_by_id(
+    db_session: Session,
+    team_id: UUID,
+) -> Team | None:
+    return db_session.query(Team).filter(Team.id == team_id).first()
+
+
+def get_team_by_organization_id_and_name(
+    db_session: Session,
+    organization_id: UUID,
+    name: str,
+) -> Team | None:
+    return (
+        db_session.query(Team)
+        .filter(Team.organization_id == organization_id)
+        .filter(Team.name == name)
+        .first()
+    )
+
+
+def add_team_member(
+    db_session: Session,
+    organization_id: UUID,
+    team_id: UUID,
+    user_id: UUID,
+) -> None:
+    team_member = TeamMembership(
+        team_id=team_id, organization_id=organization_id, user_id=user_id, role=TeamRole.MEMBER
+    )
+    db_session.add(team_member)
+    db_session.flush()
+
+
+def remove_team_member(
+    db_session: Session,
+    organization_id: UUID,
+    team_id: UUID,
+    user_id: UUID,
+) -> None:
+    db_session.query(TeamMembership).filter(
+        TeamMembership.team_id == team_id,
+        TeamMembership.organization_id == organization_id,
+        TeamMembership.user_id == user_id,
+    ).delete()
+    db_session.flush()
+
+
+def get_team_members(
+    db_session: Session,
+    team_id: UUID,
+) -> list[TeamMembership]:
+    return (
+        db_session.query(TeamMembership)
+        .filter(TeamMembership.team_id == team_id)
+        .order_by(TeamMembership.created_at.desc())
+        .all()
+    )

--- a/backend/aci/common/schemas/organizations.py
+++ b/backend/aci/common/schemas/organizations.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-from aci.common.enums import OrganizationRole
+from aci.common.enums import OrganizationRole, TeamRole
 
 
 class CreateOrganizationRequest(BaseModel):
@@ -14,7 +14,7 @@ class CreateOrganizationRequest(BaseModel):
 
 
 class OrganizationInfo(BaseModel):
-    organization_id: str
+    organization_id: UUID
     name: str
     description: str | None = None
 
@@ -29,3 +29,25 @@ class OrganizationMembershipInfo(BaseModel):
 
 class UpdateOrganizationMemberRoleRequest(BaseModel):
     role: OrganizationRole
+
+
+class CreateOrganizationTeamRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=100, description="Team name")
+    description: str | None = Field(
+        default=None, min_length=1, max_length=255, description="Team description"
+    )
+
+
+class TeamInfo(BaseModel):
+    team_id: UUID
+    name: str
+    description: str | None = None
+    created_at: datetime.datetime
+
+
+class TeamMembershipInfo(BaseModel):
+    user_id: UUID
+    name: str
+    email: str
+    role: TeamRole
+    created_at: datetime.datetime

--- a/backend/aci/control_plane/dependencies.py
+++ b/backend/aci/control_plane/dependencies.py
@@ -65,7 +65,7 @@ def get_request_context(
     jwt_payload: Annotated[JWTPayload, Depends(get_jwt_payload)],
 ) -> RequestContext:
     """
-    This method validates the user's permission to act as an organization.
+    This method validates whether the user is permitted to act as the desired organization and role.
     Returns a RequestContext object containing the DB session, user_id and act_as information.
     """
     if jwt_payload.act_as:


### PR DESCRIPTION
### 🏷️ Ticket
https://www.notion.so/team-operations-API-setup-2578378d6a4780809da8ee77d34ebbde?v=c135b6e7f76243819caf99a83e291380&source=copy_link

### 📝 Description
added teams APIs, unified a method for user's organization and role checking

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds Teams APIs under organizations and centralizes permission checks for acting as an org. Also switches organization_id in responses to UUID.

- **New Features**
  - Endpoints: create team, list teams, list team members, add/remove team members.
  - Schemas: CreateOrganizationTeamRequest, TeamInfo, TeamMembershipInfo.
  - Validation: organizations.is_user_in_organization to guard team membership.

- **Migration**
  - OrganizationInfo.organization_id is now a UUID (was str). Update client types.
  - Permission rules are enforced uniformly: act_as must match the org; ADMIN required for creating teams, adding members, and updating member roles.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added organization team management: create/list teams, view team members, and add/remove members.
* Refactor
  * Centralized permission checks across organization and team endpoints; clearer admin/member rules (self-removal allowed, last-admin protections).
  * Organization creation simplified: any signed-in user can create an organization.
  * Responses now return organization_id as a UUID (was string), and new team-related response types are available.
* Documentation
  * Clarified request context validation description for permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->