### PR TITLE
feat: overload get_request_context method to expect act_as by param, default ture

### DIFF
--- a/backend/aci/control_plane/routes/auth.py
+++ b/backend/aci/control_plane/routes/auth.py
@@ -72,9 +72,7 @@ async def get_google_oauth2_url(
     """,
 )
 async def google_callback(
-    context: Annotated[
-        deps.RequestContextWithoutAuth, Depends(deps.get_request_context_without_auth)
-    ],
+    db_session: Annotated[Session, Depends(deps.yield_db_session)],
     operation: AuthOperation,
     response: Response,
     error: str | None = None,
@@ -101,7 +99,7 @@ async def google_callback(
 
     if operation == AuthOperation.REGISTER:
         # Check if email already been used
-        user = crud.users.get_user_by_email(context.db_session, google_userinfo.email)
+        user = crud.users.get_user_by_email(db_session, google_userinfo.email)
         if user:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail="Email already been used"
@@ -109,7 +107,7 @@ async def google_callback(
 
         # Create user
         user = crud.users.create_user(
-            db_session=context.db_session,
+            db_session=db_session,
             name=google_userinfo.name,
             email=google_userinfo.email,
             password_hash=None,
@@ -117,7 +115,7 @@ async def google_callback(
         )
 
     elif operation == AuthOperation.LOGIN:
-        user = crud.users.get_user_by_email(context.db_session, google_userinfo.email)
+        user = crud.users.get_user_by_email(db_session, google_userinfo.email)
 
         # User not found or deleted
         if not user or user.deleted_at:
@@ -127,7 +125,7 @@ async def google_callback(
         raise OAuth2Error(message="Invalid operation parameter during OAuth2 flow")
 
     # Issue a refresh token, store in secure cookie
-    _issue_refresh_token(context.db_session, user.id, response)
+    _issue_refresh_token(db_session, user.id, response)
 
     return RedirectResponse(oauth_info.post_oauth_redirect_uri, status_code=status.HTTP_302_FOUND)
 
@@ -141,14 +139,12 @@ async def google_callback(
     """,
 )
 async def register(
-    context: Annotated[
-        deps.RequestContextWithoutAuth, Depends(deps.get_request_context_without_auth)
-    ],
+    db_session: Annotated[Session, Depends(deps.yield_db_session)],
     request: EmailRegistrationRequest,
     response: Response,
 ) -> None:
     # Check if user already exists
-    user = crud.users.get_user_by_email(context.db_session, request.email)
+    user = crud.users.get_user_by_email(db_session, request.email)
     if user:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Email already been used"
@@ -159,17 +155,17 @@ async def register(
 
     # Create user
     user = crud.users.create_user(
-        db_session=context.db_session,
+        db_session=db_session,
         name=request.name,
         email=request.email,
         password_hash=hashed,
         identity_provider=UserIdentityProvider.EMAIL,
     )
 
-    context.db_session.commit()
+    db_session.commit()
 
     # Issue a refresh token, store in secure cookie
-    _issue_refresh_token(context.db_session, user.id, response)
+    _issue_refresh_token(db_session, user.id, response)
 
 
 @router.post(
@@ -181,13 +177,11 @@ async def register(
     """,
 )
 async def login(
-    context: Annotated[
-        deps.RequestContextWithoutAuth, Depends(deps.get_request_context_without_auth)
-    ],
+    db_session: Annotated[Session, Depends(deps.yield_db_session)],
     request: EmailLoginRequest,
     response: Response,
 ) -> None:
-    user = crud.users.get_user_by_email(context.db_session, request.email)
+    user = crud.users.get_user_by_email(db_session, request.email)
 
     # User not found or deleted
     if not user or user.deleted_at:
@@ -205,10 +199,10 @@ async def login(
 
     # Update the last login time
     user.last_login_at = datetime.datetime.now(datetime.UTC)
-    context.db_session.commit()
+    db_session.commit()
 
     # Issue a refresh token, store in secure cookie
-    _issue_refresh_token(context.db_session, user.id, response)
+    _issue_refresh_token(db_session, user.id, response)
 
 
 @router.post(
@@ -221,7 +215,7 @@ async def login(
     """,
 )
 async def issue_token(
-    context: Annotated[deps.RequestContext, Depends(deps.get_request_context_without_auth)],
+    db_session: Annotated[Session, Depends(deps.yield_db_session)],
     request: Request,
     input: IssueTokenRequest,
 ) -> TokenResponse:
@@ -235,21 +229,21 @@ async def issue_token(
 
     # Check if refresh token is valid
     refresh_token_hash = _hash_refresh_token(refresh_token)
-    refresh_token_obj = crud.users.get_refresh_token(context.db_session, refresh_token_hash)
+    refresh_token_obj = crud.users.get_refresh_token(db_session, refresh_token_hash)
     if not refresh_token_obj:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token"
         )
 
     # Get the user from the database
-    user = crud.users.get_user_by_id(context.db_session, refresh_token_obj.user_id)
+    user = crud.users.get_user_by_id(db_session, refresh_token_obj.user_id)
     if not user:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
 
     if input.act_as:
         # Check if user is a member of the requested organization
         membership = crud.organizations.get_organization_membership(
-            context.db_session, input.act_as.organization_id, user.id
+            db_session, input.act_as.organization_id, user.id
         )
         if not membership:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
@@ -288,9 +282,7 @@ async def issue_token(
     """,
 )
 async def logout(
-    context: Annotated[
-        deps.RequestContextWithoutAuth, Depends(deps.get_request_context_without_auth)
-    ],
+    db_session: Annotated[Session, Depends(deps.yield_db_session)],
     request: Request,
     response: Response,
 ) -> None:
@@ -300,7 +292,7 @@ async def logout(
     # Delete the refresh token in database
     if refresh_token:
         token_hash = _hash_refresh_token(refresh_token)
-        crud.users.delete_refresh_token(context.db_session, token_hash)
+        crud.users.delete_refresh_token(db_session, token_hash)
 
     # Delete the refresh token in cookie
     response.delete_cookie("refresh_token")

--- a/backend/aci/control_plane/routes/organizations.py
+++ b/backend/aci/control_plane/routes/organizations.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Annotated
 from uuid import UUID
 
@@ -23,7 +24,7 @@ router = APIRouter()
 
 
 def _throw_if_not_permitted(
-    act_as: ActAsInfo | None,
+    act_as: ActAsInfo,
     requested_organization_id: UUID | None = None,
     required_role: OrganizationRole = OrganizationRole.MEMBER,
 ) -> None:
@@ -31,8 +32,6 @@ def _throw_if_not_permitted(
     This function throws an HTTPException if the user is not permitted to act as the requested
     organization and role.
     """
-    if not act_as:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     if requested_organization_id and act_as.organization_id != requested_organization_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     if required_role == OrganizationRole.ADMIN and act_as.role != OrganizationRole.ADMIN:
@@ -41,7 +40,10 @@ def _throw_if_not_permitted(
 
 @router.post("/", response_model=OrganizationInfo, status_code=status.HTTP_201_CREATED)
 async def create_organization(
-    context: Annotated[deps.RequestContext, Depends(deps.get_request_context)],
+    context: Annotated[
+        deps.RequestContextWithoutActAs,
+        Depends(partial(deps.get_request_context, is_act_as_required=False)),
+    ],
     request: CreateOrganizationRequest,
 ) -> OrganizationInfo:
     # Every logged in user can create an organization. No permission check.
@@ -112,9 +114,6 @@ async def remove_organization_member(
 ) -> None:
     # Check user's role permission
     _throw_if_not_permitted(context.act_as, requested_organization_id=organization_id)
-
-    if not context.act_as:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
 
     # Admin can remove anyone in the organization
     if context.act_as.role == OrganizationRole.ADMIN:
@@ -344,16 +343,18 @@ async def remove_team_member(
     _throw_if_not_permitted(context.act_as, requested_organization_id=organization_id)
 
     # Admin can remove anyone in the team
-    if context.act_as and context.act_as.role == OrganizationRole.ADMIN:
+    if context.act_as.role == OrganizationRole.ADMIN:
         # No blocking.
         pass
 
     # Member can only remove themselves
-    elif context.act_as and context.act_as.role == OrganizationRole.MEMBER:
+    elif context.act_as.role == OrganizationRole.MEMBER:
         if context.user_id != user_id:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN, detail="Cannot remove other members"
             )
+    else:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
 
     # Check if targeted user is a member of the team
     if not crud.teams.get_team_members(context.db_session, team_id):


### PR DESCRIPTION
### 📝 Description
Overloaded the get_request_context dependency method to optionally expect act_as by param, default true
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make act_as optional per-endpoint via an overloaded get_request_context dependency with an is_act_as_required flag (default true). This lets auth and org creation run without an organization context while keeping strict checks elsewhere.

- **New Features**
  - Overloaded get_request_context with is_act_as_required (default true); returns RequestContext or RequestContextWithoutActAs and 403s if act_as is required but missing.

- **Refactors**
  - Replaced RequestContext classes with Pydantic models and removed get_request_context_without_auth.
  - Auth routes now depend only on db_session; no act_as needed.
  - create_organization uses get_request_context(..., is_act_as_required=False).
  - Simplified org permission checks and tightened team member removal logic.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * You can now create an organization without selecting an existing organization or acting-as a role.
  * Permission checks are more consistent across organization and team operations, with clearer error messages when an organizational context is required.

* Bug Fixes
  * Resolved intermittent errors during member management caused by missing organizational context.
  * Unauthorized actions now consistently return a 403 status instead of ambiguous failures.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->