### PR TITLE
feat: added a command to seed a mock db with organization, teams, and users

### DIFF
--- a/backend/aci/cli/README.md
+++ b/backend/aci/cli/README.md
@@ -9,3 +9,8 @@ docker compose exec runner python -m aci.cli upsert-mcp-server --mcp-server-file
 ```bash
 docker compose exec runner python -m aci.cli upsert-mcp-tools --mcp-tools-file ./mcp_servers/notion/tools.json
 ```
+
+#### Create a mock organization, teams and users setting
+```bash
+docker compose exec runner python -m aci.cli create-mock-org-teams-users
+```

--- a/backend/aci/cli/aci.py
+++ b/backend/aci/cli/aci.py
@@ -1,6 +1,6 @@
 import click
 
-from aci.cli.commands import mcp
+from aci.cli.commands import mcp, organization
 from aci.common.logging_setup import setup_logging
 
 setup_logging()
@@ -13,6 +13,7 @@ def cli() -> None:
 
 cli.add_command(mcp.upsert_mcp_server, name="upsert-mcp-server")
 cli.add_command(mcp.upsert_mcp_tools, name="upsert-mcp-tools")
+cli.add_command(organization.create_mock_org_teams_users, name="create-mock-org-teams-users")
 
 
 if __name__ == "__main__":

--- a/backend/aci/cli/commands/organization/__init__.py
+++ b/backend/aci/cli/commands/organization/__init__.py
@@ -1,0 +1,3 @@
+from aci.cli.commands.organization.create_mock_org_teams_users import create_mock_org_teams_users
+
+__all__ = ["create_mock_org_teams_users"]

--- a/backend/aci/cli/commands/organization/create_mock_org_teams_users.py
+++ b/backend/aci/cli/commands/organization/create_mock_org_teams_users.py
@@ -1,0 +1,132 @@
+import uuid
+
+import click
+from rich.console import Console
+
+from aci.cli import config
+from aci.common import utils
+from aci.common.db import crud
+from aci.common.enums import OrganizationRole, UserIdentityProvider
+from aci.control_plane.routes import auth
+
+console = Console()
+
+
+@click.command()
+@click.option(
+    "--skip-dry-run",
+    is_flag=True,
+    help="provide this flag to run the command and apply changes to the database",
+)
+def create_mock_org_teams_users(
+    skip_dry_run: bool,
+) -> None:
+    """
+    Create a mock organization with teams and users in db.
+
+    This creates the following mock settings:
+
+    Organization: ACI Dev Org
+
+    Users:
+    - Admin (admin@aci.dev) - Admin role
+    - User1 (user1@aci.dev) - Member role
+    - User2 (user2@aci.dev) - Member role
+
+    Teams:
+    - Team 1 (Admin, User1)
+    - Team 2 (Admin, User1, User2)
+    """
+
+    short_id = uuid.uuid4().hex[:8]
+
+    with utils.create_db_session(config.DB_FULL_URL) as db_session:
+        # Create organization
+        organization = crud.organizations.create_organization(
+            db_session, f"ACI Dev Org {short_id}", f"ACI Dev Org {short_id} Description"
+        )
+
+        # Create users
+        admin = crud.users.create_user(
+            db_session,
+            name="ACI Admin",
+            email=f"admin-{short_id}@aci.dev",
+            password_hash=auth._hash_user_password("password"),
+            identity_provider=UserIdentityProvider.EMAIL,
+        )
+        user1 = crud.users.create_user(
+            db_session,
+            name="ACI User 1",
+            email=f"user1-{short_id}@aci.dev",
+            password_hash=auth._hash_user_password("password"),
+            identity_provider=UserIdentityProvider.EMAIL,
+        )
+        user2 = crud.users.create_user(
+            db_session,
+            name="ACI User 2",
+            email=f"user2-{short_id}@aci.dev",
+            password_hash=auth._hash_user_password("password"),
+            identity_provider=UserIdentityProvider.EMAIL,
+        )
+
+        # Add users to organization
+        crud.organizations.add_user_to_organization(
+            db_session, organization.id, admin.id, OrganizationRole.ADMIN
+        )
+        crud.organizations.add_user_to_organization(
+            db_session, organization.id, user1.id, OrganizationRole.MEMBER
+        )
+        crud.organizations.add_user_to_organization(
+            db_session, organization.id, user2.id, OrganizationRole.MEMBER
+        )
+
+        # Create teams
+        team1 = crud.teams.create_team(db_session, organization.id, f"Team 1 - {short_id}")
+        crud.teams.add_team_member(db_session, organization.id, team1.id, admin.id)
+        crud.teams.add_team_member(db_session, organization.id, team1.id, user1.id)
+
+        team2 = crud.teams.create_team(db_session, organization.id, f"Team 2 - {short_id}")
+        crud.teams.add_team_member(db_session, organization.id, team2.id, admin.id)
+        crud.teams.add_team_member(db_session, organization.id, team2.id, user1.id)
+        crud.teams.add_team_member(db_session, organization.id, team2.id, user2.id)
+
+        # Create JWTs
+        jwt_admin = auth._sign_token(admin, None)
+        jwt_user1 = auth._sign_token(user1, None)
+        jwt_user2 = auth._sign_token(user2, None)
+
+        if not skip_dry_run:
+            console.rule(
+                "[bold green]Provide --skip-dry-run to create mock organization[/bold green]"
+            )
+            db_session.rollback()
+        else:
+            db_session.commit()
+            console.rule("[bold green]Organization created with following hierarchy[/bold green]")
+            console.print(f"""Organization:
+ACI DevOrg {short_id}
+
+Users:
+- Admin (admin-{short_id}@aci.dev) - Admin role
+- User1 (user1-{short_id}@aci.dev) - Member role
+- User2 (user2-{short_id}@aci.dev) - Member role
+
+Teams:
+- Team 1 - {short_id} (Admin, User1)
+- Team 2 - {short_id} (Admin, User1, User2)
+            """)
+            console.print(
+                f"Admin JWT:\n{jwt_admin}\n", style="bold yellow", overflow="ignore", soft_wrap=True
+            )
+            console.print(
+                f"User 1 JWT:\n{jwt_user1}\n",
+                style="bold yellow",
+                overflow="ignore",
+                soft_wrap=True,
+            )
+            console.print(
+                f"User 2 JWT:\n{jwt_user2}\n",
+                style="bold yellow",
+                overflow="ignore",
+                soft_wrap=True,
+            )

--- a/backend/aci/control_plane/routes/auth.py
+++ b/backend/aci/control_plane/routes/auth.py
@@ -156,15 +156,14 @@ async def register(
         )
 
     # Hash password
-    salt = bcrypt.gensalt()
-    hashed = bcrypt.hashpw(request.password.encode(), salt)
+    hashed = _hash_user_password(request.password)
 
     # Create user
     user = crud.users.create_user(
         db_session=context.db_session,
         name=request.name,
         email=request.email,
-        password_hash=hashed.decode(),
+        password_hash=hashed,
         identity_provider=UserIdentityProvider.EMAIL,
     )
 
@@ -341,6 +340,12 @@ def _issue_refresh_token(db_session: Session, user_id: UUID, response: Response)
         samesite="lax",
         max_age=60 * 60 * 24 * 30,
     )
+
+
+def _hash_user_password(password: str) -> str:
+    salt = bcrypt.gensalt()
+    hashed = bcrypt.hashpw(password.encode(), salt)
+    return hashed.decode()
 
 
 def _sign_token(user: User, act_as: ActAsInfo | None) -> str:


### PR DESCRIPTION
### 🏷️ Ticket

[[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]
](https://www.notion.so/Create-command-to-seed-a-mock-DB-25b8378d6a47807697f9e992dc50277f?v=c135b6e7f76243819caf99a83e291380&source=copy_link)

### 📝 Description
- Created a command to create mock org, teams, and users

### 📸 Screenshots (if applicable)
<img width="1255" height="422" alt="Screenshot 2025-08-26 at 12 27 31" src="https://github.com/user-attachments/assets/34c0897f-a928-45f1-bb6b-a199eca86bb3" />
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a CLI command to seed a mock organization with teams and users for local development and testing. It prints ready-to-use JWTs and defaults to a safe dry run.

- **New Features**
  - New command: create-mock-org-teams-users
  - Creates one org, two teams, and three users (admin + 2 members) with a unique suffix to avoid collisions
  - Assigns roles and team memberships, then outputs JWTs for each user
  - Dry-run by default; use --skip-dry-run to commit to the DB
  - README updated and command registered in the CLI

- **Refactors**
  - Extracted password hashing into _hash_user_password and used it in the register flow (no behavior change)

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to quickly create a mock organization with teams and users for testing.
  * Supports dry-run by default with an option to persist changes.
  * Outputs a structured summary and sample access tokens for created users.

* **Documentation**
  * Added README instructions for using the new CLI command to generate a mock organization, teams, and users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->