### PR TITLE
chore: using non-json formatter for local development

### DIFF
--- a/backend/aci/control_plane/main.py
+++ b/backend/aci/control_plane/main.py
@@ -25,12 +25,17 @@ from aci.control_plane.routes import (
 )
 from aci.control_plane.routes.mcp import route
 
-setup_logging(
-    formatter=JsonFormatter(
+if config.ENVIRONMENT == "local":
+    formatter = None
+else:
+    formatter = JsonFormatter(
         "{levelname} {asctime} {name} {message}",
         style="{",
         rename_fields={"asctime": "timestamp", "name": "file", "levelname": "level"},
-    ),
+    )
+
+setup_logging(
+    formatter=formatter,
     filters=[RequestContextFilter()],
 )
 


### PR DESCRIPTION
### 📝 Description
chore: using non-json formatter for local development

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use non-JSON logging locally to make logs easier to read during development. JSON logging remains enabled in all non-local environments.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated logging to be environment-aware: local runs now use a human-readable format, while non-local environments retain JSON logs.
  - No changes to public APIs or configuration required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->