### PR TITLE
chore: rename access control method name

### DIFF
--- a/backend/aci/control_plane/access_control.py
+++ b/backend/aci/control_plane/access_control.py
@@ -11,19 +11,20 @@ from aci.control_plane.exceptions import NotPermittedError
 logger = get_logger(__name__)
 
 
-def check_permission(
+def check_act_as_organization_role(
     act_as: ActAsInfo,
     requested_organization_id: UUID | None = None,
     required_role: OrganizationRole = OrganizationRole.MEMBER,
     throw_error_if_not_permitted: bool = True,
 ) -> bool:
     """
+    Check based on user's act_as information, verify if the user's act as:
+    - Matches the requested organization_id
+    - The role has permission to the requested role. (Admin is eligible to act as member role)
+
     This function throws an NotPermittedError if the user is not permitted to act as the requested
     organization and role.
     """
-    # TODO: Extend this function to check authorization of other entities
-    # E.g., MCPServerConfiguration, MCPServerBundle, ConnectedAccount, etc.
-
     try:
         if requested_organization_id and act_as.organization_id != requested_organization_id:
             raise NotPermittedError(

--- a/backend/aci/control_plane/routes/connected_accounts.py
+++ b/backend/aci/control_plane/routes/connected_accounts.py
@@ -379,7 +379,7 @@ async def delete_connected_account(
         raise HTTPException(status_code=404, detail="Connected account not found")
 
     # Check if the user is acted as the organization of the connected account
-    access_control.check_permission(
+    access_control.check_act_as_organization_role(
         context.act_as,
         requested_organization_id=connected_account.mcp_server_configuration.organization_id,
         throw_error_if_not_permitted=True,

--- a/backend/aci/control_plane/routes/mcp_server_bundles.py
+++ b/backend/aci/control_plane/routes/mcp_server_bundles.py
@@ -112,7 +112,7 @@ async def get_mcp_server_bundle(
         raise HTTPException(status_code=404, detail="MCP server bundle not found")
 
     # check if the MCP server bundle is under the user's org
-    access_control.check_permission(
+    access_control.check_act_as_organization_role(
         context.act_as,
         requested_organization_id=mcp_server_bundle.organization_id,
         throw_error_if_not_permitted=True,
@@ -141,7 +141,7 @@ async def delete_mcp_server_bundle(
         raise HTTPException(status_code=404, detail="MCP server bundle not found")
 
     # check if the MCP server bundle is under the user's org
-    access_control.check_permission(
+    access_control.check_act_as_organization_role(
         context.act_as,
         requested_organization_id=mcp_server_bundle.organization_id,
         throw_error_if_not_permitted=True,

--- a/backend/aci/control_plane/routes/mcp_server_configurations.py
+++ b/backend/aci/control_plane/routes/mcp_server_configurations.py
@@ -29,7 +29,7 @@ async def create_mcp_server_configuration(
 ) -> MCPServerConfigurationPublic:
     # TODO: check allowed_teams are actually in the org
     # TODO: check enabled_tools are actually in the mcp server
-    access_control.check_permission(
+    access_control.check_act_as_organization_role(
         context.act_as,
         requested_organization_id=context.act_as.organization_id,
         required_role=OrganizationRole.ADMIN,
@@ -119,7 +119,7 @@ async def get_mcp_server_configuration(
         raise HTTPException(status_code=404, detail="MCP server configuration not found")
 
     # Check if the MCP server configuration is under the user's org
-    access_control.check_permission(
+    access_control.check_act_as_organization_role(
         context.act_as,
         requested_organization_id=mcp_server_configuration.organization_id,
         throw_error_if_not_permitted=True,
@@ -154,7 +154,7 @@ async def update_mcp_server_configuration(
 
     # Check if the MCP server configuration is under the user's org
     # Check if the user is acted as admin
-    access_control.check_permission(
+    access_control.check_act_as_organization_role(
         context.act_as,
         requested_organization_id=mcp_server_configuration.organization_id,
         required_role=OrganizationRole.ADMIN,
@@ -271,7 +271,7 @@ async def delete_mcp_server_configuration(
     if mcp_server_configuration is not None:
         # Check if the user is an admin and is acted as the organization_id of the MCP server
         # configuration
-        access_control.check_permission(
+        access_control.check_act_as_organization_role(
             context.act_as,
             requested_organization_id=mcp_server_configuration.organization_id,
             required_role=OrganizationRole.ADMIN,

--- a/backend/aci/control_plane/routes/organizations.py
+++ b/backend/aci/control_plane/routes/organizations.py
@@ -76,7 +76,9 @@ async def list_organization_members(
     organization_id: UUID,
 ) -> list[OrganizationMembershipInfo]:
     # Check user's role permission
-    access_control.check_permission(context.act_as, requested_organization_id=organization_id)
+    access_control.check_act_as_organization_role(
+        context.act_as, requested_organization_id=organization_id
+    )
 
     # Get organization members
     organization_members = crud.organizations.get_organization_members(
@@ -102,7 +104,9 @@ async def remove_organization_member(
     user_id: UUID,
 ) -> None:
     # Check user's role permission
-    access_control.check_permission(context.act_as, requested_organization_id=organization_id)
+    access_control.check_act_as_organization_role(
+        context.act_as, requested_organization_id=organization_id
+    )
 
     # Admin can remove anyone in the organization
     if context.act_as.role == OrganizationRole.ADMIN:
@@ -147,7 +151,7 @@ async def update_organization_member_role(
     request: UpdateOrganizationMemberRoleRequest,
 ) -> None:
     # Check user's role permission
-    access_control.check_permission(
+    access_control.check_act_as_organization_role(
         context.act_as,
         requested_organization_id=organization_id,
         required_role=OrganizationRole.ADMIN,
@@ -194,7 +198,7 @@ async def create_team(
     request: CreateOrganizationTeamRequest,
 ) -> TeamInfo:
     # Check user's role permission
-    access_control.check_permission(
+    access_control.check_act_as_organization_role(
         context.act_as,
         requested_organization_id=organization_id,
         required_role=OrganizationRole.ADMIN,
@@ -236,7 +240,9 @@ async def list_teams(
     organization_id: UUID,
 ) -> list[TeamInfo]:
     # Check user's role permission
-    access_control.check_permission(context.act_as, requested_organization_id=organization_id)
+    access_control.check_act_as_organization_role(
+        context.act_as, requested_organization_id=organization_id
+    )
 
     # Get organization teams
     teams = crud.teams.get_teams_by_organization_id(
@@ -265,7 +271,9 @@ async def list_team_members(
     team_id: UUID,
 ) -> list[TeamMembershipInfo]:
     # Check user's role permission
-    access_control.check_permission(context.act_as, requested_organization_id=organization_id)
+    access_control.check_act_as_organization_role(
+        context.act_as, requested_organization_id=organization_id
+    )
 
     # Get team members
     team_members = crud.teams.get_team_members(
@@ -292,7 +300,7 @@ async def add_team_member(
     user_id: UUID,
 ) -> None:
     # Check user's role permission
-    access_control.check_permission(
+    access_control.check_act_as_organization_role(
         context.act_as,
         requested_organization_id=organization_id,
         required_role=OrganizationRole.ADMIN,
@@ -340,7 +348,9 @@ async def remove_team_member(
     user_id: UUID,
 ) -> None:
     # Check user's role permission
-    access_control.check_permission(context.act_as, requested_organization_id=organization_id)
+    access_control.check_act_as_organization_role(
+        context.act_as, requested_organization_id=organization_id
+    )
 
     # Admin can remove anyone in the team
     if context.act_as.role == OrganizationRole.ADMIN:


### PR DESCRIPTION
### 🏷️ Ticket
https://www.notion.so/Minor-code-cleaning-2678378d6a4780258c29d05b1e3923bb?v=c135b6e7f76243819caf99a83e291380&source=copy_link

### 📝 Description
chore: rename access control method name

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed the access control function from check_permission to check_act_as_organization_role for clearer intent and updated all usages across routes. Improved the docstring to spell out org ID and role checks; no behavior change intended.

<!-- End of auto-generated description by cubic. -->

