### PR TITLE
fix: fix missing committing db session

### DIFF
--- a/backend/aci/control_plane/routes/mcp_servers.py
+++ b/backend/aci/control_plane/routes/mcp_servers.py
@@ -127,6 +127,8 @@ async def create_custom_mcp_server(
         embedding=mcp_server_embedding,
     )
 
+    context.db_session.commit()
+
     mcp_server_public = schema_utils.construct_mcp_server_public(mcp_server)
     return mcp_server_public
 


### PR DESCRIPTION
### 📝 Description
fix missing db session commit
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix missing database commit in create_custom_mcp_server so new servers and their embeddings are persisted. This prevents data loss at request end and makes the server immediately available to subsequent reads.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensures newly created custom MCP servers are reliably saved and immediately available.
  - Prevents intermittent cases where new servers might not appear or return inconsistent data right after creation.
  - Improves stability and consistency of server creation responses, especially under load.

- **Chores**
  - No changes to public APIs; internal adjustments only to improve data persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->