### PR TITLE
check if the organization name is already been used

### DIFF
--- a/backend/aci/control_plane/routes/organizations.py
+++ b/backend/aci/control_plane/routes/organizations.py
@@ -46,11 +46,11 @@ async def create_organization(
 ) -> OrganizationInfo:
     # Every logged in user can create an organization. No permission check.
 
-    # Check if user already has an organization
+    # Check if organization name already been used
     if crud.organizations.get_organization_by_name(context.db_session, request.name):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Organization name already in use",
+            detail="Organization name already been used",
         )
 
     # Create organization


### PR DESCRIPTION
### 📝 Description
check if the organization name is already been used
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a server-side check to block creating an organization with a name that already exists. If the name is taken, the API returns 400 Bad Request with "Organization name already been used".

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced unique organization names during creation to prevent duplicate entries.
  * Users now receive a clear error message if the chosen organization name is already in use, improving feedback and reducing confusion.
  * Enhances data integrity by blocking duplicate organization creation at the server level.
  * Provides a more reliable workflow when adding new organizations, ensuring names remain distinct across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->