### PR TITLE
Update add-account-dialog.tsx

### DIFF
--- a/frontend/src/features/linked-accounts/components/add-account-dialog.tsx
+++ b/frontend/src/features/linked-accounts/components/add-account-dialog.tsx
@@ -155,7 +155,7 @@ export function AddAccountDialog({}: AddAccountDialogProps) {
                                   "Unknown Server"}
                               </span>
                               <span className="text-xs text-muted-foreground">
-                                ({selectedConfig.id.slice(0, 8)}...)
+                                ({selectedConfig.id})
                               </span>
                             </div>
                           )}
@@ -183,7 +183,7 @@ export function AddAccountDialog({}: AddAccountDialogProps) {
                               {config.mcp_server?.name || "Unknown Server"}
                             </span>
                             <span className="text-xs text-muted-foreground">
-                              ({config.id.slice(0, 8)}...)
+                              ({config.id})
                             </span>
                           </div>
                         </SelectItem>


### PR DESCRIPTION
### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

[Describe your changes in detail (optional if the issue you linked already contains a
detail description of the change)]

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Show the full MCP server ID in the Add Account dialog instead of a truncated 8-character version. This removes ambiguity when IDs share prefixes and makes them easier to copy and verify.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Display full MCP server configuration IDs instead of truncated versions in the Add Account dialog for Linked Accounts.
  * Applies to both the selected configuration view and each dropdown item.
  * Improves clarity and easy copy/verification of IDs.
  * Visual-only change; no impact on logic, data flow, or API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->