### PR TITLE
fix: setting cookies to redirect response for google login flow

### DIFF
--- a/backend/aci/control_plane/routes/auth.py
+++ b/backend/aci/control_plane/routes/auth.py
@@ -76,7 +76,6 @@ async def google_callback(
         deps.RequestContextWithoutAuth, Depends(deps.get_request_context_without_auth)
     ],
     operation: AuthOperation,
-    response: Response,
     error: str | None = None,
     code: str | None = None,
     state: str | None = None,
@@ -127,9 +126,12 @@ async def google_callback(
         raise OAuth2Error(message="Invalid operation parameter during OAuth2 flow")
 
     # Issue a refresh token, store in secure cookie
+    response = RedirectResponse(
+        oauth_info.post_oauth_redirect_uri, status_code=status.HTTP_302_FOUND
+    )
     _issue_refresh_token(context.db_session, user.id, response)
 
-    return RedirectResponse(oauth_info.post_oauth_redirect_uri, status_code=status.HTTP_302_FOUND)
+    return response
 
 
 @router.post(


### PR DESCRIPTION
### 📝 Description
fix: setting cookies to redirect response for google login flow

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix Google OAuth callback to set the refresh token cookie on the redirect response so users stay logged in after login. We now create the RedirectResponse, set the cookie on it, and return it; removed the unused response parameter to prevent cookies from being written to a different response.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues where Google sign-in redirects were unreliable, ensuring users are consistently returned to the app after authentication.
  * Fixed session persistence by reliably setting the refresh token cookie during the post-login redirect, reducing unexpected sign-outs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->