### PR TITLE
feat: remove min length check for description

### DIFF
--- a/backend/aci/common/schemas/organization.py
+++ b/backend/aci/common/schemas/organization.py
@@ -9,7 +9,7 @@ from aci.common.enums import OrganizationRole, TeamRole
 class CreateOrganizationRequest(BaseModel):
     name: str = Field(min_length=1, max_length=100, description="Organization name")
     description: str | None = Field(
-        default=None, min_length=1, max_length=255, description="Organization description"
+        default=None, max_length=255, description="Organization description"
     )
 
 
@@ -33,9 +33,7 @@ class UpdateOrganizationMemberRoleRequest(BaseModel):
 
 class CreateOrganizationTeamRequest(BaseModel):
     name: str = Field(min_length=1, max_length=100, description="Team name")
-    description: str | None = Field(
-        default=None, min_length=1, max_length=255, description="Team description"
-    )
+    description: str | None = Field(default=None, max_length=255, description="Team description")
 
 
 class TeamInfo(BaseModel):


### PR DESCRIPTION
### 🏷️ Ticket
https://www.notion.so/Take-out-checking-on-min_length-for-descriptions-2688378d6a4780338866e400e5a6cde6?v=c135b6e7f76243819caf99a83e291380&source=copy_link

### 📝 Description
remove min length check for team description / organization description

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the min length constraint on organization and team descriptions so empty strings are allowed. Max length (255) and None remain supported.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Relaxed validation for organization and team descriptions during creation. You can now omit the description or leave it empty without triggering validation errors.
  - Applies to both UI and API creation flows, reducing friction for users who don’t need to provide a description.
  - The maximum allowed length remains 255 characters; no other fields or behaviors are affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->