### PR TITLE
chore: wait 10 minutes for service deploy

### DIFF
--- a/.github/workflows/ecs-deploy-service.yml
+++ b/.github/workflows/ecs-deploy-service.yml
@@ -68,5 +68,5 @@ jobs:
           service: ${{ inputs.ecs_service }}
           cluster: ${{ inputs.ecs_cluster }}
           wait-for-service-stability: true
-          wait-for-minutes: 5
+          wait-for-minutes: 10
           force-new-deployment: true


### PR DESCRIPTION
### 📝 Description
Existing deployment CI/CD action wait for 5 minutes after service deployment for completion.
Extending it to 10 minutes.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Increases ECS service stability wait from 5 to 10 minutes in the deploy workflow to reduce false failures during slower rollouts.
Only the wait-for-minutes parameter is updated; deployment behavior is unchanged.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Increased the deployment stabilization wait from 5 to 10 minutes during service releases, resulting in slightly longer deployment windows.
  - No changes to application features, UI, or APIs; end-user experience remains unchanged.
  - Release cadence and availability are unaffected outside of deployment windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->