### PR TITLE
bypass the need for connected account for virtual mcp servers when generate-tools

### DIFF
--- a/backend/aci/cli/commands/mcp/generate_tools.py
+++ b/backend/aci/cli/commands/mcp/generate_tools.py
@@ -95,9 +95,9 @@ async def _get_auth(
         # TODO: handle token refresh for oauth2 credentials
         auth_credentials = await acm.get_auth_credentials(
             db_session,
-            connected_account.user_id,
             mcp_server_configuration.id,
             connected_account.ownership,  # Use the ownership type of whatever account we retrieved
+            user_id=connected_account.user_id,
         )
 
         return auth_config, auth_credentials


### PR DESCRIPTION
### 📝 Description
For now, virtual mcp servers tools/list doesn't require auth, so we just return some mock auth config and credentials when calling generate-tools cli command for indexing convenience.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Allow generate-tools to run for virtual MCP servers without a connected account by returning NoAuth config/credentials. This matches current tools/list behavior and unblocks indexing.

- **Refactors**
  - Added _get_auth with MCPServerMetadata check; returns NoAuthConfig/NoAuthCredentials for virtual servers.
  - Preserved existing account-based auth for non-virtual servers.
  - Improved error messages to use server.name and commit DB session after auth resolution.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of tool generation by correctly handling virtual vs. real authentication.
  * Clearer error messages referencing the actual server name when configurations or accounts are missing.
  * Ensures database changes are committed before fetching tools to avoid transient failures.

* **Refactor**
  * Centralized authentication into a single flow and streamlined the tool-generation process for clearer, more maintainable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->