### PR TITLE
update profile api method to GET

### DIFF
--- a/backend/aci/control_plane/routes/users.py
+++ b/backend/aci/control_plane/routes/users.py
@@ -11,10 +11,10 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-@router.post("/me/profile", response_model=UserInfo | None, status_code=status.HTTP_200_OK)
+@router.get("/me/profile", response_model=UserInfo, status_code=status.HTTP_200_OK)
 async def profile(
     context: Annotated[deps.RequestContext, Depends(deps.get_request_context)],
-) -> UserInfo | None:
+) -> UserInfo:
     user = crud.users.get_user_by_id(context.db_session, context.user_id)
 
     # Should never happen as the user_id is validated in the JWT payload


### PR DESCRIPTION
### 📝 Description
Update profile API method to GET
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched /me/profile from POST to GET and made the response always return UserInfo. Aligns with REST semantics and clarifies that this endpoint only reads data.

- **Migration**
  - Update clients to call GET /me/profile (was POST).
  - Expect HTTP 200 with a UserInfo body; null is no longer returned.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Changed /me/profile from POST to GET for retrieving the current user’s profile.
  - Response is now guaranteed to be a profile object; empty responses removed.

- Bug Fixes
  - Not-found profiles now return HTTP 404 instead of a null payload.
  - Response schema clarified to eliminate ambiguity for API consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->