### PR TITLE
rate limiting mcp server tools refreshing

### DIFF
--- a/backend/aci/control_plane/exceptions.py
+++ b/backend/aci/control_plane/exceptions.py
@@ -262,3 +262,16 @@ class MCPToolsNormalizationError(ControlPlaneException):
             message=message,
             error_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
+
+
+class MCPToolsRefreshTooFrequent(ControlPlaneException):
+    """
+    Exception raised when an MCP tools refresh is too frequent
+    """
+
+    def __init__(self, message: str | None = None):
+        super().__init__(
+            title="MCP tools refresh too frequent",
+            message=message,
+            error_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        )

--- a/backend/aci/control_plane/routes/mcp_servers.py
+++ b/backend/aci/control_plane/routes/mcp_servers.py
@@ -1,4 +1,5 @@
 import string
+from datetime import UTC, datetime, timedelta
 from typing import Annotated, Literal
 from uuid import UUID
 
@@ -25,7 +26,7 @@ from aci.common.schemas.mcp_server_configuration import MCPServerConfigurationCr
 from aci.common.schemas.pagination import PaginationParams, PaginationResponse
 from aci.control_plane import access_control, config, schema_utils
 from aci.control_plane import dependencies as deps
-from aci.control_plane.exceptions import OAuth2MetadataDiscoveryError
+from aci.control_plane.exceptions import MCPToolsRefreshTooFrequent, OAuth2MetadataDiscoveryError
 from aci.control_plane.routes.connected_accounts import (
     CONNECTED_ACCOUNTS_OAUTH2_CALLBACK_ROUTE_NAME,
 )
@@ -266,6 +267,9 @@ async def refresh_mcp_server_tools(
     if not mcp_server:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
+    if mcp_server.organization_id is None:
+        raise HTTPException(status_code=403, detail="MCP server is public")
+
     # Enforce only admin to perform this action
     access_control.check_act_as_organization_role(
         context.act_as,
@@ -273,6 +277,18 @@ async def refresh_mcp_server_tools(
         required_role=OrganizationRole.ADMIN,
         throw_error_if_not_permitted=True,
     )
+
+    # Basic rate limiting by checking the last synced at time
+    # TODO: Handle case if last_synced_at is null and keeps failing, in this case this check does
+    # not work.
+    if mcp_server.last_synced_at is not None:
+        if mcp_server.last_synced_at + timedelta(hours=1) > datetime.now(UTC):
+            logger.error(
+                f"MCP server {mcp_server.name} has been refreshed too frequently, last_synced_at={mcp_server.last_synced_at}"  # noqa: E501
+            )
+            raise MCPToolsRefreshTooFrequent(
+                f"MCP server {mcp_server.name} has been refreshed too frequently"
+            )
 
     mcp_tools_diff = await MCPToolsManager(mcp_server).refresh_mcp_tools(context.db_session)
 

--- a/backend/aci/control_plane/tests/routes/mcp_servers/test_mcp_servers.py
+++ b/backend/aci/control_plane/tests/routes/mcp_servers/test_mcp_servers.py
@@ -1,11 +1,13 @@
 import re
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from aci.common.db import crud
-from aci.common.db.sql_models import Organization
+from aci.common.db.sql_models import MCPServer, Organization
 from aci.common.enums import (
     AuthType,
     HttpLocation,
@@ -20,6 +22,7 @@ from aci.common.schemas.mcp_server import (
 )
 from aci.common.schemas.pagination import PaginationResponse
 from aci.control_plane import config
+from aci.control_plane.services.mcp_tools.mcp_tools_manager import MCPToolsDiff
 
 logger = get_logger(__name__)
 
@@ -255,3 +258,52 @@ def test_get_mcp_server(
     assert mcp_server_data.id == dummy_mcp_server.id
     assert mcp_server_data.name == dummy_mcp_server.name
     assert mcp_server_data.url == dummy_mcp_server.url
+
+
+@pytest.mark.parametrize("is_mcp_server_same_org", [True, False])
+@pytest.mark.parametrize("is_too_frequent", [True, False])
+@patch("aci.control_plane.routes.mcp_servers.MCPToolsManager")
+def test_refresh_mcp_server_tools(
+    mock_mcp_tools_manager_class: AsyncMock,
+    test_client: TestClient,
+    db_session: Session,
+    dummy_access_token_admin: str,
+    is_too_frequent: bool,
+    is_mcp_server_same_org: bool,
+    dummy_organization: Organization,
+    dummy_mcp_server: MCPServer,
+) -> None:
+    # Set up the mock
+    mock_mcp_tools_manager_instance = AsyncMock()
+    mock_mcp_tools_manager_instance.refresh_mcp_tools.return_value = MCPToolsDiff(
+        tools_created=[],
+        tools_deleted=[],
+        tools_updated=[],
+        tools_unchanged=[],
+    )
+    mock_mcp_tools_manager_class.return_value = mock_mcp_tools_manager_instance
+
+    dummy_mcp_server.organization_id = dummy_organization.id if is_mcp_server_same_org else None
+    dummy_mcp_server.last_synced_at = (
+        datetime.now(UTC) - timedelta(minutes=1)
+        if is_too_frequent
+        else datetime.now(UTC) - timedelta(days=30)
+    )
+
+    db_session.commit()
+
+    response = test_client.post(
+        f"{config.ROUTER_PREFIX_MCP_SERVERS}/{dummy_mcp_server.id}/refresh-tools",
+        headers={"Authorization": f"Bearer {dummy_access_token_admin}"},
+    )
+
+    if not is_mcp_server_same_org:
+        assert response.status_code == 403
+        return
+
+    if is_too_frequent:
+        assert response.status_code == 429
+        return
+
+    assert response.status_code == 200
+    assert mock_mcp_tools_manager_instance.refresh_mcp_tools.call_count == 1


### PR DESCRIPTION
🏷️ Ticket
https://www.notion.so/Custom-MCP-Server-Fetch-MCP-Tool-List-2708378d6a4780efb59bf28ec922d891?v=c135b6e7f76243819caf99a83e291380&source=copy_link

📝 Description
Rate limiting the tool fetching
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a 1-hour rate limit to the MCP server tools refresh endpoint to prevent repeated refreshes. Returns 429 when refreshed too soon and 403 when the server is public.

- **New Features**
  - Added MCPToolsRefreshTooFrequent exception (HTTP 429).
  - Refresh blocked for public MCP servers (HTTP 403).
  - Route checks last_synced_at and logs when too frequent.
  - Tests cover org/public access and rate limit paths.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added rate limiting for MCP tools refresh: requests within one hour now return 429 (Too Many Requests).
  - Enforced organization scoping: refreshing tools for public MCP servers is blocked and returns 403 (Forbidden).
- Tests
  - Added tests covering rate limiting, org scoping, and successful refresh scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->