### PR TITLE
feat: remove stale records after removing user from team

### DIFF
--- a/backend/aci/common/db/crud/mcp_server_bundles.py
+++ b/backend/aci/common/db/crud/mcp_server_bundles.py
@@ -111,16 +111,18 @@ def get_mcp_server_configurations_of_mcp_server_bundle(
     return list(db_session.execute(statement).scalars().all())
 
 
-def update_mcp_server_bundle_configuration_ids(
+def remove_mcp_server_configuration_id_from_mcp_server_bundle(
     db_session: Session,
     mcp_server_bundle_id: UUID,
-    update_mcp_server_bundle_configuration_ids: list[UUID],
+    mcp_server_configuration_id: UUID,
 ) -> MCPServerBundle:
     statement = select(MCPServerBundle).where(MCPServerBundle.id == mcp_server_bundle_id)
     mcp_server_bundle = db_session.execute(statement).scalar_one()
-    mcp_server_bundle.mcp_server_configuration_ids = list(
-        dict.fromkeys(update_mcp_server_bundle_configuration_ids)
-    )
+
+    updated_config_ids = list(dict.fromkeys(mcp_server_bundle.mcp_server_configuration_ids))
+    updated_config_ids.remove(mcp_server_configuration_id)
+
+    mcp_server_bundle.mcp_server_configuration_ids = updated_config_ids
     db_session.flush()
     db_session.refresh(mcp_server_bundle)
     return mcp_server_bundle


### PR DESCRIPTION
### 🏷️ Ticket
https://www.notion.so/Show-the-username-in-the-connected-account-list-the-bundle-list-as-well-2688378d6a4780b4be5ccfcb797afd1e?v=c135b6e7f76243819caf99a83e291380&source=copy_link

### 📝 Description
feat: remove stale records after removing user from team

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Automatically cleans up stale connected accounts and bundle configuration references when a user is removed from a team or loses access to an MCP server configuration. This prevents orphaned records and keeps bundles limited to accessible configs.

- **New Features**
  - On team removal: delete the user's inaccessible connected accounts and remove inaccessible MCP configuration IDs from their bundles.
  - On MCP configuration ACL updates: prune inaccessible configuration IDs from affected bundles and remove stale connected accounts via a central check.
  - Added helpers: access_control.check_and_remove_stale_connected_accounts and crud.mcp_server_bundles.remove_mcp_server_configuration_id_from_mcp_server_bundle.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically cleans up stale connected accounts and removes inaccessible configurations from bundles after team member changes, ensuring accurate access and preventing orphaned entries.
  * Improves reliability of access checks during configuration cleanup to reflect current permissions.

* **Refactor**
  * Centralizes cleanup logic for connected accounts and bundle associations for more consistent behavior across the app.

* **Chores**
  * Streamlines internal cleanup paths to reduce duplication and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->