### PR TITLE
move auth_credentials_manager and oauth2_manager to common

### DIFF
--- a/backend/aci/common/exceptions.py
+++ b/backend/aci/common/exceptions.py
@@ -1,0 +1,35 @@
+class ACICommonError(Exception):
+    def __init__(
+        self,
+        title: str,
+        message: str | None = None,
+    ):
+        super().__init__(title, message)
+        self.title = title
+        self.message = message
+
+    def __str__(self) -> str:
+        """
+        String representation that combines title and message (if available)
+        """
+        if self.message:
+            return f"{self.title}: {self.message}"
+        return self.title
+
+
+class OAuth2ManagerError(ACICommonError):
+    """
+    Exception raised when an OAuth2 manager error occurs
+    """
+
+    def __init__(self, message: str | None = None):
+        super().__init__(title="OAuth2 manager error", message=message)
+
+
+class AuthCredentialsManagerError(ACICommonError):
+    """
+    Exception raised when an auth credentials manager error occurs
+    """
+
+    def __init__(self, message: str | None = None):
+        super().__init__(title="Auth credentials manager error", message=message)

--- a/backend/aci/common/oauth2_manager.py
+++ b/backend/aci/common/oauth2_manager.py
@@ -5,9 +5,9 @@ from typing import Any, cast
 
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 
+from aci.common.exceptions import OAuth2ManagerError
 from aci.common.logging_setup import get_logger
 from aci.common.schemas.mcp_auth import OAuth2Credentials
-from aci.control_plane.exceptions import OAuth2Error
 
 UNICODE_ASCII_CHARACTER_SET = string.ascii_letters + string.digits
 logger = get_logger(__name__)
@@ -146,7 +146,7 @@ class OAuth2Manager:
             return token
         except Exception as e:
             logger.error(f"Failed to fetch access token, app_name={self.app_name}, error={e}")
-            raise OAuth2Error("failed to fetch access token") from e
+            raise OAuth2ManagerError("Failed to fetch access token") from e
 
     async def refresh_token(
         self,
@@ -162,7 +162,7 @@ class OAuth2Manager:
             return token
         except Exception as e:
             logger.error(f"Failed to refresh access token, app_name={self.app_name}, error={e}")
-            raise OAuth2Error("Failed to refresh access token") from e
+            raise OAuth2ManagerError("Failed to refresh access token") from e
 
     def parse_fetch_token_response(self, token: dict) -> OAuth2Credentials:
         """
@@ -187,7 +187,7 @@ class OAuth2Manager:
 
         if "access_token" not in data:
             logger.error(f"Missing access_token in OAuth response, app={self.app_name}")
-            raise OAuth2Error("Missing access_token in OAuth response")
+            raise OAuth2ManagerError("Missing access_token in OAuth response")
 
         # some apps have long live access token so expiration time may not be present
         expires_at: int | None = None

--- a/backend/aci/control_plane/exceptions.py
+++ b/backend/aci/control_plane/exceptions.py
@@ -96,32 +96,6 @@ class UnexpectedError(ControlPlaneException):
         )
 
 
-class AuthCredentialsRefreshError(ControlPlaneException):
-    """
-    Exception raised when an auth credentials refresh error occurs
-    """
-
-    def __init__(self, message: str | None = None):
-        super().__init__(
-            title="Auth credentials refresh error",
-            message=message,
-            error_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
-
-
-class ConnectedAccountNotFound(ControlPlaneException):
-    """
-    Exception raised when a connected account is not found
-    """
-
-    def __init__(self, message: str | None = None):
-        super().__init__(
-            title="Connected account not found",
-            message=message,
-            error_code=status.HTTP_404_NOT_FOUND,
-        )
-
-
 class MCPToolNotFound(ControlPlaneException):
     """
     Exception raised when an mcp tool is not found

--- a/backend/aci/control_plane/google_login_utils.py
+++ b/backend/aci/control_plane/google_login_utils.py
@@ -4,10 +4,10 @@ from google.oauth2 import id_token
 from pydantic import BaseModel
 
 from aci.common.logging_setup import get_logger
+from aci.common.oauth2_manager import OAuth2Manager
 from aci.common.schemas.auth import AuthOperation, OAuth2State
 from aci.control_plane import config
 from aci.control_plane.exceptions import OAuth2Error
-from aci.control_plane.oauth2_manager import OAuth2Manager
 
 logger = get_logger(__name__)
 

--- a/backend/aci/control_plane/routes/connected_accounts.py
+++ b/backend/aci/control_plane/routes/connected_accounts.py
@@ -6,10 +6,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
+from aci.common import auth_credentials_manager as acm
 from aci.common.db import crud
 from aci.common.db.sql_models import MCPServerConfiguration
 from aci.common.enums import AuthType, OrganizationRole
 from aci.common.logging_setup import get_logger
+from aci.common.oauth2_manager import OAuth2Manager
 from aci.common.schemas.connected_account import (
     ConnectedAccountCreate,
     ConnectedAccountOAuth2CreateState,
@@ -17,7 +19,6 @@ from aci.common.schemas.connected_account import (
     OAuth2ConnectedAccountCreateResponse,
 )
 from aci.common.schemas.pagination import PaginationParams, PaginationResponse
-from aci.control_plane import auth_credentials_manager as acm
 from aci.control_plane import config, rbac
 from aci.control_plane import dependencies as deps
 from aci.control_plane.exceptions import (
@@ -25,7 +26,6 @@ from aci.control_plane.exceptions import (
     NotPermittedError,
     OAuth2Error,
 )
-from aci.control_plane.oauth2_manager import OAuth2Manager
 
 logger = get_logger(__name__)
 router = APIRouter()

--- a/backend/aci/control_plane/routes/mcp/tools/execute_tool.py
+++ b/backend/aci/control_plane/routes/mcp/tools/execute_tool.py
@@ -7,6 +7,7 @@ from mcp.client.streamable_http import streamablehttp_client
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
+from aci.common import auth_credentials_manager as acm
 from aci.common.db import crud
 from aci.common.db.sql_models import MCPServer, MCPServerBundle, MCPServerConfiguration, MCPTool
 from aci.common.enums import MCPServerTransportType
@@ -16,7 +17,6 @@ from aci.common.schemas.mcp_auth import (
     AuthCredentials,
 )
 from aci.common.schemas.mcp_tool import MCPToolMetadata
-from aci.control_plane import auth_credentials_manager as acm
 from aci.control_plane.exceptions import (
     MCPServerNotConfigured,
     MCPToolNotEnabled,


### PR DESCRIPTION
- move move auth_credentials_manager and oauth2_manager to common module
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Centralized auth managers by moving OAuth2Manager and AuthCredentialsManager to aci.common and added shared exceptions. This reduces duplication and standardizes error handling across services.

- **Refactors**
  - Moved aci.control_plane.oauth2_manager ➝ aci.common.oauth2_manager.
  - Moved aci.control_plane.auth_credentials_manager ➝ aci.common.auth_credentials_manager.
  - Added aci.common.exceptions with OAuth2ManagerError and AuthCredentialsManagerError.
  - Replaced raises and imports in affected modules; removed ConnectedAccountNotFound and AuthCredentialsRefreshError from control_plane.exceptions.

- **Migration**
  - Update imports to aci.common.oauth2_manager and aci.common.auth_credentials_manager.
  - Replace usage of ConnectedAccountNotFound/AuthCredentialsRefreshError with AuthCredentialsManagerError.
  - Catch OAuth2ManagerError where you previously handled OAuth2Error from the manager, or map it to your HTTP-layer errors.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized error handling across OAuth2 login and connected account flows for more consistent, readable messages.
  - Unified error types to reduce ambiguity without changing public behavior.
- Bug Fixes
  - Clearer messaging when token refresh isn’t possible (e.g., missing refresh token), guiding users to re-authenticate.
- Chores
  - Consolidated auth and OAuth2 logic under common modules to simplify maintenance and reduce duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->