### PR TITLE
exclude none when returning tool call result

### DIFF
--- a/backend/aci/cli/commands/mock_data/create_mock_org_teams_users.py
+++ b/backend/aci/cli/commands/mock_data/create_mock_org_teams_users.py
@@ -93,7 +93,7 @@ def create_mock_org_teams_users(
         # Important: not adding these configs to cli/config.py as these should only be used in local
         # development. These not be used by any other code in cli, and would not be accessible in
         # actual deployment
-        jwt_signing_key = utils.check_and_get_env_variable("JWT_SIGNING_KEY")
+        jwt_signing_key = utils.check_and_get_env_variable("CONTROL_PLANE_JWT_SIGNING_KEY")
         jwt_algorithm = "HS256"
         jwt_access_token_expire_minutes = 1440
 

--- a/backend/aci/mcp/routes/tools/execute_tool.py
+++ b/backend/aci/mcp/routes/tools/execute_tool.py
@@ -127,7 +127,7 @@ async def handle_execute_tool(
         )
         return JSONRPCSuccessResponse(
             id=jsonrpc_tools_call_request.id,
-            result=tool_call_result.model_dump(),
+            result=tool_call_result.model_dump(exclude_none=True),
         )
     except Exception as e:
         logger.exception(f"Error forwarding tool call: {e}")

--- a/backend/aci/mcp/routes/tools/search_tools.py
+++ b/backend/aci/mcp/routes/tools/search_tools.py
@@ -92,7 +92,7 @@ async def handle_search_tools(
 
     return JSONRPCSuccessResponse(
         id=jsonrpc_tools_call_request.id,
-        result=tool_call_result.model_dump(),
+        result=tool_call_result.model_dump(exclude_none=True),
     )
 
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Ensure tool call responses omit null fields to prevent client parsing issues and reduce payload size. Also update the mock data CLI to use CONTROL_PLANE_JWT_SIGNING_KEY.

- **Bug Fixes**
  - Return tool call results with model_dump(exclude_none=True) in execute_tool and search_tools.
  - Use CONTROL_PLANE_JWT_SIGNING_KEY in the mock data CLI for JWT signing.

- **Migration**
  - Local dev: set CONTROL_PLANE_JWT_SIGNING_KEY before running create_mock_org_teams_users.py (replaces JWT_SIGNING_KEY).

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool execution and tool search responses now omit null fields, producing cleaner and smaller JSON payloads. Clients relying on null-valued fields should adjust accordingly.

* **Chores**
  * Updated the environment variable for the JWT signing key to CONTROL_PLANE_JWT_SIGNING_KEY. Please update deployment configurations. No other behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->