### PR TITLE
add tools file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,17 @@ repos:
       - id: check-added-large-files
       - id: check-merge-conflict
 
+  - repo: local
+    hooks:
+      - id: prettier-json
+        name: prettier (json)
+        language: node
+        entry: prettier
+        args: ["--write"]
+        files: \.(json|jsonc)$
+        additional_dependencies:
+          - prettier@3.6.2
+
   # Frontend checks
   - repo: local
     hooks:

--- a/backend/aci/cli/commands/mcp/generate_tools.py
+++ b/backend/aci/cli/commands/mcp/generate_tools.py
@@ -79,6 +79,9 @@ async def _get_auth(
             .limit(1)
         ).scalar()
         if mcp_server_configuration is None:
+            console.print(
+                f"[yellow]Warning: MCP server configuration for {mcp_server.name} not found, skipping tools generation[/yellow]"  # noqa: E501
+            )
             raise click.ClickException(f"MCP server configuration for {mcp_server.name} not found")
 
         # find one connected account for the mcp server configuration
@@ -88,6 +91,9 @@ async def _get_auth(
             .limit(1)
         ).scalar()
         if connected_account is None:
+            console.print(
+                f"[yellow]Warning: Connected account for {mcp_server.name} not found, skipping tools generation[/yellow]"  # noqa: E501
+            )
             raise click.ClickException(f"Connected account for {mcp_server.name} not found")
 
         # Get the auth config and credentials

--- a/backend/mcp_servers/accredible/tools.json
+++ b/backend/mcp_servers/accredible/tools.json
@@ -1,0 +1,525 @@
+[
+  {
+    "name": "ACCREDIBLE__CREATE_CREDENTIAL",
+    "description": "Create a new digital credential or badge for a recipient",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_CREDENTIAL",
+      "canonical_tool_description_hash": "f0f7ca80432a6a6c0336254befde6f37b7cb630f9472c7cca2e9e147f629ef9e",
+      "canonical_tool_input_schema_hash": "bed6ab04fe275012fdc78a0a7120b33b7702e97df9c90af38af3b64425f3fd91"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["credential"],
+          "properties": {
+            "credential": {
+              "type": "object",
+              "required": ["recipient"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The credential name"
+                },
+                "group_id": {
+                  "type": "integer",
+                  "description": "The group ID this credential belongs to"
+                },
+                "issued_on": {
+                  "type": "string",
+                  "description": "Date of issue, format: YYYY-MM-DD"
+                },
+                "meta_data": {
+                  "type": "object",
+                  "required": ["batch_id"],
+                  "properties": {
+                    "batch_id": {
+                      "type": "string",
+                      "description": "Batch identifier"
+                    }
+                  },
+                  "description": "Additional metadata for the credential",
+                  "additionalProperties": true
+                },
+                "recipient": {
+                  "type": "object",
+                  "required": ["name", "email"],
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "The recipient's user ID as defined by your organization"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Full name of the recipient"
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "Email address of the recipient"
+                    },
+                    "meta_data": {
+                      "type": "object",
+                      "required": [],
+                      "properties": {
+                        "credential_batch": {
+                          "type": "string",
+                          "description": "Batch identifier for the credential"
+                        }
+                      },
+                      "description": "Additional metadata for the recipient",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "group_name": {
+                  "type": "string",
+                  "description": "The group name this credential belongs to"
+                },
+                "references": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "visible": ["description", "referee", "relationship"],
+                    "required": ["description", "referee"],
+                    "properties": {
+                      "referee": {
+                        "type": "object",
+                        "visible": ["name", "email", "avatar", "url"],
+                        "required": ["name"],
+                        "properties": {
+                          "url": {
+                            "type": "string",
+                            "description": "URL associated with the referee"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Name of the referee"
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "Email of the referee"
+                          },
+                          "avatar": {
+                            "type": "string",
+                            "description": "Avatar URL of the referee"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "Reference description"
+                      },
+                      "relationship": {
+                        "type": "string",
+                        "description": "Relationship with the recipient"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "description": "References for the credential"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "The credential description"
+                },
+                "evidence_items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "visible": ["description", "url", "file", "category"],
+                    "required": ["description", "category"],
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "description": "URL of the evidence"
+                      },
+                      "file": {
+                        "type": "string",
+                        "description": "File URL of the evidence"
+                      },
+                      "category": {
+                        "enum": ["url", "file"],
+                        "type": "string",
+                        "description": "Category of evidence"
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "Description of the evidence"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "description": "Evidence items for the credential"
+                },
+                "custom_attributes": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "dob": {
+                      "type": "string",
+                      "description": "Date of birth"
+                    },
+                    "custom_variables": {
+                      "type": "string",
+                      "description": "Custom variable value"
+                    }
+                  },
+                  "description": "Custom attributes for the credential",
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "description": "Credential creation details",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ACCREDIBLE__SEARCH_CREDENTIALS",
+    "description": "Search for credentials using various criteria. Supports complex queries with multiple conditions.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_CREDENTIALS",
+      "canonical_tool_description_hash": "32555c7855140de0efdc2bf22631a963ca75ea4be9e82a28a65e62aaeddde73a",
+      "canonical_tool_input_schema_hash": "faefd3b7e613739ff9c2da4cf7ac8ad3624b1a2c885b8ae343420a725373613a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["query"],
+          "properties": {
+            "page": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Page number for pagination"
+            },
+            "query": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "group.id": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Filter by group ID"
+                },
+                "issued_on": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Filter by issue date"
+                },
+                "expires_on": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Filter by expiration date"
+                },
+                "custom_field": {
+                  "type": "object",
+                  "required": ["name", "value"],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the custom field"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "Value of the custom field"
+                    }
+                  },
+                  "description": "Filter by custom field",
+                  "additionalProperties": false
+                },
+                "recipient.email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "Filter by recipient email"
+                }
+              },
+              "description": "Search query parameters",
+              "additionalProperties": false
+            },
+            "per_page": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Number of results per page"
+            }
+          },
+          "description": "Search criteria",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ACCREDIBLE__CREATE_GROUP",
+    "description": "Create a new group for organizing credentials. Groups are similar to courses or folders.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_GROUP",
+      "canonical_tool_description_hash": "70d172fad247cff3d0f11388a3596399fc435a48ed797de027a9cce8c47918ef",
+      "canonical_tool_input_schema_hash": "b3ba65b5fb0e316bd6108c051c39fed84ae14c20eea14e559651398ddc1f4084"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["group"],
+          "properties": {
+            "group": {
+              "type": "object",
+              "required": ["name", "course_name", "course_description"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Name of the group (for your reference and never shown to the recipient)"
+                },
+                "language": {
+                  "enum": [
+                    "en",
+                    "es",
+                    "vi",
+                    "pt",
+                    "ja",
+                    "fr",
+                    "da",
+                    "nl",
+                    "fi",
+                    "no",
+                    "nb",
+                    "ro",
+                    "sv",
+                    "th",
+                    "tw",
+                    "zh",
+                    "tr",
+                    "ar",
+                    "he",
+                    "ms",
+                    "de"
+                  ],
+                  "type": "string",
+                  "default": "en",
+                  "description": "Language for the group. Default language is en"
+                },
+                "meta_data": {
+                  "type": "object",
+                  "required": ["batch_id"],
+                  "properties": {
+                    "batch_id": {
+                      "type": "string",
+                      "description": "Batch identifier"
+                    }
+                  },
+                  "description": "Additional metadata for the group",
+                  "additionalProperties": true
+                },
+                "attach_pdf": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "PDF of the Credential should be attached to email when recipient is informed"
+                },
+                "blockchain": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Enable or disable recording of these Credentials on a Blockchain"
+                },
+                "signup_url": {
+                  "type": "string",
+                  "description": "This provides a direct path for credential viewers to enroll in your course"
+                },
+                "auto_expiry": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Specifies the number of years from the issue date after which the credential will automatically expire. If the specified value is less than or equal to 0, it will be ignored"
+                },
+                "course_link": {
+                  "type": "string",
+                  "description": "Link to the web page with information related to this Credential. Typically this is a course information or event information page"
+                },
+                "course_name": {
+                  "type": "string",
+                  "description": "Name of the course or achievement. This is visible to the recipient"
+                },
+                "department_id": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Department that the group belongs to. If not defined the group will be assigned to the organizations default department"
+                },
+                "badge_design_id": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Badge Design which the Group will use to display Credentials"
+                },
+                "signup_url_show": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Show or hide the sign up url"
+                },
+                "course_link_show": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "This links the credential data record to your information about the credential on your website"
+                },
+                "learning_outcomes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of learning outcomes for the course"
+                },
+                "primary_design_id": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Primary Design which the Group will use to display Credentials"
+                },
+                "course_description": {
+                  "type": "string",
+                  "description": "Description of the course or achievement. This is visible to the recipient"
+                },
+                "certificate_design_id": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Certificate Design which the Group will use to display Credentials"
+                },
+                "organization_link_show": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Show or hide the link to your website homepage"
+                },
+                "allow_duplicate_credentials": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "An email address can receive more than one credential"
+                },
+                "generate_private_credential": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "The default value of Credential.private for the Group"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "description": "Group creation details",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ACCREDIBLE__CREATE_ATTRIBUTE_KEY",
+    "description": "Create a new custom attribute key for use in credentials and templates",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_ATTRIBUTE_KEY",
+      "canonical_tool_description_hash": "4fa327fb6b025c475506c7d21edbf38502e9061560c5b2ce735c348c2e23d3c3",
+      "canonical_tool_input_schema_hash": "b860df5f34977d91afefa00eb186fdc93e984824e769f47cd269ad6f9f6ea047"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["attribute_key"],
+          "properties": {
+            "attribute_key": {
+              "type": "object",
+              "required": ["name", "kind"],
+              "properties": {
+                "kind": {
+                  "enum": ["text", "date", "number", "boolean"],
+                  "type": "string",
+                  "description": "Type of the attribute key"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the attribute key"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Description of what this attribute key represents"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "description": "Attribute key creation details",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ACCREDIBLE__SEARCH_ATTRIBUTE_KEYS",
+    "description": "Search for attribute keys using various criteria",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_ATTRIBUTE_KEYS",
+      "canonical_tool_description_hash": "447843d6c726bc0ff207c79b5053e583a64666c390e9a86f330651fb7a85a1b0",
+      "canonical_tool_input_schema_hash": "d1b5329395a6646a485497f91c052add2c4e36a7f61cb3b811d5176f2088f41e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "kind": {
+              "enum": ["text", "date", "email", "image"],
+              "type": "string",
+              "description": "Optional. Filter by attribute key type"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional. Filter by attribute key name"
+            },
+            "page": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optional. Page number for pagination"
+            },
+            "page_size": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "description": "Optional. Number of results per page"
+            },
+            "department_id": {
+              "type": "integer",
+              "description": "Optional. Filter by department ID"
+            }
+          },
+          "description": "Search criteria for attribute keys. All parameters are optional.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/active_campaign/tools.json
+++ b/backend/mcp_servers/active_campaign/tools.json
@@ -1,0 +1,355 @@
+[
+  {
+    "name": "ACTIVE_CAMPAIGN__CREATE_CONTACT",
+    "description": "Creates a new contact in ActiveCampaign. Accepts contact details including email, first name, last name, phone, and custom field values, and returns the created contact object.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_CONTACT",
+      "canonical_tool_description_hash": "ea6a8f0eef198420062df29be421be8eba240b961cefb1ecb1cf3e6b432b1f46",
+      "canonical_tool_input_schema_hash": "2a9eae3f20526451d4e9eed23964e94c2d90745753802f502879cea0411f6641"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body", "path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["contact"],
+          "properties": {
+            "contact": {
+              "type": "object",
+              "required": ["email"],
+              "properties": {
+                "email": {
+                  "type": "string",
+                  "description": "Contact's email address."
+                },
+                "phone": {
+                  "type": "string",
+                  "description": "Contact's phone number."
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "Contact's last name."
+                },
+                "firstName": {
+                  "type": "string",
+                  "description": "Contact's first name."
+                },
+                "fieldValues": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["field", "value"],
+                    "properties": {
+                      "field": {
+                        "type": "number",
+                        "description": "ID of the custom field."
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "Value for the custom field."
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "description": "List of custom field values for the contact."
+                }
+              },
+              "description": "Contact object with details.",
+              "additionalProperties": false
+            }
+          },
+          "description": "The request body containing contact data.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["account_name"],
+          "properties": {
+            "account_name": {
+              "type": "string",
+              "description": "Your ActiveCampaign account name"
+            }
+          },
+          "description": "Path parameters for the URL",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ACTIVE_CAMPAIGN__RETRIEVE_CONTACT",
+    "description": "Retrieves a contact from ActiveCampaign using the contact ID. Returns the contact's details including email, first name, last name, phone, and custom field values.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RETRIEVE_CONTACT",
+      "canonical_tool_description_hash": "a8ae2b5abb5cdf56c4f7610a2c5749377b1123805609ff7824f55540c8d25209",
+      "canonical_tool_input_schema_hash": "d738bfeb40e7b0c4c60a3c6abde29752186af95e33637e699fddd3e675ae2c4b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["account_name", "contact_id"],
+          "properties": {
+            "contact_id": {
+              "type": "string",
+              "description": "The ID of the contact to retrieve"
+            },
+            "account_name": {
+              "type": "string",
+              "description": "Your ActiveCampaign account name"
+            }
+          },
+          "description": "Path parameters for the URL",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ACTIVE_CAMPAIGN__UPDATE_CONTACT",
+    "description": "Updates an existing contact in ActiveCampaign using the contact ID. Accepts updated contact details including email, first name, last name, phone, and custom field values.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_CONTACT",
+      "canonical_tool_description_hash": "7d190c5a5a00f57f7297a8cb5ccd3897ee36cfde0826a46ffbde4eae43dc433c",
+      "canonical_tool_input_schema_hash": "bf1d12b8dac1612ad0fe61c269f43b1c74016f0f869ce3c6f32180ac394f6225"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["contact"],
+          "properties": {
+            "contact": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "email": {
+                  "type": "string",
+                  "description": "Contact's email address."
+                },
+                "phone": {
+                  "type": "string",
+                  "description": "Contact's phone number."
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "Contact's last name."
+                },
+                "firstName": {
+                  "type": "string",
+                  "description": "Contact's first name."
+                },
+                "fieldValues": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["field", "value"],
+                    "properties": {
+                      "field": {
+                        "type": "number",
+                        "description": "ID of the custom field."
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "Value for the custom field."
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "description": "List of custom field values for the contact."
+                }
+              },
+              "description": "Contact object with updated details.",
+              "additionalProperties": false
+            }
+          },
+          "description": "The request body containing updated contact data.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["account_name", "contact_id"],
+          "properties": {
+            "contact_id": {
+              "type": "string",
+              "description": "The ID of the contact to update"
+            },
+            "account_name": {
+              "type": "string",
+              "description": "Your ActiveCampaign account name"
+            }
+          },
+          "description": "Path parameters for the URL",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ACTIVE_CAMPAIGN__CREATE_LIST",
+    "description": "Creates a new list in ActiveCampaign. Accepts list details including name, stringid, sender_url, sender_reminder, and sender address information, and returns the created list object.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_LIST",
+      "canonical_tool_description_hash": "4f852aa7fc48acc3f867cf651b58abd7bc188dc373264e63b4accc6a2ddcc3f4",
+      "canonical_tool_input_schema_hash": "fba8f0758d593987fdc3c6d43e9e8c0ff1ae4edcc44d9d1f1e4e756cccea59ec"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["list"],
+          "properties": {
+            "list": {
+              "type": "object",
+              "required": [
+                "name",
+                "stringid",
+                "sender_url",
+                "sender_reminder",
+                "sender_name",
+                "sender_addr1",
+                "sender_city",
+                "sender_zip",
+                "sender_country"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the list."
+                },
+                "stringid": {
+                  "type": "string",
+                  "description": "Unique string identifier for the list."
+                },
+                "sender_url": {
+                  "type": "string",
+                  "description": "URL displayed in the footer of the email."
+                },
+                "sender_zip": {
+                  "type": "string",
+                  "description": "ZIP code of the sender."
+                },
+                "sender_city": {
+                  "type": "string",
+                  "description": "City of the sender."
+                },
+                "sender_name": {
+                  "type": "string",
+                  "description": "Name of the sender."
+                },
+                "sender_addr1": {
+                  "type": "string",
+                  "description": "Address line 1 of the sender."
+                },
+                "sender_addr2": {
+                  "type": "string",
+                  "description": "Address line 2 of the sender."
+                },
+                "sender_state": {
+                  "type": "string",
+                  "description": "State of the sender."
+                },
+                "sender_country": {
+                  "type": "string",
+                  "description": "Country of the sender."
+                },
+                "sender_reminder": {
+                  "type": "string",
+                  "description": "Reminder message displayed in the footer of the email."
+                }
+              },
+              "description": "List object with details.",
+              "additionalProperties": false
+            }
+          },
+          "description": "The request body containing list data.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["account_name"],
+          "properties": {
+            "account_name": {
+              "type": "string",
+              "description": "Your ActiveCampaign account name"
+            }
+          },
+          "description": "Path parameters for the URL",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ACTIVE_CAMPAIGN__UPDATE_CONTACT_LIST_STATUS",
+    "description": "Subscribes or unsubscribes a contact to/from a list in ActiveCampaign. Accepts contact ID, list ID, and status to update the contact's subscription status.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_CONTACT_LIST_STATUS",
+      "canonical_tool_description_hash": "c15a4d897b18672e8d0c7807b0e7da7fd025da022aab2ce574ab912067c1f48f",
+      "canonical_tool_input_schema_hash": "0146cee5d292db1ce99647ce50ca897017360724e52847e73e2421b4cb941140"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["contactList"],
+          "properties": {
+            "contactList": {
+              "type": "object",
+              "required": ["list", "contact", "status"],
+              "properties": {
+                "list": {
+                  "type": "string",
+                  "description": "The ID of the list."
+                },
+                "status": {
+                  "type": "string",
+                  "description": "The status of the contact in the list. '1' for active (subscribed), '2' for unsubscribed."
+                },
+                "contact": {
+                  "type": "string",
+                  "description": "The ID of the contact."
+                }
+              },
+              "description": "Contact list status object.",
+              "additionalProperties": false
+            }
+          },
+          "description": "The request body containing contact list status data.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["account_name"],
+          "properties": {
+            "account_name": {
+              "type": "string",
+              "description": "Your ActiveCampaign account name"
+            }
+          },
+          "description": "Path parameters for the URL",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/aero_workflow/tools.json
+++ b/backend/mcp_servers/aero_workflow/tools.json
@@ -1,0 +1,174 @@
+[
+  {
+    "name": "AERO_WORKFLOW__GET_OTHERS",
+    "description": "Retrieve miscellaneous AeroWorkflow data",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_OTHERS",
+      "canonical_tool_description_hash": "367f94348e372028c5b3c6b0ab334d3e02452ecffd0d11136dba13624d67abc5",
+      "canonical_tool_input_schema_hash": "f546e3328c11cdc887e10a7557d4f06b9bb894b7ee3141a696993b08bf4190dc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["account_id"],
+          "properties": {
+            "account_id": {
+              "type": "string",
+              "description": "Account ID"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AERO_WORKFLOW__GET_EMAILS",
+    "description": "Retrieve paginated email data from AeroWorkflow",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_EMAILS",
+      "canonical_tool_description_hash": "e21ab45dc30289b378e0c3a63031c00921be4effaaf36d61dd61fc59ca75cb01",
+      "canonical_tool_input_schema_hash": "2d918dcfb00beac0915bc3b2ad2b6a9a0c24e5c750845b03162f4273221e21bc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["account_id"],
+          "properties": {
+            "account_id": {
+              "type": "string",
+              "description": "Account ID"
+            }
+          },
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "pageNumber": {
+              "type": "integer",
+              "default": 1,
+              "description": "Page number for pagination"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AERO_WORKFLOW__GET_TASKS",
+    "description": "Retrieve task data from AeroWorkflow",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_TASKS",
+      "canonical_tool_description_hash": "8645034fd9cf60d4be911421c0eee1a9ed8ae3a512cb348a9a2173bf4cb1a0a2",
+      "canonical_tool_input_schema_hash": "f546e3328c11cdc887e10a7557d4f06b9bb894b7ee3141a696993b08bf4190dc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["account_id"],
+          "properties": {
+            "account_id": {
+              "type": "string",
+              "description": "Account ID"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AERO_WORKFLOW__GET_CONTACTS",
+    "description": "Retrieve contact data from AeroWorkflow",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CONTACTS",
+      "canonical_tool_description_hash": "a292c962e930ab19a02b737bcd732b4a7f8e6e42c70213386db00d67770af62c",
+      "canonical_tool_input_schema_hash": "f546e3328c11cdc887e10a7557d4f06b9bb894b7ee3141a696993b08bf4190dc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["account_id"],
+          "properties": {
+            "account_id": {
+              "type": "string",
+              "description": "Account ID"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AERO_WORKFLOW__CREATE_CONTACT",
+    "description": "Create a new contact in AeroWorkflow",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_CONTACT",
+      "canonical_tool_description_hash": "3aa55380ca441b70d64e439e5a5871c7579afcf64c1d985cf1400c63c60edbc2",
+      "canonical_tool_input_schema_hash": "30e34b4931af3f563183e00907da862c54086f88f0dfc85577e9796a1b5242ce"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["firstName", "lastName"],
+          "properties": {
+            "lastName": {
+              "type": "string",
+              "description": "Contact's last name"
+            },
+            "firstName": {
+              "type": "string",
+              "description": "Contact's first name"
+            },
+            "defaultEmailAddress": {
+              "type": "string",
+              "format": "email",
+              "description": "Primary email address"
+            }
+          },
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["account_id"],
+          "properties": {
+            "account_id": {
+              "type": "string",
+              "description": "Account ID"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/agent_mail/tools.json
+++ b/backend/mcp_servers/agent_mail/tools.json
@@ -1,0 +1,149 @@
+[
+  {
+    "name": "AGENT_MAIL__GET_INBOX",
+    "description": "Retrieve information about a specific inbox by its ID (email address)",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_INBOX",
+      "canonical_tool_description_hash": "0092c5f47fd55f6c3bfcbc8f8ce5296131512e79b64191572e3a6503aad8bb6a",
+      "canonical_tool_input_schema_hash": "22805971b071e3c84b5d23966dfa2dd7d99481b378185f6e1a37daca29fdf05a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["inbox_id"],
+          "properties": {
+            "inbox_id": {
+              "type": "string",
+              "description": "ID (email address) of the inbox"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AGENT_MAIL__CREATE_INBOX",
+    "description": "Create a new inbox with a specified username and display name",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_INBOX",
+      "canonical_tool_description_hash": "39d345b129873b52a9a6e862d2e44883c51567683cce9625b00395f6c128b6de",
+      "canonical_tool_input_schema_hash": "88da6e027087bc07c91b60e48a92de467bc7f68367935819281d890d5d2aa645"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["username", "display_name"],
+          "properties": {
+            "domain": {
+              "type": "string",
+              "description": "Domain of address. Must be verified domain. Defaults to agentmail.to"
+            },
+            "username": {
+              "type": "string",
+              "description": "Username of address. Randomly generated if not specified."
+            },
+            "display_name": {
+              "type": "string",
+              "description": "Display name for address: Display Name <username@domain.com>"
+            }
+          },
+          "description": "Body parameters for creating the inbox",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AGENT_MAIL__LIST_THREADS",
+    "description": "List threads from a specific inbox with pagination support",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_THREADS",
+      "canonical_tool_description_hash": "55bf6ab4baf0c7421226edd7decd5aff0f16f8d0dc06e9e3b6ee47476d681dca",
+      "canonical_tool_input_schema_hash": "87f73a01fe3e94a12c5229ca909fd602fd5b0bd1706ff6376af90d461df4d494"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["inbox_id"],
+          "properties": {
+            "inbox_id": {
+              "type": "string",
+              "description": "ID (email address) of the inbox"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "description": "Limit of number of items returned"
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Labels to filter threads by"
+            },
+            "last_key": {
+              "type": "string",
+              "description": "Key of last item for pagination"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AGENT_MAIL__LIST_MESSAGES",
+    "description": "List messages from a specific inbox",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_MESSAGES",
+      "canonical_tool_description_hash": "58cda03a7dacaae7fe479e18029643eee8aeef9c096b7e82dc2246f0a6528a23",
+      "canonical_tool_input_schema_hash": "22805971b071e3c84b5d23966dfa2dd7d99481b378185f6e1a37daca29fdf05a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["inbox_id"],
+          "properties": {
+            "inbox_id": {
+              "type": "string",
+              "description": "ID (email address) of the inbox"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/aidbase/tools.json
+++ b/backend/mcp_servers/aidbase/tools.json
@@ -1,0 +1,212 @@
+[
+  {
+    "name": "AIDBASE__GET_ALL_CHATBOTS",
+    "description": "Get all chatbots associated with the user.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ALL_CHATBOTS",
+      "canonical_tool_description_hash": "41d9324f5428cf5be4077e1a56fec5194b99f0900a51d06558b689e8e2dab6d0",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AIDBASE__GET_CHATBOT_BY_ID",
+    "description": "Get a specific chatbot by ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CHATBOT_BY_ID",
+      "canonical_tool_description_hash": "151a60a558ca247225bdda7fc3bc3c6b875b77014c200d65079e821a952e2527",
+      "canonical_tool_input_schema_hash": "b55c83f86fb33f207ae310ede14e72d0d303856c970f43ece698c284142631d1"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "p-8KP033W9GT8xZMEULqa",
+              "description": "Unique identifier for the chatbot"
+            }
+          },
+          "description": "Path parameters.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AIDBASE__POST_CHATBOT_REPLY",
+    "description": "Get an AI reply from a chatbot.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "POST_CHATBOT_REPLY",
+      "canonical_tool_description_hash": "7ae50b08c66e0767700003137b2b56ec5a090645e35aedeaed627bbfd580d287",
+      "canonical_tool_input_schema_hash": "8cd43fdb68faf184cd4adca42ab453814d17b1df26847a829746047816846491"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["message"],
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "How can I get started with Aidbase API?",
+              "description": "The reply message to send."
+            },
+            "session_id": {
+              "type": "string",
+              "example": "tAp_XW4qvRzKw",
+              "description": "Optional session identifier for the chatbot."
+            }
+          },
+          "description": "Reply payload.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "odguL9hXiB413s3g9ZO3z",
+              "description": "Unique identifier for the chatbot."
+            }
+          },
+          "description": "Path parameters.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AIDBASE__GET_CHATBOT_KNOWLEDGE",
+    "description": "Get all knowledge items associated with a chatbot.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CHATBOT_KNOWLEDGE",
+      "canonical_tool_description_hash": "2f5fb85fe5269837a2414ea0ef5710bd9974699de11d5226491e8add95f60cca",
+      "canonical_tool_input_schema_hash": "e6058667d24dcd7c20b266026dc5b53473b43074d252b2e40e027640bf215fa9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "odguL9hXiB413s3g9ZO3z",
+              "description": "Unique identifier for the chatbot."
+            }
+          },
+          "description": "Path parameters.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AIDBASE__PUT_CHATBOT_KNOWLEDGE",
+    "description": "Add a new knowledge item to a chatbot.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PUT_CHATBOT_KNOWLEDGE",
+      "canonical_tool_description_hash": "114a416d15257cdfb53c44b4e2030e7c52363aa143bd10b5a3393ef2f0417c4a",
+      "canonical_tool_input_schema_hash": "2720359e88d2d6674ece7722c4c1f119045f5dbf92d2ccd480ccb972bbd79a0d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["knowledge_id"],
+          "properties": {
+            "knowledge_id": {
+              "type": "string",
+              "example": "cd2faf2c-464b-421f-a7b1-b856860551f8",
+              "description": "Unique identifier for the knowledge item to update."
+            }
+          },
+          "description": "Knowledge update payload.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "odguL9hXiB413s3g9ZO3z",
+              "description": "Unique identifier for the chatbot."
+            }
+          },
+          "description": "Path parameters.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AIDBASE__REMOVE_CHATBOT_KNOWLEDGE",
+    "description": "Remove a knowledge item from a chatbot.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REMOVE_CHATBOT_KNOWLEDGE",
+      "canonical_tool_description_hash": "c1b1d759d3fc297d25c89b7501c86dec6883bb9bd96a47a04d78fc6285dee466",
+      "canonical_tool_input_schema_hash": "edbd315a514131c80dc2bcabdc5d3acd14be56be3eaff566137298eda13df4cf"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["knowledge_id"],
+          "properties": {
+            "knowledge_id": {
+              "type": "string",
+              "example": "cd2faf2c-464b-421f-a7b1-b856860551f8",
+              "description": "Unique identifier for the knowledge item to delete."
+            }
+          },
+          "description": "Knowledge delete payload.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "odguL9hXiB413s3g9ZO3z",
+              "description": "Unique identifier for the chatbot."
+            }
+          },
+          "description": "Path parameters.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/airtable/tools.json
+++ b/backend/mcp_servers/airtable/tools.json
@@ -1,0 +1,369 @@
+[
+  {
+    "name": "AIRTABLE__LIST_BASES",
+    "description": "List all bases in Airtable that the user has access to",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_BASES",
+      "canonical_tool_description_hash": "7e1383151cfe84881f2b0d4f96ee12130f924a90e2829b7dc6f1d6ff39a3877e",
+      "canonical_tool_input_schema_hash": "98abee7b17f50ff687433e6aa66c4a8a407130e6c24685a489269b6f16872bea"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["header"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "offset": {
+              "type": "string",
+              "description": "Pagination offset. Use the offset returned in the previous response to fetch the next page of records."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": ["Content-Type"],
+          "properties": {
+            "Content-Type": {
+              "type": "string",
+              "default": "application/json",
+              "description": "Content type of the request"
+            }
+          },
+          "description": "Headers for the HTTP request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AIRTABLE__GET_BASE_SCHEMA",
+    "description": "Get the schema of tables in a specific base",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_BASE_SCHEMA",
+      "canonical_tool_description_hash": "a2002e03dcf5f3180daabbb39fd339e1904bfa4f84ded43ad3a8fbb641397aa9",
+      "canonical_tool_input_schema_hash": "01dcfba643d1898063f4f4164fd0e6bcb152b046340e5e3eecb11782cc7c89fc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["base_id"],
+          "properties": {
+            "base_id": {
+              "type": "string",
+              "description": "ID of the base to retrieve tables from"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "include": {
+              "type": "array",
+              "items": {
+                "enum": ["visibleFieldIds"],
+                "type": "string"
+              },
+              "description": "If specified, additional fields to include in the views object response; currently, this list only allows a single literal value 'visibleFieldIds' (for views of type grid only)"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AIRTABLE__CREATE_TABLE",
+    "description": "Create a new table in a specific base",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_TABLE",
+      "canonical_tool_description_hash": "2491f284a41cc42b77ed8729ae64a9af56909b622e23f0f89cf3e27020ccc870",
+      "canonical_tool_input_schema_hash": "a4a7788a8f45e78f149e346786e074b3df17a2bc3cdcd1ec125da63022ac99ba"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name", "fields"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the new table"
+            },
+            "fields": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["name", "description", "type", "options"],
+                "required": ["name", "type"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the field"
+                  },
+                  "type": {
+                    "enum": [
+                      "autoNumber",
+                      "barcode",
+                      "button",
+                      "checkbox",
+                      "count",
+                      "createdBy",
+                      "createdTime",
+                      "currency",
+                      "date",
+                      "dateTime",
+                      "duration",
+                      "email",
+                      "formula",
+                      "lastModifiedBy",
+                      "lastModifiedTime",
+                      "lookup",
+                      "multilineText",
+                      "multipleAttachments",
+                      "multipleCollaborators",
+                      "multipleRecordLinks",
+                      "multipleSelects",
+                      "number",
+                      "percent",
+                      "phoneNumber",
+                      "rating",
+                      "richText",
+                      "rollup",
+                      "singleCollaborator",
+                      "singleLineText",
+                      "singleSelect",
+                      "url"
+                    ],
+                    "type": "string",
+                    "description": "Type of the field"
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "max": {
+                        "type": "number",
+                        "description": "For rating fields, the maximum rating value"
+                      },
+                      "icon": {
+                        "type": "string",
+                        "description": "Icon identifier for fields like checkbox (e.g., 'check', 'x')"
+                      },
+                      "color": {
+                        "type": "string",
+                        "description": "Color for field display (e.g., 'greenBright', 'red')"
+                      },
+                      "symbol": {
+                        "type": "string",
+                        "description": "For currency fields, the currency symbol to use (e.g., '$')"
+                      },
+                      "choices": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "Display name for the choice"
+                            },
+                            "color": {
+                              "type": "string",
+                              "description": "Color for the choice (e.g., 'blue', 'red')"
+                            }
+                          }
+                        },
+                        "description": "For singleSelect and multipleSelects fields, the list of available options"
+                      },
+                      "formula": {
+                        "type": "string",
+                        "description": "For formula fields, the formula expression"
+                      },
+                      "timeZone": {
+                        "type": "string",
+                        "description": "For dateTime fields, the time zone (e.g., 'America/Los_Angeles', 'UTC')"
+                      },
+                      "precision": {
+                        "type": "integer",
+                        "description": "For number fields, the number of digits after the decimal point"
+                      },
+                      "dateFormat": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "enum": ["local", "friendly", "iso", "european", "us"],
+                            "type": "string",
+                            "description": "Format name for the date"
+                          }
+                        },
+                        "description": "For date fields, the format of the date"
+                      },
+                      "isReversed": {
+                        "type": "boolean",
+                        "description": "For multipleRecordLinks fields, whether the relationship is reversed"
+                      },
+                      "timeFormat": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "enum": ["12hour", "24hour"],
+                            "type": "string",
+                            "description": "Format name for the time"
+                          }
+                        },
+                        "description": "For dateTime fields, the format of the time"
+                      },
+                      "relationship": {
+                        "enum": ["oneToMany", "manyToOne", "manyToMany"],
+                        "type": "string",
+                        "description": "For multipleRecordLinks fields, the relationship type"
+                      },
+                      "foreignTableId": {
+                        "type": "string",
+                        "description": "For multipleRecordLinks fields, the ID of the linked table"
+                      },
+                      "symmetricColumnId": {
+                        "type": "string",
+                        "description": "For multipleRecordLinks fields, the ID of the symmetric field in the linked table"
+                      },
+                      "inverseForeignFieldId": {
+                        "type": "string",
+                        "description": "For lookup fields, the ID of the field to look up from"
+                      },
+                      "inverseForeignTableId": {
+                        "type": "string",
+                        "description": "For lookup fields, the ID of the table to look up from"
+                      }
+                    },
+                    "description": "Additional options for the field based on its type"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Description of the field"
+                  }
+                },
+                "description": "Field definition",
+                "additionalProperties": false
+              },
+              "description": "Fields to create in the new table. A list of JSON objects representing the fields in the table."
+            },
+            "description": {
+              "type": "string",
+              "description": "Description of the new table"
+            }
+          },
+          "description": "Table creation parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["base_id"],
+          "properties": {
+            "base_id": {
+              "type": "string",
+              "description": "ID of the base to create a table in"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AIRTABLE__LIST_WEBHOOKS",
+    "description": "List all webhooks for a specific base",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_WEBHOOKS",
+      "canonical_tool_description_hash": "f37bd22295b4cf40eb68af0743979e5a31887d6f0c00b5ff0123518140a142a0",
+      "canonical_tool_input_schema_hash": "d27188a2585ceddf7de34a54e16c21b76a976f8c17abcaa01d877cf3e052bb78"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["base_id"],
+          "properties": {
+            "base_id": {
+              "type": "string",
+              "description": "ID of the base to retrieve webhooks from"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AIRTABLE__UPDATE_TABLE",
+    "description": "Update an existing table in a specific base",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_TABLE",
+      "canonical_tool_description_hash": "3a53769aac6f33bbec7ed74eaa5be8c03c547a95db82a721400dd74f4ea0574a",
+      "canonical_tool_input_schema_hash": "d84d3388d15412afbc7aebe4d09174d4757308a06dcc6a182d41759539a6c7ed"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "New name for the table"
+            },
+            "description": {
+              "type": "string",
+              "description": "New description for the table"
+            }
+          },
+          "description": "Table update parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["base_id", "table_id"],
+          "properties": {
+            "base_id": {
+              "type": "string",
+              "description": "ID of the base containing the table"
+            },
+            "table_id": {
+              "type": "string",
+              "description": "ID of the table to update"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/akkio/tools.json
+++ b/backend/mcp_servers/akkio/tools.json
@@ -1,0 +1,172 @@
+[
+  {
+    "name": "AKKIO__LIST_MODELS",
+    "description": "Get all models in your organization",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_MODELS",
+      "canonical_tool_description_hash": "84c919521f62bdf388e3900d8c3739b7ebaf8c1c72f23272f72a6278c8862697",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AKKIO__LIST_DATASETS",
+    "description": "Get all datasets in your organization, or optionally get a specific dataset",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_DATASETS",
+      "canonical_tool_description_hash": "bfc1f8b85d428bb2d841ba19ee43986c5dd1224116acd931e06d4dbfe320fa93",
+      "canonical_tool_input_schema_hash": "f12374cfa21145d054ab0d549a19058e55a0880029935fefa3c9eaa0a4cd001d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "(Optional): If dataset ID is included, only the specific dataset is returned"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AKKIO__CREATE_DATASET",
+    "description": "Creates a dataset with a given name",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_DATASET",
+      "canonical_tool_description_hash": "2cc13d3c1a4452a8d39a7911d8b1f2ac7abb97a5168628c948ddd5575159610d",
+      "canonical_tool_input_schema_hash": "35184b3a1dc160dd3d6a3a2964bc1c28382fa7a53c8940c4ecdee3cbeabf0c5b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the dataset to be created"
+            }
+          },
+          "description": "The request body",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AKKIO__ADD_ROWS_TO_DATASET",
+    "description": "Add rows to an existing dataset",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ADD_ROWS_TO_DATASET",
+      "canonical_tool_description_hash": "9e33b5301ead3e5af8172fc16d65db0cf033a120c86017fae00d19468d6d0b25",
+      "canonical_tool_input_schema_hash": "c16efc9248077528420d24743ab595ca5c363cdf101e9a3021072e8c72980773"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["id", "rows"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the dataset to add rows to"
+            },
+            "rows": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "description": "A row of data with field names and values",
+                "additionalProperties": true
+              },
+              "description": "An array of objects, each representing a row of data. Example: [{\"name\": \"John\", \"age\": 30}]"
+            }
+          },
+          "description": "The request body",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AKKIO__DELETE_DATASET",
+    "description": "Deletes a given dataset from a given ID",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_DATASET",
+      "canonical_tool_description_hash": "29a660057d16e60d74b545e380901f28132ab2645f89860ced03750cf7a1b968",
+      "canonical_tool_input_schema_hash": "03929ebe5d524b0d7267bcecfb484cc383d88a0857d3660006441dc27f9dba67"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the dataset to delete"
+            }
+          },
+          "description": "The request body",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "AKKIO__DELETE_MODEL",
+    "description": "Deletes a specific model by ID",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_MODEL",
+      "canonical_tool_description_hash": "a6f9b30162a575490540cf7318a74a57da63ca7f520d9e41f394b496f2281f64",
+      "canonical_tool_input_schema_hash": "0c36ae0067650ceecc1757da495d1c1fde403c8f82d588bf08726b3d35945b3e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the model to delete"
+            }
+          },
+          "description": "The request body",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/all_images/tools.json
+++ b/backend/mcp_servers/all_images/tools.json
@@ -1,0 +1,223 @@
+[
+  {
+    "name": "ALL_IMAGES__CHECK_API_KEY",
+    "description": "Check if the API key is valid",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CHECK_API_KEY",
+      "canonical_tool_description_hash": "79e1888b0bd69981ef91b2772302c285908225a0dbdc6178f480d2419da7d24e",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ALL_IMAGES__SEARCH_IMAGES",
+    "description": "Search for images using keywords and filters",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_IMAGES",
+      "canonical_tool_description_hash": "57e182e64edc9ac0ff66e845ae1c50df0cd10b5010042810e461a487602a354d",
+      "canonical_tool_input_schema_hash": "d9bff6143eb6aed0ec6adbc22d2aeb4905ff2afe277b4b55ed930586204e3d5e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["search"],
+          "properties": {
+            "sort": {
+              "type": "string",
+              "description": "Sort order"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Maximum number of results to return"
+            },
+            "offset": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0,
+              "description": "Number of results to skip"
+            },
+            "search": {
+              "type": "string",
+              "description": "Search query keywords"
+            },
+            "filterFree": {
+              "type": "boolean",
+              "default": false,
+              "description": "Filter to show only free images"
+            }
+          },
+          "description": "Search parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ALL_IMAGES__DOWNLOAD_IMAGE",
+    "description": "Download an image by its ID",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DOWNLOAD_IMAGE",
+      "canonical_tool_description_hash": "e91c88e355c66e5244205a229c387a1d777e400f0eebccc5e583e4a71bee203f",
+      "canonical_tool_input_schema_hash": "22a6c6a442ccbced6b7ba65b1ab0f185c8ee5ff40611a3716cfc8f313bcc55fb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the image to download"
+            }
+          },
+          "description": "Download parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ALL_IMAGES__CREATE_GENERATION",
+    "description": "Create an AI image generation task",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_GENERATION",
+      "canonical_tool_description_hash": "507f071b6f469a69e79125ecbd4653d961e9b5c9567051888eeedb9edf3017d6",
+      "canonical_tool_input_schema_hash": "594a7d900ce08e7a88cf4b3e31b868026485bee512ff18a7c0e744c48bbce22d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name", "mode", "prompt"],
+          "properties": {
+            "mode": {
+              "enum": ["simple", "advanced"],
+              "type": "string",
+              "default": "simple",
+              "description": "Generation mode"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the generation task"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Tags make it easy to find generations"
+            },
+            "params": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["name", "value"],
+                "required": ["name", "value"],
+                "properties": {
+                  "name": {
+                    "enum": [
+                      "sujetMode",
+                      "templatePrompt",
+                      "angle",
+                      "photographe",
+                      "time",
+                      "weather",
+                      "format",
+                      "camera",
+                      "interdiction",
+                      "version",
+                      "chaos",
+                      "stylize",
+                      "fromImageUrl"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "List of generation parameters"
+            },
+            "prompt": {
+              "type": "string",
+              "maxLength": 4096,
+              "description": "Text prompt for image generation"
+            },
+            "processMode": {
+              "enum": ["relax", "fast"],
+              "type": "string",
+              "default": "fast",
+              "description": "Mode of the image generation (only for 'Dedicated' user)"
+            },
+            "optimizePrompt": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to optimize the prompt"
+            },
+            "additionalPrompt": {
+              "type": "string",
+              "maxLength": 1024,
+              "description": "Additional text prompt, not affected by optimization if enabled. Added at the beginning"
+            }
+          },
+          "description": "Generation parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ALL_IMAGES__GET_GENERATION",
+    "description": "Get the status of an image generation task",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_GENERATION",
+      "canonical_tool_description_hash": "715ae5de3294e99d7815c746a7cb3ca84f4285beab33e4d78711a281dcd19d99",
+      "canonical_tool_input_schema_hash": "7d74711e8a3cb11c5f9955d3499ef8ed7675cfb4a44a37fb3f8bd468b4d42916"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["generation_id"],
+          "properties": {
+            "generation_id": {
+              "type": "string",
+              "description": "ID of the generation task"
+            }
+          },
+          "description": "URL path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/apaleo/tools.json
+++ b/backend/mcp_servers/apaleo/tools.json
@@ -1,0 +1,417 @@
+[
+  {
+    "name": "APALEO__GET_PROPERTIES",
+    "description": "Retrieves a list of properties with optional filters",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PROPERTIES",
+      "canonical_tool_description_hash": "ac43dd7dc742a598c1230a86dd233ccb20cc03a4ddc307284b9de4d2191297f9",
+      "canonical_tool_input_schema_hash": "5dfc887000791f31d65712ef6c4e5c318d2f586f9cb51a042b6a386b0344abd2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "expand": {
+              "type": "string",
+              "description": "Expand related entities"
+            },
+            "status": {
+              "type": "string",
+              "description": "Filter properties by status"
+            },
+            "pageNumber": {
+              "type": "integer",
+              "description": "Page number"
+            },
+            "countryCode": {
+              "type": "string",
+              "description": "Filter by country code"
+            },
+            "includeArchived": {
+              "type": "boolean",
+              "description": "Include archived properties"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "APALEO__CREATE_BOOKING",
+    "description": "Creates a new booking with reservations",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_BOOKING",
+      "canonical_tool_description_hash": "2a0cd5bafff85c488eb0bf99fd64db7e30f35bed5b80b0f880c10ee978ba0383",
+      "canonical_tool_input_schema_hash": "3778b523e80a26af849eabc2230fdcbaf344b4beb3039c0005e5fd2cf3328033"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body", "header"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["reservations"],
+          "properties": {
+            "booker": {
+              "type": "object",
+              "required": ["firstName", "lastName", "email"],
+              "properties": {
+                "email": {
+                  "type": "string"
+                },
+                "address": {
+                  "type": "object",
+                  "required": ["addressLine1", "city", "countryCode"],
+                  "properties": {
+                    "city": {
+                      "type": "string"
+                    },
+                    "countryCode": {
+                      "type": "string"
+                    },
+                    "addressLine1": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "lastName": {
+                  "type": "string"
+                },
+                "firstName": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "reservations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": [
+                  "arrival",
+                  "departure",
+                  "adults",
+                  "primaryGuest",
+                  "timeSlices",
+                  "services",
+                  "prePaymentAmount"
+                ],
+                "required": ["arrival", "departure", "adults", "primaryGuest", "timeSlices"],
+                "properties": {
+                  "adults": {
+                    "type": "integer"
+                  },
+                  "arrival": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "services": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "visible": ["serviceId", "dates"],
+                      "required": ["serviceId"],
+                      "properties": {
+                        "dates": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "visible": ["serviceDate", "amount"],
+                            "required": ["serviceDate"],
+                            "properties": {
+                              "amount": {
+                                "type": "object",
+                                "visible": ["amount", "currency"],
+                                "required": ["amount", "currency"],
+                                "properties": {
+                                  "amount": {
+                                    "type": "number"
+                                  },
+                                  "currency": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "serviceDate": {
+                                "type": "string",
+                                "format": "date"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "serviceId": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "departure": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "timeSlices": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "visible": ["ratePlanId", "totalAmount"],
+                      "required": ["ratePlanId"],
+                      "properties": {
+                        "ratePlanId": {
+                          "type": "string"
+                        },
+                        "totalAmount": {
+                          "type": "object",
+                          "visible": ["amount", "currency"],
+                          "required": ["amount", "currency"],
+                          "properties": {
+                            "amount": {
+                              "type": "number"
+                            },
+                            "currency": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "channelCode": {
+                    "type": "string"
+                  },
+                  "childrenAges": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "guestComment": {
+                    "type": "string"
+                  },
+                  "primaryGuest": {
+                    "type": "object",
+                    "visible": ["firstName", "lastName", "email", "address", "vehicleRegistration"],
+                    "required": ["firstName", "lastName", "email"],
+                    "properties": {
+                      "email": {
+                        "type": "string"
+                      },
+                      "phone": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "gender": {
+                        "type": "string"
+                      },
+                      "address": {
+                        "type": "object",
+                        "visible": ["addressLine1", "city", "countryCode"],
+                        "required": ["addressLine1", "city", "countryCode"],
+                        "properties": {
+                          "city": {
+                            "type": "string"
+                          },
+                          "postalCode": {
+                            "type": "string"
+                          },
+                          "countryCode": {
+                            "type": "string"
+                          },
+                          "addressLine1": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "lastName": {
+                        "type": "string"
+                      },
+                      "firstName": {
+                        "type": "string"
+                      },
+                      "middleInitial": {
+                        "type": "string"
+                      },
+                      "vehicleRegistration": {
+                        "type": "object",
+                        "visible": ["number", "countryCode"],
+                        "required": ["number", "countryCode"],
+                        "properties": {
+                          "number": {
+                            "type": "string"
+                          },
+                          "countryCode": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "guaranteeType": {
+                    "type": "string"
+                  },
+                  "travelPurpose": {
+                    "type": "string"
+                  },
+                  "prePaymentAmount": {
+                    "type": "object",
+                    "visible": ["amount", "currency"],
+                    "required": ["amount", "currency"],
+                    "properties": {
+                      "amount": {
+                        "type": "number"
+                      },
+                      "currency": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "paymentAccount": {
+              "type": "object",
+              "required": ["accountNumber", "accountHolder", "paymentMethod"],
+              "properties": {
+                "accountHolder": {
+                  "type": "string"
+                },
+                "accountNumber": {
+                  "type": "string"
+                },
+                "paymentMethod": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "transactionReference": {
+              "type": "string"
+            }
+          },
+          "description": "Request body",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": ["Content-Type"],
+          "properties": {
+            "Content-Type": {
+              "type": "string",
+              "default": "application/json"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "APALEO__GET_RATE_PLANS",
+    "description": "Retrieves a list of rate plans",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_RATE_PLANS",
+      "canonical_tool_description_hash": "cdd6640744661ebf418729496b17b461c250ebf3b7731b40a525bc2373a67c7a",
+      "canonical_tool_input_schema_hash": "b9575b5cea245ebf971e680c19319d43a3b62ae50ff8542b15b60c5b7ce97ce6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "pageNumber": {
+              "type": "integer",
+              "description": "Page number"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "APALEO__GET_UNITS",
+    "description": "Retrieves a list of units",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_UNITS",
+      "canonical_tool_description_hash": "5251c7235afee0d861e8f64e95b54ea4801e995afc910ae00f529ebdc4302e19",
+      "canonical_tool_input_schema_hash": "b9575b5cea245ebf971e680c19319d43a3b62ae50ff8542b15b60c5b7ce97ce6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "pageNumber": {
+              "type": "integer",
+              "description": "Page number"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "APALEO__GET_RESERVATIONS",
+    "description": "Retrieves a list of reservations",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_RESERVATIONS",
+      "canonical_tool_description_hash": "870d8555582e885ead05a33e13ed5cc810dc52c7e7004bb8a17b5ea5eb8658e4",
+      "canonical_tool_input_schema_hash": "b9575b5cea245ebf971e680c19319d43a3b62ae50ff8542b15b60c5b7ce97ce6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "pageNumber": {
+              "type": "integer",
+              "description": "Page number"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/api_template/tools.json
+++ b/backend/mcp_servers/api_template/tools.json
@@ -1,0 +1,118 @@
+[
+  {
+    "name": "API_TEMPLATE__LIST_TEMPLATES",
+    "description": "List all templates from APITemplate.io",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_TEMPLATES",
+      "canonical_tool_description_hash": "18c4d83aa3a05d472f9be92d3d84cafde73bcc49931516b34522c218d189173c",
+      "canonical_tool_input_schema_hash": "0882716f390523efb64c5654a68a434de7e6ee36f3b1130218d8af9f1ac74ff5"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "string",
+              "default": "300",
+              "description": "Retrieve only the number of records specified. Default to 300"
+            },
+            "format": {
+              "enum": ["PDF", "JPEG"],
+              "type": "string",
+              "description": "To filter the templates by either 'PDF' or 'JPEG'"
+            },
+            "offset": {
+              "type": "string",
+              "default": "0",
+              "description": "Offset is used to skip the number of records from the results. Default to 0"
+            },
+            "group_name": {
+              "type": "string",
+              "description": "To filter the templates by the group name"
+            },
+            "template_id": {
+              "type": "string",
+              "description": "To filter the templates by template id"
+            },
+            "with_layer_info": {
+              "enum": ["0", "1"],
+              "type": "string",
+              "default": "0",
+              "description": "Return along with layer information for image templates, 0=false , 1=true. Default to '0'"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "API_TEMPLATE__GET_TEMPLATE",
+    "description": "Get a specific template details from APITemplate.io",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_TEMPLATE",
+      "canonical_tool_description_hash": "89632f15701d18b71bf4b739bd809bdf95a195817042cf693ea27c0fc48466f0",
+      "canonical_tool_input_schema_hash": "351303c9a8b8a9b7fdc171318a89224b4ce625bfac301514724ad70b2ff3ec38"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["template_id"],
+          "properties": {
+            "template_id": {
+              "type": "string",
+              "description": "The ID of the template to retrieve"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "API_TEMPLATE__UPDATE_TEMPLATE",
+    "description": "Update a specific template in APITemplate.io",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_TEMPLATE",
+      "canonical_tool_description_hash": "400334c3dcd5bd055794064ec86123d090f5a7394a416d3e2dd326fe91ef0a7b",
+      "canonical_tool_input_schema_hash": "3dffb684f23a52c6da98d5dacac42bf4470bdcad170b13a8270b4a4a0e11aefb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["template_id", "css"],
+          "properties": {
+            "css": {
+              "type": "string",
+              "description": "The new template HTML content"
+            },
+            "template_id": {
+              "type": "string",
+              "description": "The ID of the template to update"
+            }
+          },
+          "description": "Template update parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/arxiv/tools.json
+++ b/backend/mcp_servers/arxiv/tools.json
@@ -1,0 +1,182 @@
+[
+  {
+    "name": "ARXIV__SEARCH_PAPERS",
+    "description": "Search for papers on arXiv by query, category, and other criteria. Returns results in Atom XML format that needs to be parsed into JSON.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_PAPERS",
+      "canonical_tool_description_hash": "f6e4442fab28403c3a23c78f1b4e6ba97498d32bf1d4ea9d3edf03813eb079b7",
+      "canonical_tool_input_schema_hash": "8390dd7c53ddd5628fbf2bb3bcdf441fbd757ac5a4f41871ee0af1fc8dc7ac16"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["search_query"],
+          "properties": {
+            "start": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0,
+              "description": "Starting index for results (for pagination)"
+            },
+            "sortBy": {
+              "enum": ["relevance", "lastUpdatedDate", "submittedDate"],
+              "type": "string",
+              "default": "relevance",
+              "description": "Sorting criterion for results"
+            },
+            "id_list": {
+              "type": "string",
+              "description": "Comma-separated list of arXiv IDs to return"
+            },
+            "sortOrder": {
+              "enum": ["ascending", "descending"],
+              "type": "string",
+              "default": "descending",
+              "description": "Order of sorting"
+            },
+            "max_results": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Maximum number of results to return (1-1000)"
+            },
+            "search_query": {
+              "type": "string",
+              "description": "Search query string. Supports Boolean operators (AND, OR, NOT), grouping with parentheses, and field-specific searches."
+            }
+          },
+          "description": "Query parameters for searching papers",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ARXIV__GET_PAPER_METADATA",
+    "description": "Retrieve detailed metadata for a specific paper on arXiv by its ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PAPER_METADATA",
+      "canonical_tool_description_hash": "d70798a6d2a554b97fd7eb6a702970e5a4b631195a8b43f2e9e8ddc3fb9bfa03",
+      "canonical_tool_input_schema_hash": "3755f6a354d341cf71695ba9e16cd0ee268e926ef3f8346a103c59fc2d5c56e8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["id_list"],
+          "properties": {
+            "id_list": {
+              "type": "string",
+              "description": "arXiv ID of the paper (e.g., '2108.07258' or 'cs/0703041')"
+            }
+          },
+          "description": "Query parameters for retrieving paper metadata",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ARXIV__DOWNLOAD_PAPER",
+    "description": "Download a paper from arXiv in PDF format.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DOWNLOAD_PAPER",
+      "canonical_tool_description_hash": "ebf3d93144198d884ec47877d28c2dbfe233b0faff4316ee6fc27501f42681d7",
+      "canonical_tool_input_schema_hash": "70e162d56aed512d6365fcac6b46ee850b66cab9f7ecfabcc75a0f846048bddb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["paper_id"],
+          "properties": {
+            "paper_id": {
+              "type": "string",
+              "description": "arXiv ID of the paper (e.g., '2108.07258' or 'cs/0703041')"
+            }
+          },
+          "description": "Path parameters for downloading paper",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ARXIV__GET_CATEGORIES",
+    "description": "Retrieve a list of all available categories on arXiv.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CATEGORIES",
+      "canonical_tool_description_hash": "bd5c574a3a71d4087163433dd45d95050819cef7c8dc2fc2e957df8472010a6a",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ARXIV__GET_DAILY_UPDATES",
+    "description": "Retrieve the latest papers from specific categories, published within the last day.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DAILY_UPDATES",
+      "canonical_tool_description_hash": "b2ed30738d166bfaa2a7f001fd0bef4f79bec8daa8bcda9fbdc81ede3cfa5c60",
+      "canonical_tool_input_schema_hash": "99e45e112e47c1fb1fdd93842ffbed845dd9d1817fac02867d9c58c145aab9aa"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["search_query"],
+          "properties": {
+            "sortBy": {
+              "enum": ["lastUpdatedDate", "submittedDate"],
+              "type": "string",
+              "default": "submittedDate",
+              "description": "Sorting criterion for results"
+            },
+            "sortOrder": {
+              "enum": ["ascending", "descending"],
+              "type": "string",
+              "default": "descending",
+              "description": "Order of sorting"
+            },
+            "max_results": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Maximum number of results to return (1-100)"
+            },
+            "search_query": {
+              "type": "string",
+              "description": "Comma-separated list of arXiv categories to fetch updates from (e.g., 'cat:cs.AI,cat:physics.gen-ph')"
+            }
+          },
+          "description": "Query parameters for getting daily updates",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/baidu_map/tools.json
+++ b/backend/mcp_servers/baidu_map/tools.json
@@ -1,0 +1,437 @@
+[
+  {
+    "name": "BAIDU_MAP__DRIVING_DIRECTIONS",
+    "description": "Driving route planning service",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DRIVING_DIRECTIONS",
+      "canonical_tool_description_hash": "bca971dd301c0660721011a99899db5631e25511bea3d385970b708f9786be57",
+      "canonical_tool_input_schema_hash": "f3dc7adb714a5047a42bad47bb7e06f16ecddac83f4a8758d2d62716b9974902"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["origin", "destination"],
+          "properties": {
+            "speed": {
+              "type": "string",
+              "description": "Travel speed at starting point (meters/second)"
+            },
+            "origin": {
+              "type": "string",
+              "description": "Starting coordinates in format: latitude,longitude"
+            },
+            "output": {
+              "enum": ["json", "xml"],
+              "type": "string",
+              "default": "json",
+              "description": "Output format"
+            },
+            "radius": {
+              "type": "string",
+              "description": "Positioning accuracy at starting point (0-2000)"
+            },
+            "cartype": {
+              "type": "string",
+              "default": "0",
+              "description": "Vehicle type: 0-regular car, 1-electric car, etc."
+            },
+            "tactics": {
+              "enum": ["0", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"],
+              "type": "string",
+              "default": "0",
+              "description": "Driving strategy: 0-default, 2-shortest distance, 3-avoid highways, 4-highway preferred, 5-avoid congestion, etc."
+            },
+            "walkinfo": {
+              "enum": ["0", "1"],
+              "type": "string",
+              "default": "0",
+              "description": "Whether to include walking directions at starting/ending points: 0-no, 1-yes"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Timestamp, used with SN for authentication"
+            },
+            "waypoints": {
+              "type": "string",
+              "description": "Waypoints, up to 16 points, multiple points separated by '|' in format: latitude,longitude|latitude,longitude"
+            },
+            "coord_type": {
+              "enum": ["bd09ll", "bd09mc", "gcj02", "wgs84"],
+              "type": "string",
+              "default": "bd09ll",
+              "description": "Coordinate type"
+            },
+            "origin_uid": {
+              "type": "string",
+              "description": "POI UID of starting point for higher accuracy"
+            },
+            "steps_info": {
+              "enum": ["0", "1"],
+              "type": "string",
+              "default": "0",
+              "description": "Whether to include detailed step information: 0-no, 1-yes"
+            },
+            "destination": {
+              "type": "string",
+              "description": "Destination coordinates in format: latitude,longitude"
+            },
+            "alternatives": {
+              "enum": ["0", "1"],
+              "type": "string",
+              "default": "0",
+              "description": "Whether to return alternative routes: 0-return one recommended route, 1-return up to 3 alternative routes"
+            },
+            "plate_number": {
+              "type": "string",
+              "description": "License plate number for traffic restriction check"
+            },
+            "gps_direction": {
+              "type": "string",
+              "description": "Direction of travel at starting point (0-359 degrees)"
+            },
+            "ret_coordtype": {
+              "enum": ["bd09ll", "gcj02"],
+              "type": "string",
+              "default": "bd09ll",
+              "description": "Return result coordinate type"
+            },
+            "destination_uid": {
+              "type": "string",
+              "description": "POI UID of destination point for higher accuracy"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BAIDU_MAP__RIDING_DIRECTIONS",
+    "description": "Cycling route planning service",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RIDING_DIRECTIONS",
+      "canonical_tool_description_hash": "93b617f85c94d970f9a569e883f10e6bb828f23dffd4223fed5562ef33b320f2",
+      "canonical_tool_input_schema_hash": "54f7d47bda61dac904770dd31b331b804be475eb9e0cf2de0a93e4a3e0c109ea"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["origin", "destination"],
+          "properties": {
+            "origin": {
+              "type": "string",
+              "comment": "Starting coordinates in format: latitude,longitude; decimal places should not exceed 6, e.g. 40.056878,116.30815",
+              "description": "Starting coordinates in format: latitude,longitude"
+            },
+            "output": {
+              "enum": ["json", "xml"],
+              "type": "string",
+              "default": "json",
+              "description": "Output format"
+            },
+            "timestamp": {
+              "type": "integer",
+              "comment": "Required when SN is present",
+              "description": "Timestamp, used with SN for authentication"
+            },
+            "coord_type": {
+              "enum": ["bd09ll", "bd09mc", "gcj02", "wgs84"],
+              "type": "string",
+              "default": "bd09ll",
+              "description": "Coordinate type"
+            },
+            "origin_uid": {
+              "type": "string",
+              "description": "POI UID of starting point for higher accuracy"
+            },
+            "destination": {
+              "type": "string",
+              "comment": "Destination coordinates in format: latitude,longitude; decimal places should not exceed 6, e.g. 40.056878,116.30815",
+              "description": "Destination coordinates in format: latitude,longitude"
+            },
+            "riding_type": {
+              "enum": ["0", "1"],
+              "type": "string",
+              "default": "0",
+              "description": "Cycling type: 0-regular bike, 1-electric bike"
+            },
+            "road_prefer": {
+              "enum": ["0", "3"],
+              "type": "string",
+              "default": "0",
+              "description": "Route preference: 0-default route, 3-route without highways and toll roads"
+            },
+            "ret_coordtype": {
+              "enum": ["bd09ll", "gcj02"],
+              "type": "string",
+              "default": "bd09ll",
+              "description": "Return result coordinate type"
+            },
+            "destination_uid": {
+              "type": "string",
+              "description": "POI UID of destination point for higher accuracy"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BAIDU_MAP__WALKING_DIRECTIONS",
+    "description": "Walking route planning service",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "WALKING_DIRECTIONS",
+      "canonical_tool_description_hash": "d695dbaa8dd754f19efc945390fee3a737c3725f608d1c6f202c727f3733694a",
+      "canonical_tool_input_schema_hash": "7e5ad6e95947f869519033d6eedaa5bae1398358ed8f66fa78a519f2ce934a62"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["origin", "destination"],
+          "properties": {
+            "origin": {
+              "type": "string",
+              "description": "Starting coordinates in format: latitude,longitude"
+            },
+            "output": {
+              "enum": ["json", "xml"],
+              "type": "string",
+              "default": "json",
+              "description": "Output format"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Timestamp, used with SN for authentication"
+            },
+            "coord_type": {
+              "enum": ["bd09ll", "bd09mc", "gcj02", "wgs84"],
+              "type": "string",
+              "default": "bd09ll",
+              "description": "Coordinate type"
+            },
+            "origin_uid": {
+              "type": "string",
+              "description": "POI UID of starting point for higher accuracy"
+            },
+            "steps_info": {
+              "enum": ["0", "1"],
+              "type": "string",
+              "default": "0",
+              "description": "Whether to include detailed step information: 0-no, 1-yes"
+            },
+            "destination": {
+              "type": "string",
+              "description": "Destination coordinates in format: latitude,longitude"
+            },
+            "ret_coordtype": {
+              "enum": ["bd09ll", "gcj02"],
+              "type": "string",
+              "default": "bd09ll",
+              "description": "Return result coordinate type"
+            },
+            "destination_uid": {
+              "type": "string",
+              "description": "POI UID of destination point for higher accuracy"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BAIDU_MAP__TRANSIT_DIRECTIONS",
+    "description": "Public transit route planning service",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TRANSIT_DIRECTIONS",
+      "canonical_tool_description_hash": "4fac0b8fe4fad0d8f2ec04fc14700502bd72c7a48b12bd0d6e4c85918dbdcb6f",
+      "canonical_tool_input_schema_hash": "9df9fff9e9967265fed6ca0fb9c95efe940a3413209eff5f7f8a4ae697065b93"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["origin", "destination"],
+          "properties": {
+            "origin": {
+              "type": "string",
+              "description": "Starting coordinates in format: latitude,longitude"
+            },
+            "output": {
+              "enum": ["json", "xml"],
+              "type": "string",
+              "default": "json",
+              "description": "Output format"
+            },
+            "callback": {
+              "type": "string",
+              "description": "Callback function name, only valid when output=json"
+            },
+            "page_size": {
+              "type": "string",
+              "default": "10",
+              "description": "Number of routes per page"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Timestamp, used with SN for authentication"
+            },
+            "coord_type": {
+              "enum": ["bd09ll", "bd09mc", "gcj02", "wgs84"],
+              "type": "string",
+              "default": "bd09ll",
+              "description": "Coordinate type"
+            },
+            "origin_uid": {
+              "type": "string",
+              "description": "POI UID of starting point for higher accuracy"
+            },
+            "page_index": {
+              "type": "string",
+              "default": "1",
+              "description": "Page number"
+            },
+            "steps_info": {
+              "enum": ["0", "1"],
+              "type": "string",
+              "default": "0",
+              "description": "Whether to include detailed step information: 0-no, 1-yes"
+            },
+            "destination": {
+              "type": "string",
+              "description": "Destination coordinates in format: latitude,longitude"
+            },
+            "ret_coordtype": {
+              "enum": ["bd09ll", "gcj02"],
+              "type": "string",
+              "default": "bd09ll",
+              "description": "Return result coordinate type"
+            },
+            "departure_date": {
+              "type": "string",
+              "description": "Departure date"
+            },
+            "departure_time": {
+              "type": "string",
+              "description": "Departure time range, format: 'hh:mm-hh:mm' or 'hh:mm'"
+            },
+            "tactics_incity": {
+              "enum": ["0", "1", "2", "3", "4", "5"],
+              "type": "string",
+              "default": "0",
+              "description": "Strategy for intra-city public transit"
+            },
+            "destination_uid": {
+              "type": "string",
+              "description": "POI UID of destination point for higher accuracy"
+            },
+            "tactics_intercity": {
+              "enum": ["0", "1", "2"],
+              "type": "string",
+              "default": "0",
+              "description": "Strategy for inter-city public transit"
+            },
+            "trans_type_intercity": {
+              "enum": ["0", "1", "2"],
+              "type": "string",
+              "default": "0",
+              "description": "Inter-city transport mode strategy"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BAIDU_MAP__ROUTE_MATRIX",
+    "description": "Route matrix service for calculating distance and duration between multiple origins and destinations",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ROUTE_MATRIX",
+      "canonical_tool_description_hash": "d5d0018b83d4dcd4902394be314dc75b13ee46e77560b22c8c264a336bb2f0d7",
+      "canonical_tool_input_schema_hash": "d4a52ea5b49168e06cf5ec548d553f7993477a021c5e7d09c9b24557f53acc53"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["origins", "destinations"],
+          "properties": {
+            "output": {
+              "enum": ["json", "xml"],
+              "type": "string",
+              "default": "json",
+              "description": "Output format"
+            },
+            "origins": {
+              "type": "string",
+              "description": "Starting coordinates, multiple points separated by '|' in format: latitude,longitude|latitude,longitude"
+            },
+            "tactics": {
+              "enum": ["10", "11", "12", "13"],
+              "type": "string",
+              "default": "13",
+              "description": "Route planning preferences: 10-least time(default), a11-shortest distance, 12-avoid traffic jams, 13-shortest distance without traffic info"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Timestamp, used with SN for authentication, not required here"
+            },
+            "coord_type": {
+              "enum": ["bd09ll", "bd09mc", "gcj02", "wgs84"],
+              "type": "string",
+              "default": "bd09ll",
+              "description": "Coordinate type"
+            },
+            "riding_type": {
+              "enum": ["0", "1"],
+              "type": "string",
+              "default": "0",
+              "description": "Cycling type: 0-regular bike, 1-electric bike"
+            },
+            "destinations": {
+              "type": "string",
+              "description": "Destination\u00b7 coordinates, multiple points separated by '|' in format: latitude,longitude|latitude,longitude"
+            },
+            "ret_straight_dist": {
+              "enum": ["0", "1"],
+              "type": "string",
+              "default": "0",
+              "description": "Whether to return straight line distance: 0-return route distance, 1-return straight line distance"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/baserow/tools.json
+++ b/backend/mcp_servers/baserow/tools.json
@@ -1,0 +1,323 @@
+[
+  {
+    "name": "BASEROW__LIST_TEAMS_FIELDS",
+    "description": "List all fields in the Teams table",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_TEAMS_FIELDS",
+      "canonical_tool_description_hash": "93ddb7b49629edbda0a67af48fd0aeecaa06014ff07a0b385f224f08237b921c",
+      "canonical_tool_input_schema_hash": "2c05bd87d9c5f8b90b014ed438ad070e1e1201464efffcf4166145ab5d0ef6fb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["table_id"],
+          "properties": {
+            "table_id": {
+              "type": "integer",
+              "description": "The unique identifier of the table"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BASEROW__LIST_TEAMS_ROWS",
+    "description": "List all rows in the Teams table with pagination and filtering options",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_TEAMS_ROWS",
+      "canonical_tool_description_hash": "aa8ca9e570016be13a69a0f6076e63dc94769d52f96a4dcff18d64752499fa82",
+      "canonical_tool_input_schema_hash": "86b7dface25b04d880b0f9de03cd939d16569c93fd57de18fed2068c50c6517b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["table_id"],
+          "properties": {
+            "table_id": {
+              "type": "integer",
+              "description": "The unique identifier of the table"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "page": {
+              "type": "integer",
+              "default": 1,
+              "description": "Defines which page of rows should be returned"
+            },
+            "size": {
+              "type": "integer",
+              "default": 100,
+              "description": "Defines how many rows should be returned per page"
+            },
+            "search": {
+              "type": "string",
+              "description": "If provided, only rows matching the search query are returned"
+            },
+            "exclude": {
+              "type": "string",
+              "description": "Comma-separated list of fields to exclude from results"
+            },
+            "filters": {
+              "type": "string",
+              "description": "JSON serialized string containing the filter tree to apply"
+            },
+            "include": {
+              "type": "string",
+              "description": "Comma-separated list of fields to include in results"
+            },
+            "view_id": {
+              "type": "integer",
+              "description": "ID of the view to apply its filters and sorts"
+            },
+            "order_by": {
+              "type": "string",
+              "description": "Comma-separated list of fields to order by. Prepend with '-' for descending order"
+            },
+            "filter_type": {
+              "enum": ["AND", "OR"],
+              "type": "string",
+              "default": "AND",
+              "description": "Type of filter combination (AND/OR)"
+            },
+            "field_filters": {
+              "type": "object",
+              "required": ["field_name", "filter_type", "value"],
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "description": "Value to filter by"
+                },
+                "field_name": {
+                  "type": "string",
+                  "description": "Field name or field ID (e.g., 'Name' or 'field_1')"
+                },
+                "filter_type": {
+                  "enum": [
+                    "equal",
+                    "not_equal",
+                    "contains",
+                    "not_contains",
+                    "empty",
+                    "not_empty",
+                    "before",
+                    "after",
+                    "higher_than",
+                    "lower_than"
+                  ],
+                  "type": "string",
+                  "description": "Type of filter to apply"
+                }
+              },
+              "description": "Field-specific filters using the format filter__{field}__{filter}=value",
+              "additionalProperties": true
+            },
+            "user_field_names": {
+              "enum": ["y", "yes", "true", "t", "on", "1", ""],
+              "type": "string",
+              "description": "When provided, returns field names instead of field IDs"
+            },
+            "link_row_field__join": {
+              "type": "string",
+              "description": "Comma-separated list of fields to lookup from linked tables. Format: {link_field_name}__join={target_field1},{target_field2}"
+            }
+          },
+          "description": "Query parameters for filtering and pagination",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BASEROW__GET_TEAMS_ROW",
+    "description": "Get a single row from the Teams table",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_TEAMS_ROW",
+      "canonical_tool_description_hash": "e0c58d8a0a8d8e3a55f70a895c259bd0784def0053f9d970466022dd4653ef11",
+      "canonical_tool_input_schema_hash": "b64a855b998214075818bd9243cd8f628e9209fcdb56e3e10ec592a768a7fd24"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["table_id", "row_id"],
+          "properties": {
+            "row_id": {
+              "type": "integer",
+              "description": "The unique identifier of the row that is requested"
+            },
+            "table_id": {
+              "type": "integer",
+              "description": "The unique identifier of the table"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "user_field_names": {
+              "enum": ["y", "yes", "true", "t", "on", "1", ""],
+              "type": "string",
+              "description": "When provided, returns field names instead of field IDs"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BASEROW__CREATE_TEAMS_ROW",
+    "description": "Create a new row in the Teams table",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_TEAMS_ROW",
+      "canonical_tool_description_hash": "dca36abbe22f117c525a8ebcaf8f50eee1fda56c6c87f818791ce27110f13162",
+      "canonical_tool_input_schema_hash": "e31c40766a7b92a4e401b06945cca79f35be5c33ac4c85dca21e66a1587af471"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["Name"],
+          "properties": {
+            "Name": {
+              "type": "string",
+              "description": "Team name"
+            }
+          },
+          "description": "Row data to create",
+          "additionalProperties": true
+        },
+        "path": {
+          "type": "object",
+          "required": ["table_id"],
+          "properties": {
+            "table_id": {
+              "type": "integer",
+              "description": "The unique identifier of the table"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "before": {
+              "type": "integer",
+              "description": "If provided, the new row will be positioned before the row with this ID"
+            },
+            "user_field_names": {
+              "enum": ["y", "yes", "true", "t", "on", "1", ""],
+              "type": "string",
+              "description": "When provided, returns field names instead of field IDs"
+            },
+            "send_webhook_events": {
+              "enum": ["y", "yes", "true", "t", "on", "1", ""],
+              "type": "string",
+              "default": "true",
+              "description": "Trigger webhooks after the operation"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BASEROW__UPDATE_TEAMS_ROW",
+    "description": "Update an existing row in the Teams table",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_TEAMS_ROW",
+      "canonical_tool_description_hash": "3dbc858a7412fc55a1b1519dd455502009d0c26b3552c4c5cfd940d372949eae",
+      "canonical_tool_input_schema_hash": "4435e4c2a8504542d3674fb1a0ab362420ad80170183b7c3e371e56984db4b5b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "Name": {
+              "type": "string",
+              "description": "Team name"
+            }
+          },
+          "description": "Row data to update",
+          "additionalProperties": true
+        },
+        "path": {
+          "type": "object",
+          "required": ["table_id", "row_id"],
+          "properties": {
+            "row_id": {
+              "type": "integer",
+              "description": "The unique identifier of the row that needs to be updated"
+            },
+            "table_id": {
+              "type": "integer",
+              "description": "The unique identifier of the table"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "user_field_names": {
+              "enum": ["y", "yes", "true", "t", "on", "1", ""],
+              "type": "string",
+              "description": "When provided, returns field names instead of field IDs"
+            },
+            "send_webhook_events": {
+              "enum": ["y", "yes", "true", "t", "on", "1", ""],
+              "type": "string",
+              "default": "true",
+              "description": "Trigger webhooks after the operation"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/brave_search/tools.json
+++ b/backend/mcp_servers/brave_search/tools.json
@@ -1,0 +1,536 @@
+[
+  {
+    "name": "BRAVE_SEARCH__WEB_SEARCH",
+    "description": "Brave Web Search API is a REST API to query Brave Search and get back search results from the web.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "WEB_SEARCH",
+      "canonical_tool_description_hash": "4dd6b9e6d736b2a9f7d4fd362ed34075d24ab3b2bea26caba16771ce3d83a0b6",
+      "canonical_tool_input_schema_hash": "dec8572e5d7a79a6cd7f9e0b9a5cc8a1525a438aa24ed9919bd17d57174e9cd9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "maxLength": 400,
+              "description": "The user's search query term. Maximum of 400 characters and 50 words"
+            },
+            "count": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 20,
+              "minimum": 1,
+              "description": "Number of search results returned in response (max 20) The actual number delivered may be less than requested. Combine this parameter with offset to paginate search results."
+            },
+            "offset": {
+              "type": "integer",
+              "default": 0,
+              "maximum": 9,
+              "minimum": 0,
+              "description": "The zero based offset that indicates number of search results per page (count) to skip before returning the result. The maximum is 9. The actual number delivered may be less than requested based on the query. In order to paginate results use this parameter together with count"
+            },
+            "safesearch": {
+              "enum": ["off", "moderate", "strict"],
+              "type": "string",
+              "default": "moderate",
+              "description": "Filters search results for adult content"
+            },
+            "extra_snippets": {
+              "type": "boolean",
+              "default": false,
+              "description": "A snippet is an excerpt from a page you get as a result of the query, and extra_snippets allow you to get up to 5 additional, alternative excerpts."
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BRAVE_SEARCH__IMAGE_SEARCH",
+    "description": "Brave Image Search API is a REST API to query Brave Search and get back search results from the web.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "IMAGE_SEARCH",
+      "canonical_tool_description_hash": "aa011a8a6bd02b6cdd7c13cf9f1820275f0cb2087ed00efe23093cbf504d7f82",
+      "canonical_tool_input_schema_hash": "a3d6e21caf2cc7e3dce1435816e67f51781dfb36bf7b9f272f32bd61374d1bc3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "maxLength": 400,
+              "description": "The user\u2019s search query term. Query can not be empty. Maximum of 400 characters and 50 words in the query."
+            },
+            "count": {
+              "type": "integer",
+              "default": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Number of search results returned in response (max 20) The actual number delivered may be less than requested. Combine this parameter with offset to paginate search results."
+            },
+            "country": {
+              "enum": [
+                "ALL",
+                "AR",
+                "AU",
+                "AT",
+                "BE",
+                "BR",
+                "CA",
+                "CL",
+                "DK",
+                "FI",
+                "FR",
+                "DE",
+                "HK",
+                "IN",
+                "ID",
+                "IT",
+                "JP",
+                "KR",
+                "MY",
+                "MX",
+                "NL",
+                "NZ",
+                "NO",
+                "CN",
+                "PL",
+                "PT",
+                "PH",
+                "RU",
+                "SA",
+                "ZA",
+                "ES",
+                "SE",
+                "CH",
+                "TW",
+                "TR",
+                "GB",
+                "US"
+              ],
+              "type": "string",
+              "default": "US",
+              "description": "The search query country (2 character country codes)"
+            },
+            "safesearch": {
+              "enum": ["off", "strict"],
+              "type": "string",
+              "default": "strict",
+              "description": "Filters search results for adult content"
+            },
+            "spellcheck": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to spellcheck provided query"
+            },
+            "search_lang": {
+              "enum": [
+                "ar",
+                "eu",
+                "bn",
+                "bg",
+                "ca",
+                "zh-hans",
+                "zh-hant",
+                "hr",
+                "cs",
+                "da",
+                "nl",
+                "en",
+                "en-gb",
+                "et",
+                "fi",
+                "fr",
+                "gl",
+                "de",
+                "gu",
+                "he",
+                "hi",
+                "hu",
+                "is",
+                "it",
+                "jp",
+                "kn",
+                "ko",
+                "lv",
+                "lt",
+                "ms",
+                "ml",
+                "mr",
+                "nb",
+                "pl",
+                "pt-br",
+                "pt-pt",
+                "pa",
+                "ro",
+                "ru",
+                "sr",
+                "sk",
+                "sl",
+                "es",
+                "sv",
+                "ta",
+                "te",
+                "th",
+                "tr",
+                "uk",
+                "vi"
+              ],
+              "type": "string",
+              "default": "en",
+              "description": "The search language preference (2+ character language code)"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BRAVE_SEARCH__VIDEO_SEARCH",
+    "description": "Brave Video Search API is a REST API to query Brave Search and get back search results from the web.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "VIDEO_SEARCH",
+      "canonical_tool_description_hash": "0f729891e7bef4e0fc607a13a37e353ac915121a4b852fb3a4ba8eec3c53fc23",
+      "canonical_tool_input_schema_hash": "5dda3d27b530f9661d06d1f50d64ef50029119b4c432f66f4ea1bec0506b88ec"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "maxLength": 400,
+              "description": "The user\u2019s search query term. Query can not be empty. Maximum of 400 characters and 50 words in the query."
+            },
+            "count": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 50,
+              "minimum": 1,
+              "description": "Number of search results returned in response (max 50). The actual number delivered may be less than requested. Combine this parameter with offset to paginate search results."
+            },
+            "offset": {
+              "type": "integer",
+              "default": 0,
+              "maximum": 9,
+              "minimum": 0,
+              "description": "The zero-based offset that indicates the number of search results per page to skip before returning the result. The maximum is 9."
+            },
+            "country": {
+              "enum": [
+                "ALL",
+                "AR",
+                "AU",
+                "AT",
+                "BE",
+                "BR",
+                "CA",
+                "CL",
+                "DK",
+                "FI",
+                "FR",
+                "DE",
+                "HK",
+                "IN",
+                "ID",
+                "IT",
+                "JP",
+                "KR",
+                "MY",
+                "MX",
+                "NL",
+                "NZ",
+                "NO",
+                "CN",
+                "PL",
+                "PT",
+                "PH",
+                "RU",
+                "SA",
+                "ZA",
+                "ES",
+                "SE",
+                "CH",
+                "TW",
+                "TR",
+                "GB",
+                "US"
+              ],
+              "type": "string",
+              "default": "US",
+              "description": "The search query country (2 character country codes)"
+            },
+            "ui_lang": {
+              "type": "string",
+              "default": "en-US",
+              "description": "User interface language preferred in response. Usually formatted as '<language_code>-<country_code>' (RFC 9110)."
+            },
+            "freshness": {
+              "type": "string",
+              "description": "Filters search results by when they were discovered. Supported values: 'pd' (24 hours), 'pw' (7 days), 'pm' (31 days), 'py' (365 days), or a date range 'YYYY-MM-DDtoYYYY-MM-DD'."
+            },
+            "safesearch": {
+              "enum": ["off", "moderate", "strict"],
+              "type": "string",
+              "default": "moderate",
+              "description": "Filters search results for adult content."
+            },
+            "spellcheck": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether to spellcheck provided query. If the spellchecker is enabled, the modified query is always used for search."
+            },
+            "search_lang": {
+              "enum": [
+                "ar",
+                "eu",
+                "bn",
+                "bg",
+                "ca",
+                "zh-hans",
+                "zh-hant",
+                "hr",
+                "cs",
+                "da",
+                "nl",
+                "en",
+                "en-gb",
+                "et",
+                "fi",
+                "fr",
+                "gl",
+                "de",
+                "gu",
+                "he",
+                "hi",
+                "hu",
+                "is",
+                "it",
+                "jp",
+                "kn",
+                "ko",
+                "lv",
+                "lt",
+                "ms",
+                "ml",
+                "mr",
+                "nb",
+                "pl",
+                "pt-br",
+                "pt-pt",
+                "pa",
+                "ro",
+                "ru",
+                "sr",
+                "sk",
+                "sl",
+                "es",
+                "sv",
+                "ta",
+                "te",
+                "th",
+                "tr",
+                "uk",
+                "vi"
+              ],
+              "type": "string",
+              "default": "en",
+              "description": "The search language preference (2+ character language code)"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BRAVE_SEARCH__NEWS_SEARCH",
+    "description": "Brave News Search API is a REST API to query Brave Search and get back search results from the web.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "NEWS_SEARCH",
+      "canonical_tool_description_hash": "dcf56d0d3503612484dc309e33be7859b56387b271c0cf920bf629bf7ecdfb54",
+      "canonical_tool_input_schema_hash": "5dda3d27b530f9661d06d1f50d64ef50029119b4c432f66f4ea1bec0506b88ec"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "maxLength": 400,
+              "description": "The user\u2019s search query term. Query can not be empty. Maximum of 400 characters and 50 words in the query."
+            },
+            "count": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 50,
+              "minimum": 1,
+              "description": "Number of search results returned in response (max 50). The actual number delivered may be less than requested. Combine this parameter with offset to paginate search results."
+            },
+            "offset": {
+              "type": "integer",
+              "default": 0,
+              "maximum": 9,
+              "minimum": 0,
+              "description": "The zero-based offset that indicates the number of search results per page to skip before returning the result. The maximum is 9."
+            },
+            "country": {
+              "enum": [
+                "ALL",
+                "AR",
+                "AU",
+                "AT",
+                "BE",
+                "BR",
+                "CA",
+                "CL",
+                "DK",
+                "FI",
+                "FR",
+                "DE",
+                "HK",
+                "IN",
+                "ID",
+                "IT",
+                "JP",
+                "KR",
+                "MY",
+                "MX",
+                "NL",
+                "NZ",
+                "NO",
+                "CN",
+                "PL",
+                "PT",
+                "PH",
+                "RU",
+                "SA",
+                "ZA",
+                "ES",
+                "SE",
+                "CH",
+                "TW",
+                "TR",
+                "GB",
+                "US"
+              ],
+              "type": "string",
+              "default": "US",
+              "description": "The search query country (2 character country codes)"
+            },
+            "ui_lang": {
+              "type": "string",
+              "default": "en-US",
+              "description": "User interface language preferred in response. Usually formatted as '<language_code>-<country_code>' (RFC 9110)."
+            },
+            "freshness": {
+              "type": "string",
+              "description": "Filters search results by when they were discovered. Supported values: 'pd' (24 hours), 'pw' (7 days), 'pm' (31 days), 'py' (365 days), or a date range 'YYYY-MM-DDtoYYYY-MM-DD'."
+            },
+            "safesearch": {
+              "enum": ["off", "moderate", "strict"],
+              "type": "string",
+              "default": "moderate",
+              "description": "Filters search results for adult content."
+            },
+            "spellcheck": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether to spellcheck provided query. If the spellchecker is enabled, the modified query is always used for search."
+            },
+            "search_lang": {
+              "enum": [
+                "ar",
+                "eu",
+                "bn",
+                "bg",
+                "ca",
+                "zh-hans",
+                "zh-hant",
+                "hr",
+                "cs",
+                "da",
+                "nl",
+                "en",
+                "en-gb",
+                "et",
+                "fi",
+                "fr",
+                "gl",
+                "de",
+                "gu",
+                "he",
+                "hi",
+                "hu",
+                "is",
+                "it",
+                "jp",
+                "kn",
+                "ko",
+                "lv",
+                "lt",
+                "ms",
+                "ml",
+                "mr",
+                "nb",
+                "pl",
+                "pt-br",
+                "pt-pt",
+                "pa",
+                "ro",
+                "ru",
+                "sr",
+                "sk",
+                "sl",
+                "es",
+                "sv",
+                "ta",
+                "te",
+                "th",
+                "tr",
+                "uk",
+                "vi"
+              ],
+              "type": "string",
+              "default": "en",
+              "description": "The search language preference (2+ character language code)"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/breezy/tools.json
+++ b/backend/mcp_servers/breezy/tools.json
@@ -1,0 +1,107 @@
+[
+  {
+    "name": "BREEZY__GET_COMPANY",
+    "description": "Retrieve the company information associated with the specified company ID",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_COMPANY",
+      "canonical_tool_description_hash": "a8938002402a2afdbaa25fb13b4fa4ba07a1dbc231f2adf313385af0af1722a2",
+      "canonical_tool_input_schema_hash": "12cf8ca61e2ee750857f710db604b485d44e835f74bf6d8b14f47ae948bc8a06"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["company_id"],
+          "properties": {
+            "company_id": {
+              "type": "string",
+              "description": "Unique identifier for the company"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BREEZY__GET_POSITIONS",
+    "description": "Retrieve all positions for given company in given state (status)",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_POSITIONS",
+      "canonical_tool_description_hash": "ad8cf24c00716f897927df376494dc2e06a540b178bf4dafcafa40a28e39ccbb",
+      "canonical_tool_input_schema_hash": "50ac7d26f1ec1fc521a2247bffe599bc431010f345e637bae72cdd9ed7d974c1"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["company_id"],
+          "properties": {
+            "company_id": {
+              "type": "string",
+              "description": "Unique identifier for the company"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "state": {
+              "enum": ["draft", "archived", "published", "closed", "pending"],
+              "type": "string",
+              "default": "published",
+              "description": "Specify an optional position state filter. Default is published."
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BREEZY__GET_POSITION_BYID",
+    "description": "Retrieve details for given position id",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_POSITION_BYID",
+      "canonical_tool_description_hash": "54a9611814364b710f9b3fb9d2d2b1e320732264ee5d1ea75d801085cc9bede0",
+      "canonical_tool_input_schema_hash": "8e623219c75199174a73f4c1c990c0e51e83af18af2eaec0a36a38e1250ae19c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["company_id", "position_id"],
+          "properties": {
+            "company_id": {
+              "type": "string",
+              "description": "Unique identifier for the company"
+            },
+            "position_id": {
+              "type": "string",
+              "description": "Unique identifier for the position"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/browserbase/tools.json
+++ b/backend/mcp_servers/browserbase/tools.json
@@ -1,0 +1,617 @@
+[
+  {
+    "name": "BROWSERBASE__GET_SESSION_LOGS",
+    "description": "Get the logs for a specific browser session.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SESSION_LOGS",
+      "canonical_tool_description_hash": "2ecfe1d9209f2483f18f75f99ad3fce6f42330ea2c0bed01a9b38bca0f25e338",
+      "canonical_tool_input_schema_hash": "0012cf88e31b52a16d992d904f24f06ab948f98832510ac904f0b3d8833c1dfa"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the session to retrieve logs for"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__GET_SESSION",
+    "description": "Get detailed information about a specific browser session by its ID. Returns complete session metadata including status, resource usage, and configuration.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SESSION",
+      "canonical_tool_description_hash": "2594b563ba5ec92304ed778065ca68dbffc462c2fe5a08a11598857debe5aa47",
+      "canonical_tool_input_schema_hash": "87ecb143378921889d08cb5a5076793e5ede2403c1db77f8b2721743539f378c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the session to retrieve"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__UPDATE_SESSION",
+    "description": "Update a browser session's status, such as requesting release of a session to avoid additional charges before timeout.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_SESSION",
+      "canonical_tool_description_hash": "43beaffc562d00ab50cdfe67aea1dca6cb6aa2468a8a56cf9f359cf989372894",
+      "canonical_tool_input_schema_hash": "76771187199b6f1a0117b0bb57d3948d751ee55a046ce5b25f964da7e443da1a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["projectId", "status"],
+          "properties": {
+            "status": {
+              "enum": ["REQUEST_RELEASE"],
+              "type": "string",
+              "description": "Set to REQUEST_RELEASE to request that the session complete. Use before session's timeout to avoid additional charges."
+            },
+            "projectId": {
+              "type": "string",
+              "description": "The Project ID. Can be found in Settings"
+            }
+          },
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the session to update"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__GET_SESSION_DEBUG",
+    "description": "Get debug URLs for a specific browser session, including debugger URLs and page information. Provides access to Chrome DevTools Protocol endpoints and page inspection interfaces.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SESSION_DEBUG",
+      "canonical_tool_description_hash": "785b65a56bc453dc0135a08d53f82e7056aaac4719de034455ad77e7cad9553b",
+      "canonical_tool_input_schema_hash": "29b29d9a8134d85125f82e92ce3b56373b47a78246296ade700f44cb69e471fe"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the session to get debug information for"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__GET_SESSION_DOWNLOADS",
+    "description": "Get a list of files downloaded during a specific browser session. Allows access to files that were downloaded while the session was active.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SESSION_DOWNLOADS",
+      "canonical_tool_description_hash": "3acac91a8db281f82b98c0e29a786537a50a2ddd65104be893272e1b7e26651d",
+      "canonical_tool_input_schema_hash": "7c654ed765a74d9b12d8f570655974584388e47cf027ae755db287703f5d4ef2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the session to retrieve downloads for"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__CREATE_SESSION",
+    "description": "Create a new browser session with Browserbase cloud browser. Configure browser settings, fingerprinting, proxy, and more to simulate real user browsing behavior.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_SESSION",
+      "canonical_tool_description_hash": "7371d1060950f19e88078eed6bc1cb364d44fa886cfef7d6cc4074f2f71f3f89",
+      "canonical_tool_input_schema_hash": "3917b07eb5bb2bd2be8a9a9559fd4ef46561a82ffce0fea852197c10ced22939"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["projectId"],
+          "properties": {
+            "region": {
+              "enum": ["us-west-2", "us-east-1", "eu-central-1", "ap-southeast-1"],
+              "type": "string",
+              "description": "The region where the Session should run"
+            },
+            "proxies": {
+              "type": "boolean",
+              "description": "Proxy configuration. Can be true for default proxy, or an array of proxy configurations"
+            },
+            "timeout": {
+              "type": "integer",
+              "maximum": 21600,
+              "minimum": 60,
+              "description": "Duration in seconds after which the session will automatically end"
+            },
+            "keepAlive": {
+              "type": "boolean",
+              "description": "Set to true to keep the session alive even after disconnections (Startup plan only)"
+            },
+            "projectId": {
+              "type": "string",
+              "description": "The Project ID. Can be found in Settings"
+            },
+            "extensionId": {
+              "type": "string",
+              "description": "The uploaded Extension ID"
+            },
+            "userMetadata": {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "description": "Arbitrary user metadata to attach to the session",
+              "additionalProperties": true
+            },
+            "browserSettings": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "context": {
+                  "type": "object",
+                  "required": ["id"],
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "The Context ID"
+                    },
+                    "persist": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Whether or not to persist the context after browsing"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "blockAds": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Enable or disable ad blocking in the browser"
+                },
+                "viewport": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "width": {
+                      "type": "integer"
+                    },
+                    "height": {
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "logSession": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Enable or disable session logging"
+                },
+                "fingerprint": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "screen": {
+                      "type": "object",
+                      "required": [],
+                      "properties": {
+                        "maxWidth": {
+                          "type": "integer"
+                        },
+                        "minWidth": {
+                          "type": "integer"
+                        },
+                        "maxHeight": {
+                          "type": "integer"
+                        },
+                        "minHeight": {
+                          "type": "integer"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "devices": {
+                      "type": "array",
+                      "items": {
+                        "enum": ["desktop", "mobile"],
+                        "type": "string"
+                      },
+                      "description": "Device types"
+                    },
+                    "browsers": {
+                      "type": "array",
+                      "items": {
+                        "enum": ["chrome", "edge", "firefox", "safari"],
+                        "type": "string"
+                      },
+                      "description": "List of supported browsers"
+                    },
+                    "httpVersion": {
+                      "enum": ["1", "2"],
+                      "type": "string",
+                      "description": "HTTP version"
+                    },
+                    "operatingSystems": {
+                      "type": "array",
+                      "items": {
+                        "enum": ["android", "ios", "linux", "macos", "windows"],
+                        "type": "string"
+                      },
+                      "description": "List of operating systems"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "recordSession": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Enable or disable session recording"
+                },
+                "solveCaptchas": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Enable or disable captcha solving in the browser"
+                },
+                "advancedStealth": {
+                  "type": "boolean",
+                  "description": "Advanced Browser Stealth Mode"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__LIST_SESSIONS",
+    "description": "List all browser sessions for a project. Returns session details including ID, status, resource usage, and metadata.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_SESSIONS",
+      "canonical_tool_description_hash": "c6311a782748ca72ee8e44b8b6f7b7eeaffaf57afa649f20c2b0d24679e6bc14",
+      "canonical_tool_input_schema_hash": "18a1b6474364a9cc3d44dd49532fca37103ab13f2fbfc5664c407549727716ab"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "Query sessions by user metadata. See Querying Sessions by User Metadata for the schema of this query."
+            },
+            "status": {
+              "enum": ["RUNNING", "ERROR", "TIMED_OUT", "COMPLETED"],
+              "type": "string",
+              "description": "Filter sessions by their current status"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__GET_SESSION_RECORDING",
+    "description": "Get the recording of a specific browser session. Returns a list of recorded events in the session with timestamps.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SESSION_RECORDING",
+      "canonical_tool_description_hash": "46fd73b1d366ba593b4fc6fbefaf8d67dde702a4db8ff68eebfc170261187dc7",
+      "canonical_tool_input_schema_hash": "4f14dbdf4288587be005aa815e4facbda0b9e8cf4dce0fa347d43f038de192ce"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the session to retrieve recording for"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__LIST_PROJECTS",
+    "description": "List all available projects associated with your Browserbase account.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_PROJECTS",
+      "canonical_tool_description_hash": "6ca9cd80e2c3962eeaa4cf56ead2a145f64a114e589a20b72955b9a7527fe5a6",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__GET_PROJECT",
+    "description": "Get detailed information about a specific project by its ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PROJECT",
+      "canonical_tool_description_hash": "8932bef47a39e1354b454ae559494d4a24f9fa8f912c06c385d9183e9377f9e4",
+      "canonical_tool_input_schema_hash": "1f5ff354c32f681e027f2fc9ae58e88c797e43dd711e74525591587c875b568d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the project to retrieve"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__GET_PROJECT_USAGE",
+    "description": "Get resource usage statistics for a specific project.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PROJECT_USAGE",
+      "canonical_tool_description_hash": "7504a6bee4bb284fc021c68e47e366ce4bacf574b2e9d4891ec16ff0b38ee81c",
+      "canonical_tool_input_schema_hash": "12c126f3e55fb0a18ed23b3ca361dc747d4b7e1c677016b2828f3de81cbf9ee9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the project to retrieve usage statistics for"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__CREATE_CONTEXT",
+    "description": "Create a new browser context. A browser context is a persistent browser profile that can be reused across multiple sessions.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_CONTEXT",
+      "canonical_tool_description_hash": "f42953e8ea9d9710ccdf6f9e2c9aaa5572ea57fa1ef49758ca40b400850175ed",
+      "canonical_tool_input_schema_hash": "288be245b26eebea1b29698311e1eb897b52444fcab25a3b552d6ebe04ee5e9a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["projectId"],
+          "properties": {
+            "projectId": {
+              "type": "string",
+              "description": "The Project ID. Can be found in Settings"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__GET_CONTEXT",
+    "description": "Get detailed information about a specific browser context by its ID. Returns context metadata including creation date and associated project.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CONTEXT",
+      "canonical_tool_description_hash": "11ecdedef6e5f02f4931160fc385c8fe2a964110033d651b8b27350ac02dabcc",
+      "canonical_tool_input_schema_hash": "a0a5680260c5d000ae4b963c945f64ca62565208dc6e950dc3a45b9f74c45ce2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the context to retrieve"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__UPDATE_CONTEXT",
+    "description": "Update a specific browser context by its ID. Refreshes encryption keys and other security parameters.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_CONTEXT",
+      "canonical_tool_description_hash": "12cf543c559302ccd52aaa573374d7744fd1517cffa4cf4dccfaae23b181cd5f",
+      "canonical_tool_input_schema_hash": "34bb4f216e8c3b60cb4fbc2155e09e2b860905ca1bc34ff7f53d255db0a81e06"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the context to update"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__GET_EXTENSION",
+    "description": "Get detailed information about a specific browser extension by its ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_EXTENSION",
+      "canonical_tool_description_hash": "40a4658fcec371bb870b076da3ca48fcf2be5009022c46c38a3b2e3c0849b56e",
+      "canonical_tool_input_schema_hash": "9d3da41e4afe8705814c90d48d22cf6ed43ec4f874c6a83530b580874858a449"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the extension to retrieve"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "BROWSERBASE__DELETE_EXTENSION",
+    "description": "Delete a specific browser extension by its ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_EXTENSION",
+      "canonical_tool_description_hash": "0fbe74c1829f1d326de6244c1c0e592a3ebbfa10d14f206e02bca0c2043d76a8",
+      "canonical_tool_input_schema_hash": "9a53efb39cf7130d339173e96cd3fbb1083e1ab9d41a6d77e3b4da6f3c6ba433"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique identifier of the extension to delete"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/cal/tools.json
+++ b/backend/mcp_servers/cal/tools.json
@@ -1,0 +1,254 @@
+[
+  {
+    "name": "CAL__GET_SCHEDULES",
+    "description": "Retrieves a list of schedules from the authenticated user in Cal.com",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SCHEDULES",
+      "canonical_tool_description_hash": "e82f9b9667d177430ba5412081d5cf06063a8ee92bf324ba01c28811e33a9f3d",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CAL__CREATE_SCHEDULE",
+    "description": "Create a new schedule in Cal.com",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_SCHEDULE",
+      "canonical_tool_description_hash": "ddf070d463c3a62241be6dbc4dcfd53a9bdac50bdece17ed6991840415953704",
+      "canonical_tool_input_schema_hash": "dfc81ca69d36f3e4411ebc75ada84dfdd3bbb8bb9f1f1033b677ba95cee04027"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name", "timeZone"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the schedule"
+            },
+            "timeZone": {
+              "type": "string",
+              "example": "Asia/Shanghai",
+              "description": "Timezone for the schedule in IANA format"
+            },
+            "isDefault": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether this is the default schedule"
+            },
+            "availability": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "days": {
+                    "type": "array",
+                    "items": {
+                      "enum": [
+                        "Monday",
+                        "Tuesday",
+                        "Wednesday",
+                        "Thursday",
+                        "Friday",
+                        "Saturday",
+                        "Sunday"
+                      ],
+                      "type": "string"
+                    },
+                    "description": "Days of the week for this availability"
+                  },
+                  "endTime": {
+                    "type": "string",
+                    "example": "17:00",
+                    "description": "End time in HH:MM format"
+                  },
+                  "startTime": {
+                    "type": "string",
+                    "example": "09:00",
+                    "description": "Start time in HH:MM format"
+                  }
+                }
+              },
+              "description": "Availability time slots for the schedule"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CAL__GET_SCHEDULE",
+    "description": "Retrieve a specific schedule from Cal.com by ID",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SCHEDULE",
+      "canonical_tool_description_hash": "16123b885d0ef0639e7154b869f63d7be62d7600fd1ebf25691dd6428bde83b5",
+      "canonical_tool_input_schema_hash": "5ecf31574695d04a9b6cbb6934f78311882bf2c31af309eebd9adcf7b808a296"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["schedule_id"],
+          "properties": {
+            "schedule_id": {
+              "type": "string",
+              "example": "660201",
+              "description": "ID of the schedule to retrieve"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CAL__UPDATE_SCHEDULE",
+    "description": "Update an existing schedule in Cal.com",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_SCHEDULE",
+      "canonical_tool_description_hash": "ccfcd0dc2aade78cd03bdf680424b0c5e164bca60689405349af4c5e7f088364",
+      "canonical_tool_input_schema_hash": "2d1462c4b0275817269e5ff6e327315428b208edc9097e35084e07946c5b74e1"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "example": "work time",
+              "description": "Updated name for the schedule"
+            },
+            "timeZone": {
+              "type": "string",
+              "example": "Asia/Shanghai",
+              "description": "Updated timezone in IANA format"
+            },
+            "overrides": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "date": {
+                    "type": "string",
+                    "example": "2024-05-20",
+                    "description": "Date for the override in YYYY-MM-DD format"
+                  },
+                  "endTime": {
+                    "type": "string",
+                    "example": "18:00",
+                    "description": "End time in HH:MM format"
+                  },
+                  "startTime": {
+                    "type": "string",
+                    "example": "10:00",
+                    "description": "Start time in HH:MM format"
+                  }
+                }
+              },
+              "description": "Overrides for specific dates"
+            },
+            "availability": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "days": {
+                    "type": "array",
+                    "items": {
+                      "enum": [
+                        "Monday",
+                        "Tuesday",
+                        "Wednesday",
+                        "Thursday",
+                        "Friday",
+                        "Saturday",
+                        "Sunday"
+                      ],
+                      "type": "string"
+                    },
+                    "description": "Days of the week for this availability"
+                  },
+                  "endTime": {
+                    "type": "string",
+                    "example": "17:00",
+                    "description": "End time in HH:MM format"
+                  },
+                  "startTime": {
+                    "type": "string",
+                    "example": "09:00",
+                    "description": "Start time in HH:MM format"
+                  }
+                }
+              },
+              "description": "Updated availability time slots for the schedule"
+            }
+          },
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["schedule_id"],
+          "properties": {
+            "schedule_id": {
+              "type": "string",
+              "example": "660201",
+              "description": "ID of the schedule to update"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CAL__DELETE_SCHEDULE",
+    "description": "Delete a specific schedule from Cal.com by ID",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_SCHEDULE",
+      "canonical_tool_description_hash": "f03401c02a6ffddac8f15fde87249a4e76a6599cc0aea1b0ff5c41c161259cf0",
+      "canonical_tool_input_schema_hash": "ef620ee89be644e3620b542d6a944a6f2a0a5bea7ead537e43d57c72c398d93e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["schedule_id"],
+          "properties": {
+            "schedule_id": {
+              "type": "string",
+              "example": "660201",
+              "description": "ID of the schedule to delete"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/calendly/tools.json
+++ b/backend/mcp_servers/calendly/tools.json
@@ -1,0 +1,339 @@
+[
+  {
+    "name": "CALENDLY__LIST_SCHEDULED_EVENTS",
+    "description": "List all scheduled events from Calendly",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_SCHEDULED_EVENTS",
+      "canonical_tool_description_hash": "d96f973a697294d12c4c30504ca4aa375573dd1462736ccc94308991ee9573f9",
+      "canonical_tool_input_schema_hash": "2f7d20875c9ac467d8f80f656c322961baa93c55a2b0004eb83cb0c7c3d25382"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["header", "query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "user": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URI of the user to list events for. Format: https://api.calendly.com/users/{uuid}. NOTE: You must provide at least one of: user, organization, or group."
+            },
+            "count": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Number of results per page"
+            },
+            "group": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URI of the group to list events for. Format: https://api.calendly.com/groups/{uuid}. NOTE: You must provide at least one of: user, organization, or group."
+            },
+            "status": {
+              "enum": ["active", "canceled"],
+              "type": "string",
+              "description": "Filter events by status"
+            },
+            "page_token": {
+              "type": "string",
+              "description": "Token to retrieve the next page of results"
+            },
+            "organization": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URI of the organization to list events for. Format: https://api.calendly.com/organizations/{uuid}. NOTE: You must provide at least one of: user, organization, or group."
+            },
+            "max_start_time": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The start time of the last event to return"
+            },
+            "min_start_time": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The start time of the first event to return"
+            }
+          },
+          "description": "URL query parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": ["accept"],
+          "properties": {
+            "accept": {
+              "enum": ["application/json"],
+              "type": "string",
+              "default": "application/json",
+              "description": "Accept content type"
+            }
+          },
+          "description": "HTTP request headers",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CALENDLY__GET_EVENT_DETAILS",
+    "description": "Get details of a specific Calendly event",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_EVENT_DETAILS",
+      "canonical_tool_description_hash": "ab34972d81176859213e0f761ba4e8d3ea72a376092d7041bfd1e36a94ee3649",
+      "canonical_tool_input_schema_hash": "14e36bd8a20e34ddbd136bed4c14d772b6540f56c808a789a73dc587bf02e4af"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["header", "path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["uuid"],
+          "properties": {
+            "uuid": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The UUID of the event to retrieve"
+            }
+          },
+          "description": "URL path parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": ["accept"],
+          "properties": {
+            "accept": {
+              "enum": ["application/json"],
+              "type": "string",
+              "default": "application/json",
+              "description": "Accept content type"
+            }
+          },
+          "description": "HTTP request headers",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CALENDLY__LIST_EVENT_TYPES",
+    "description": "List all event types from Calendly",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_EVENT_TYPES",
+      "canonical_tool_description_hash": "6ddbcd4bfa52a7340916f4f703c19a6a4d1389521682642c6b50a3fcb4581a41",
+      "canonical_tool_input_schema_hash": "5821f8a29170a9ef4a87d51ff8b5fd76feb00def824a52755148da3fec24f98d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["header", "query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "user": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URI of the user to list event types for. Format: https://api.calendly.com/users/{uuid}. NOTE: You must provide at least one of: user, organization, or group."
+            },
+            "count": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Number of results per page"
+            },
+            "group": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URI of the group to list event types for. Format: https://api.calendly.com/groups/{uuid}. NOTE: You must provide at least one of: user, organization, or group."
+            },
+            "status": {
+              "enum": ["active", "inactive"],
+              "type": "string",
+              "description": "Filter event types by status"
+            },
+            "page_token": {
+              "type": "string",
+              "description": "Token to retrieve the next page of results"
+            },
+            "organization": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URI of the organization to list event types for. Format: https://api.calendly.com/organizations/{uuid}. NOTE: You must provide at least one of: user, organization, or group."
+            }
+          },
+          "description": "URL query parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": ["accept"],
+          "properties": {
+            "accept": {
+              "enum": ["application/json"],
+              "type": "string",
+              "default": "application/json",
+              "description": "Accept content type"
+            }
+          },
+          "description": "HTTP request headers",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CALENDLY__LIST_INVITEES",
+    "description": "List all invitees for a specific event",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_INVITEES",
+      "canonical_tool_description_hash": "f04e3e57e7221688ddc9e1c21168c92b40b8dc716b24e7fe9678bf239aedeec3",
+      "canonical_tool_input_schema_hash": "2eb10771f9a4665336b3ae91b76ef30827c8058d5b7e47feb4d3997fdbfe1a5c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["header", "path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["uuid"],
+          "properties": {
+            "uuid": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The UUID of the event to retrieve invitees for"
+            }
+          },
+          "description": "URL path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "count": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Number of results per page"
+            },
+            "status": {
+              "enum": ["active", "canceled"],
+              "type": "string",
+              "description": "Filter invitees by status"
+            },
+            "page_token": {
+              "type": "string",
+              "description": "Token to retrieve the next page of results"
+            }
+          },
+          "description": "URL query parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": ["accept"],
+          "properties": {
+            "accept": {
+              "enum": ["application/json"],
+              "type": "string",
+              "default": "application/json",
+              "description": "Accept content type"
+            }
+          },
+          "description": "HTTP request headers",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CALENDLY__GET_USER_AVAILABILITY",
+    "description": "Get availability information for a specific user",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_USER_AVAILABILITY",
+      "canonical_tool_description_hash": "6d04bdebb90bf0b589d2755fe0cc29e34639979e05252fc41cd27de7485df412",
+      "canonical_tool_input_schema_hash": "12c7649971f39c1d7f937d02e7d0398c2170036f67001cd5b6af7efdf6a30ac4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["header", "query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["user"],
+          "properties": {
+            "user": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URI of the user to get availability for. Format: https://api.calendly.com/users/{uuid}"
+            }
+          },
+          "description": "URL query parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": ["accept"],
+          "properties": {
+            "accept": {
+              "enum": ["application/json"],
+              "type": "string",
+              "default": "application/json",
+              "description": "Accept content type"
+            }
+          },
+          "description": "HTTP request headers",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CALENDLY__GET_CURRENT_USER",
+    "description": "Get basic information about your user account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CURRENT_USER",
+      "canonical_tool_description_hash": "d34bff84c10f170978caf196615e2b539131dfd874ff44f677dc5ff6671a90f7",
+      "canonical_tool_input_schema_hash": "4ae07560c203958b28397aaa0e75396ef7e66392bc030630dc1c04bd3a26588c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["header"],
+      "properties": {
+        "header": {
+          "type": "object",
+          "required": ["accept"],
+          "properties": {
+            "accept": {
+              "enum": ["application/json"],
+              "type": "string",
+              "default": "application/json",
+              "description": "Accept content type"
+            }
+          },
+          "description": "HTTP request headers",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/clickup/tools.json
+++ b/backend/mcp_servers/clickup/tools.json
@@ -1,0 +1,205 @@
+[
+  {
+    "name": "CLICKUP__GET_AUTHORIZED_WORKSPACES",
+    "description": "View the Workspaces available to the authenticated user.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_AUTHORIZED_WORKSPACES",
+      "canonical_tool_description_hash": "983905f5512aa2bf40b95b7917621ed34cf697845fc0acf0f0ff52ae5888ab61",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CLICKUP__DOCS_SEARCH",
+    "description": "View the Docs in your Workspace. You can only view information of Docs you can access.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DOCS_SEARCH",
+      "canonical_tool_description_hash": "b43ac2f948299995dc3aee74293e324fbecf3fa2cd21eaaf337547d9977030ec",
+      "canonical_tool_input_schema_hash": "4279ed4e507e74b16a3bcc6e259618a7ba9c34c072c93b557ff535e02fa5a117"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["workspaceId"],
+          "properties": {
+            "workspaceId": {
+              "type": "string",
+              "description": "The ID of the workspace to search docs in."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Filter results to a single Doc with the given Doc ID."
+            },
+            "limit": {
+              "type": "number",
+              "default": 50,
+              "maximum": 100,
+              "minimum": 10,
+              "description": "The maximum number of results to retrieve for each page."
+            },
+            "creator": {
+              "type": "number",
+              "description": "Filter results to Docs created by the user with the given user ID."
+            },
+            "deleted": {
+              "type": "boolean",
+              "default": false,
+              "description": "Filter results to return deleted Docs."
+            },
+            "archived": {
+              "type": "boolean",
+              "default": false,
+              "description": "Filter results to return archived Docs."
+            },
+            "parent_id": {
+              "type": "string",
+              "description": "Filter results to children of a parent Doc with the given parent Doc ID."
+            },
+            "next_cursor": {
+              "type": "string",
+              "description": "The cursor to use to get the next page of results."
+            },
+            "parent_type": {
+              "type": "string",
+              "description": "Filter results to children of the given parent Doc type. For example, SPACE, FOLDER, LIST, EVERYTHING, WORKSPACE."
+            }
+          },
+          "description": "Query parameters for the request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CLICKUP__GOALS_GET",
+    "description": "View the Goals available in a Workspace.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GOALS_GET",
+      "canonical_tool_description_hash": "79038ef51aa178244960a5d523e8a279769b85b28f9443d8fc1cbc959cde391b",
+      "canonical_tool_input_schema_hash": "6b07f5966be7761aab2b595ff3f74d99b42f0e5d2cc8fdf1380b34782b3507ad"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "Workspace ID"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "include_completed": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether to include completed goals in the results."
+            }
+          },
+          "description": "Query parameters for the request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CLICKUP__WORKSPACE_SEATS_GET",
+    "description": "View the used, total, and available member and guest seats for a Workspace.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "WORKSPACE_SEATS_GET",
+      "canonical_tool_description_hash": "78e48cbeb04773c4f64c999f2500c5d9ecc338b9ab6b9062c3b21856781ca66c",
+      "canonical_tool_input_schema_hash": "24d45a7905c742da2d133db2f7a57947777c72f376f3453b9f71c19457005b25"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "Workspace ID"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CLICKUP__SPACES_GET",
+    "description": "View the Spaces available in a Workspace. You can only get member info in private Spaces.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SPACES_GET",
+      "canonical_tool_description_hash": "7c070c3f87cb8f65b1a93b9c3d6f19e2562f0fe6ccd31037473b7a4496f7fcdc",
+      "canonical_tool_input_schema_hash": "296eb144e546eeaff2dd852a0e49ccbb1c9cf6652b21c70de5aa3d6043602b1e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "Workspace ID"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "archived": {
+              "type": "boolean",
+              "default": false,
+              "description": "Filter results to return archived Spaces."
+            }
+          },
+          "description": "Query parameters for the request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/cloudflare/tools.json
+++ b/backend/mcp_servers/cloudflare/tools.json
@@ -1,0 +1,269 @@
+[
+  {
+    "name": "CLOUDFLARE__GET_ZONE_DETAILS",
+    "description": "Get details about a zone",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ZONE_DETAILS",
+      "canonical_tool_description_hash": "3b14d9b43c14c1d7099f3a888317768257861d1466b11cb1e6884db8b9378cc9",
+      "canonical_tool_input_schema_hash": "b1c3a510621022b78422f468b81829415780c77c2a02e6aa65181f9134b3ea34"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["zone_id"],
+          "properties": {
+            "zone_id": {
+              "type": "string",
+              "description": "The zone ID to get details about"
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CLOUDFLARE__LIST_ZONES",
+    "description": "Lists, searches, sorts, and filters your zones. Listing zones across more than 500 accounts is currently not allowed.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_ZONES",
+      "canonical_tool_description_hash": "3c6815cc268db6488e2145ebacf9c7705c7cdd7608e2cbfecd99d2e9d626dc8f",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CLOUDFLARE__LIST_ZONE_DNS_RECORDS",
+    "description": "List, search, sort, and filter a zones' DNS records.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_ZONE_DNS_RECORDS",
+      "canonical_tool_description_hash": "3be6d4176f2a16ee5887ebcb161c57aa77071eae83afc43ab224c0cc0141fbe2",
+      "canonical_tool_input_schema_hash": "6647fcdbe3477934194df7791e1f5bd7728df63c3f3f8f6ab86b40f210b6f72f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["zone_id"],
+          "properties": {
+            "zone_id": {
+              "type": "string",
+              "description": "The zone ID to get DNS records for"
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CLOUDFLARE__CREATE_ZONE_DNS_RECORD",
+    "description": "Create a new DNS record in a zone",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_ZONE_DNS_RECORD",
+      "canonical_tool_description_hash": "9ef0b01988c59d8b864d5d71c247e4c7d4d97b94ba6acc4d5b9601bfdc322d4c",
+      "canonical_tool_input_schema_hash": "3685429711731e2d0bf688f0a974b286964dcc2f60f0f85165ae4f70eb75e86f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "ttl": {
+              "type": "integer",
+              "default": 1,
+              "description": "Time To Live (TTL) of the DNS record in seconds. Setting to 1 means 'automatic'. Value must be between 60 and 86400, with the minimum reduced to 30 for Enterprise zones."
+            },
+            "name": {
+              "type": "string",
+              "description": "DNS record name (or @ for the zone apex) in Punycode."
+            },
+            "type": {
+              "type": "string",
+              "description": "Record type. A, AAAA, CNAME, MX, TXT, NS, PTR, SRV, SPF, CAA."
+            },
+            "comment": {
+              "type": "string",
+              "description": "Comments or notes about the DNS record. This field has no effect on DNS responses."
+            },
+            "content": {
+              "type": "string",
+              "description": "A valid IPv4/IPv6 address for A/AAAA record or a valid hostname for CNAME record."
+            },
+            "proxied": {
+              "type": "boolean",
+              "description": "Whether the record is receiving the performance and security benefits of Cloudflare."
+            }
+          },
+          "description": "Request body parameters for DNS record creation.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["zone_id"],
+          "properties": {
+            "zone_id": {
+              "type": "string",
+              "description": "The zone ID to create the DNS record for"
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CLOUDFLARE__DELETE_ZONE_DNS_RECORD",
+    "description": "Delete a DNS record in a zone by zone_id and dns_record_id.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_ZONE_DNS_RECORD",
+      "canonical_tool_description_hash": "51a3165e3bd02e217933ec8ab5391b2b456b4eacbe9cc6db6e7a08bd810687b9",
+      "canonical_tool_input_schema_hash": "d23f90f7a1c22eab1860a931be5b81e443432a777b6c712cfdd5b9980f401c4a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["zone_id", "dns_record_id"],
+          "properties": {
+            "zone_id": {
+              "type": "string",
+              "description": "The zone ID to delete the DNS record from."
+            },
+            "dns_record_id": {
+              "type": "string",
+              "description": "The DNS record ID to delete."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CLOUDFLARE__GET_ZONE_DNS_RECORD_DETAILS",
+    "description": "Get details of a DNS record in a zone by zone_id and dns_record_id.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ZONE_DNS_RECORD_DETAILS",
+      "canonical_tool_description_hash": "1e7eedea08df5af96fbf8f70e6c656ae8cd297f59fd5f53dabee387dae665ba8",
+      "canonical_tool_input_schema_hash": "4120bc1a9b091970741145a8fde0bcb6bb391d0fa59ccb5dd45d1ce6f2d5496a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["zone_id", "dns_record_id"],
+          "properties": {
+            "zone_id": {
+              "type": "string",
+              "description": "The zone ID to get the DNS record details from."
+            },
+            "dns_record_id": {
+              "type": "string",
+              "description": "The DNS record ID to get details for."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CLOUDFLARE__UPDATE_ZONE_DNS_RECORD",
+    "description": "Update an existing DNS record in a zone by zone_id and dns_record_id.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_ZONE_DNS_RECORD",
+      "canonical_tool_description_hash": "0d2d06c6f9865cfe515f964270a688fd5bc2925593838fa9f8fd64ce44ad3fc5",
+      "canonical_tool_input_schema_hash": "9689f04fc23715a2fccc54190652aedf740c868d426b3abb11825cc9d9bffde8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "ttl": {
+              "type": "integer",
+              "description": "Time To Live (TTL) of the DNS record in seconds. Setting to 1 means 'automatic'. Value must be between 60 and 86400, with the minimum reduced to 30 for Enterprise zones."
+            },
+            "name": {
+              "type": "string",
+              "description": "DNS record name (or @ for the zone apex) in Punycode."
+            },
+            "type": {
+              "type": "string",
+              "description": "Record type. A, AAAA, CNAME, MX, TXT, NS, PTR, SRV, SPF, CAA."
+            },
+            "comment": {
+              "type": "string",
+              "description": "Comments or notes about the DNS record. This field has no effect on DNS responses."
+            },
+            "content": {
+              "type": "string",
+              "description": "A valid IPv4/IPv6 address for A/AAAA record or a valid hostname for CNAME record."
+            },
+            "proxied": {
+              "type": "boolean",
+              "description": "Whether the record is receiving the performance and security benefits of Cloudflare."
+            }
+          },
+          "description": "Request body parameters for DNS record update.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["zone_id", "dns_record_id"],
+          "properties": {
+            "zone_id": {
+              "type": "string",
+              "description": "The zone ID to update the DNS record in."
+            },
+            "dns_record_id": {
+              "type": "string",
+              "description": "The DNS record ID to update."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/coda/tools.json
+++ b/backend/mcp_servers/coda/tools.json
@@ -1,0 +1,228 @@
+[
+  {
+    "name": "CODA__LIST_DOCS",
+    "description": "Retrieves a list of all accessible Coda documents. Supports pagination via 'limit' and 'pageToken' parameters. Returns metadata for each document, including ID, name, and creation timestamps.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_DOCS",
+      "canonical_tool_description_hash": "e6151e73c08b623667faf05bb49c40529e8ad18c5b8a37bfa687be0c1e6ff549",
+      "canonical_tool_input_schema_hash": "39e81e66c0ae25ea746eb14e24d1a7f1c390071d8958829404ae1e4bebf24113"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of docs to return. Default is 100; maximum is 100."
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Token to retrieve the next page of results."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CODA__LIST_TABLES",
+    "description": "Retrieves a list of tables within a specified Coda document. Supports pagination through 'limit' and 'pageToken' parameters. Returns metadata for each table, including ID, name, and creation timestamps.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_TABLES",
+      "canonical_tool_description_hash": "1cff1c4eb880f486818d786da6ee7986db60bd306ee4f5fa5f71a2d0e68c3fdf",
+      "canonical_tool_input_schema_hash": "4a949fc3454f5e1db725e6944edeb8ac90ccd1902d68c8f108aa28a3c72881ad"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["doc_id"],
+          "properties": {
+            "doc_id": {
+              "type": "string",
+              "description": "The ID of the document containing the tables."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of tables to return. Default is 100; maximum is 100."
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Token to retrieve the next page of results."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CODA__LIST_ROWS",
+    "description": "Retrieves a list of rows from a specified table within a Coda document. Supports pagination and filtering through query parameters. Returns metadata for each row, including ID and values for each column.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_ROWS",
+      "canonical_tool_description_hash": "fbc02391192952f23099d7de6b25fd750d66d53e1df98b10d409e34faff94ea9",
+      "canonical_tool_input_schema_hash": "856e4286e0150a6c0e291b824788e5c8765c796eb02eb601142900e9d3bae05b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["doc_id", "table_id"],
+          "properties": {
+            "doc_id": {
+              "type": "string",
+              "description": "The ID of the document containing the table."
+            },
+            "table_id": {
+              "type": "string",
+              "description": "The ID of the table from which to retrieve rows."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of rows to return. Default is 100; maximum is 100."
+            },
+            "query": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "additionalProp1": {
+                  "type": "string",
+                  "description": "Filter property name and value"
+                }
+              },
+              "description": "Filters to apply when retrieving rows. For example: {\"Column Name\": \"Value\"}. Note: Only one filter can be applied at a time.",
+              "additionalProperties": true
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Token to retrieve the next page of results."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CODA__GET_ROW",
+    "description": "Retrieves a specific row from a table within a Coda document using the row ID. Returns the values of all columns for the specified row.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ROW",
+      "canonical_tool_description_hash": "23ad9b1710b94fdee0ee000357cb97c6b7cf81a154877b27cb6f1c78fb5e5d0d",
+      "canonical_tool_input_schema_hash": "37b91b3c3db747a657555c38dc228c6d37ca5c450ed3d54638603561e0605378"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["doc_id", "table_id", "row_id"],
+          "properties": {
+            "doc_id": {
+              "type": "string",
+              "description": "The ID of the document containing the table."
+            },
+            "row_id": {
+              "type": "string",
+              "description": "The ID of the row to retrieve."
+            },
+            "table_id": {
+              "type": "string",
+              "description": "The ID of the table containing the row."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "valueFormat": {
+              "enum": ["user", "rich"],
+              "type": "string",
+              "description": "The format in which to return cell values. Options are 'user' (default) or 'rich'. 'user' returns plain text values, while 'rich' includes rich text formatting and links."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "CODA__DELETE_ROW",
+    "description": "Deletes a specific row from a table within a Coda document using the row ID. This operation is irreversible and permanently removes the row from the table.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_ROW",
+      "canonical_tool_description_hash": "28c1ecbb39405f65ec0046aae851b4468a51f024473c2e20f96259b4798764fe",
+      "canonical_tool_input_schema_hash": "949e817783b46e341f6ff2a8679f456de30ca0e5271b75510ebaa1b777bd0f2e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["doc_id", "table_id", "row_id"],
+          "properties": {
+            "doc_id": {
+              "type": "string",
+              "description": "The ID of the document containing the table."
+            },
+            "row_id": {
+              "type": "string",
+              "description": "The ID of the row to delete."
+            },
+            "table_id": {
+              "type": "string",
+              "description": "The ID of the table containing the row."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/cognito_forms/tools.json
+++ b/backend/mcp_servers/cognito_forms/tools.json
@@ -1,0 +1,211 @@
+[
+  {
+    "name": "COGNITO_FORMS__GET_FORMS",
+    "description": "Retrieves a list of all forms within the authenticated organization.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_FORMS",
+      "canonical_tool_description_hash": "3f0f88488f84f502e79aad5981012ab9e8161dddee41a670e2de29de9aedf878",
+      "canonical_tool_input_schema_hash": "60f335ed0adf5e1bff2cc9243d1cd1a913110830bac579eaea4c36c9a352be5a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "top": {
+              "type": "integer",
+              "description": "Maximum number of forms to return."
+            },
+            "skip": {
+              "type": "integer",
+              "description": "Number of forms to skip before starting to collect the result set."
+            },
+            "filter": {
+              "type": "string",
+              "description": "OData-style filter expression to filter forms."
+            },
+            "orderby": {
+              "type": "string",
+              "description": "OData-style order expression to sort forms."
+            }
+          },
+          "description": "Query parameters for filtering, sorting, and pagination.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COGNITO_FORMS__POST_FORM_ENTRIES",
+    "description": "Creates a new entry for the specified form. The entry fields must match the form's expected structure.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "POST_FORM_ENTRIES",
+      "canonical_tool_description_hash": "69dafdd751aa1ad5ebc52642e75cb63a71896b6afffa79967773e257628b31bf",
+      "canonical_tool_input_schema_hash": "afff52bc870dcfe79c9ae3a96ffa43d2e4227d3322a5ecab59263390bc97b4f3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "Name": {
+              "type": "string",
+              "description": "Example form field: Name of the person."
+            },
+            "Email": {
+              "type": "string",
+              "description": "Example form field: Email address."
+            },
+            "Phone": {
+              "type": "string",
+              "description": "Example form field: Contact number."
+            }
+          },
+          "description": "The entry data to be submitted. Field names must match those defined in the form.",
+          "additionalProperties": true
+        },
+        "path": {
+          "type": "object",
+          "required": ["formId"],
+          "properties": {
+            "formId": {
+              "type": "string",
+              "description": "The ID of the form to which the entry will be submitted."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COGNITO_FORMS__GET_FORM_ENTRY",
+    "description": "Retrieves a single entry by its ID for a given form.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_FORM_ENTRY",
+      "canonical_tool_description_hash": "4901c80bfece262d255137f9e91a7acf9dd07f585ba2bdf303e06d8b9117bb46",
+      "canonical_tool_input_schema_hash": "855692a994ab73f93c4320081d1d77574efae5a25bcb59a7f41cade0e3d2fa09"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["formId", "entryId"],
+          "properties": {
+            "formId": {
+              "type": "string",
+              "description": "The ID of the form containing the entry."
+            },
+            "entryId": {
+              "type": "string",
+              "description": "The ID of the entry to retrieve."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COGNITO_FORMS__DELETE_FORM_ENTRY",
+    "description": "Deletes a specific entry by its ID from the given form.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_FORM_ENTRY",
+      "canonical_tool_description_hash": "bb0d89caccdb21d3fcafe3da01b4f9b4b3e72189e81d4c78be2b8a2db4dfbf33",
+      "canonical_tool_input_schema_hash": "144398a65bf5148fb5161bd689b4d05319c06996426179349caa05ca1f8b02e9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["formId", "entryId"],
+          "properties": {
+            "formId": {
+              "type": "string",
+              "description": "The ID of the form."
+            },
+            "entryId": {
+              "type": "string",
+              "description": "The ID of the entry to delete."
+            }
+          },
+          "description": "Path parameters for identifying the form and entry.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COGNITO_FORMS__PATCH_FORM_ENTRY",
+    "description": "Updates an existing entry by its ID for a given form. Only the specified fields in the request body will be updated.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PATCH_FORM_ENTRY",
+      "canonical_tool_description_hash": "f8b1841d473d7ed915e68737cd6fdbc423df6bed8d389b458ac26e5fcadcab37",
+      "canonical_tool_input_schema_hash": "bb263dce753c2cc60ea05f47f5ee4ed4d80addaf1dcfd642d4a180723a7df99e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "Name": {
+              "type": "string",
+              "description": "Updated name of the person."
+            },
+            "Email": {
+              "type": "string",
+              "description": "Updated email address."
+            },
+            "Phone": {
+              "type": "string",
+              "description": "Updated contact number."
+            }
+          },
+          "description": "The entry data to be updated. Only include the fields that need to be updated.",
+          "additionalProperties": true
+        },
+        "path": {
+          "type": "object",
+          "required": ["formId", "entryId"],
+          "properties": {
+            "formId": {
+              "type": "string",
+              "description": "The ID of the form containing the entry."
+            },
+            "entryId": {
+              "type": "string",
+              "description": "The ID of the entry to update."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/coinmarketcap/tools.json
+++ b/backend/mcp_servers/coinmarketcap/tools.json
@@ -1,0 +1,2504 @@
+[
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_LISTINGS_LATEST",
+    "description": "CoinMarketCap Listings Latest API returns a paginated list of all active cryptocurrencies with the latest market data. The default sort by 'market_cap' returns cryptocurrencies in order of CoinMarketCap's market cap rank, but you may configure sorting by other market ranking fields. Use the 'convert' option to return market values in multiple fiat and cryptocurrency conversions in the same call.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_LISTINGS_LATEST",
+      "canonical_tool_description_hash": "5c8da769b72ef862239e1817204aaa935c852e3ab5409e6d75416fec174b5247",
+      "canonical_tool_input_schema_hash": "8c83cc0a8333de35cf107eae9e023c386a54bc40bfe116bbe4fccd3d61911319"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "num_market_pairs,cmc_rank,date_added,tags,platform,max_supply,circulating_supply,total_supply",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return."
+            },
+            "tag": {
+              "enum": ["all", "defi", "filesharing"],
+              "type": "string",
+              "default": "all",
+              "description": "The tag of cryptocurrency to include."
+            },
+            "sort": {
+              "enum": [
+                "market_cap",
+                "name",
+                "symbol",
+                "date_added",
+                "market_cap_strict",
+                "price",
+                "circulating_supply",
+                "total_supply",
+                "max_supply",
+                "num_market_pairs",
+                "volume_24h",
+                "percent_change_1h",
+                "percent_change_24h",
+                "percent_change_7d",
+                "market_cap_by_total_supply_strict",
+                "volume_7d",
+                "volume_30d"
+              ],
+              "type": "string",
+              "default": "market_cap",
+              "description": "What field to sort the list of cryptocurrencies by."
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Range: 1 to 5000."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies at once by passing a comma-separated list of cryptocurrency or fiat currency symbols. Basic tier users are limited to 1 convert options."
+            },
+            "sort_dir": {
+              "enum": ["asc", "desc"],
+              "type": "string",
+              "description": "The direction in which to order cryptocurrencies against the specified sort."
+            },
+            "price_max": {
+              "type": "number",
+              "description": "Optionally specify a threshold of maximum USD price to filter results by."
+            },
+            "price_min": {
+              "type": "number",
+              "description": "Optionally specify a threshold of minimum USD price to filter results by."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. This parameter cannot be used when convert is used. Basic tier users are limited to 1 convert options."
+            },
+            "market_cap_max": {
+              "type": "number",
+              "description": "Optionally specify a threshold of maximum market cap to filter results by."
+            },
+            "market_cap_min": {
+              "type": "number",
+              "description": "Optionally specify a threshold of minimum market cap to filter results by."
+            },
+            "volume_24h_max": {
+              "type": "number",
+              "description": "Optionally specify a threshold of maximum 24 hour USD volume to filter results by."
+            },
+            "volume_24h_min": {
+              "type": "number",
+              "description": "Optionally specify a threshold of minimum 24 hour USD volume to filter results by."
+            },
+            "cryptocurrency_type": {
+              "enum": ["all", "coins", "tokens"],
+              "type": "string",
+              "default": "all",
+              "description": "The type of cryptocurrency to include."
+            },
+            "circulating_supply_max": {
+              "type": "number",
+              "description": "Optionally specify a threshold of maximum circulating supply to filter results by."
+            },
+            "circulating_supply_min": {
+              "type": "number",
+              "description": "Optionally specify a threshold of minimum circulating supply to filter results by."
+            },
+            "percent_change_24h_max": {
+              "type": "number",
+              "minimum": -100,
+              "description": "Optionally specify a threshold of maximum 24 hour percent change to filter results by."
+            },
+            "percent_change_24h_min": {
+              "type": "number",
+              "minimum": -100,
+              "description": "Optionally specify a threshold of minimum 24 hour percent change to filter results by."
+            },
+            "unlocked_market_cap_max": {
+              "type": "number",
+              "description": "Optionally specify a threshold of maximum unlocked market cap to filter results by."
+            },
+            "unlocked_market_cap_min": {
+              "type": "number",
+              "description": "Optionally specify a threshold of minimum unlocked market cap to filter results by."
+            },
+            "self_reported_market_cap_max": {
+              "type": "number",
+              "description": "Optionally specify a threshold of maximum self reported market cap to filter results by."
+            },
+            "self_reported_market_cap_min": {
+              "type": "number",
+              "description": "Optionally specify a threshold of minimum self reported market cap to filter results by."
+            },
+            "unlocked_circulating_supply_max": {
+              "type": "number",
+              "description": "Optionally specify a threshold of maximum unlocked circulating supply to filter results by."
+            },
+            "unlocked_circulating_supply_min": {
+              "type": "number",
+              "description": "Optionally specify a threshold of minimum unlocked circulating supply to filter results by."
+            },
+            "self_reported_circulating_supply_max": {
+              "type": "number",
+              "description": "Optionally specify a threshold of maximum self reported circulating supply to filter results by."
+            },
+            "self_reported_circulating_supply_min": {
+              "type": "number",
+              "description": "Optionally specify a threshold of minimum self reported circulating supply to filter results by."
+            }
+          },
+          "description": "Query parameters for retrieving the latest cryptocurrency listings with market data.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CMC_CRYPTO_FEAR_GREED_LATEST",
+    "description": "Returns the latest CMC Crypto Fear and Greed Index value along with its classification. This endpoint is updated every 15 minutes and is available on the Basic, Startup, Hobbyist, Standard, Professional, and Enterprise plans. Data provided by CoinMarketCap.com. Your product must display the attribution 'Data provided by CoinMarketCap.com' with a hyperlink to https://coinmarketcap.com.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CMC_CRYPTO_FEAR_GREED_LATEST",
+      "canonical_tool_description_hash": "32d2e7ab95f4ee5a647c71fd645826f8c06a7116c81fa28eb8817496a0da5f9b",
+      "canonical_tool_input_schema_hash": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    },
+    "input_schema": {}
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_AIRDROP",
+    "description": "CoinMarketCap Airdrop API returns information about a single airdrop, including cryptocurrency metadata.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_AIRDROP",
+      "canonical_tool_description_hash": "363fff09f58d78924beb60a28469d65abb9feac5d9dea4118781a175458d7a81",
+      "canonical_tool_input_schema_hash": "714dc670d1fa88c23e06a12243af35cef3088193cd23c938d31cf77e2c81b79d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Airdrop Unique ID. This can be found using the Airdrops API."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_AIRDROPS",
+    "description": "CoinMarketCap Airdrops API returns a list of past, present, or future airdrops available on CoinMarketCap.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_AIRDROPS",
+      "canonical_tool_description_hash": "4a02fa4abaded1a8254c1c64cd824eb4ffe12bb7285f0b4645a60fc87deda5bc",
+      "canonical_tool_input_schema_hash": "e4cc232e623f65bb3d881e662903f6743a1c01f8a99f05d58ea488aececc4c41"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Filter airdrops by one cryptocurrency CoinMarketCap ID. Example: '1'."
+            },
+            "slug": {
+              "type": "string",
+              "description": "Alternatively filter airdrops by a cryptocurrency slug. Example: 'bitcoin'."
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Range: 1 to 5000."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "status": {
+              "enum": ["ONGOING", "ENDED", "UPCOMING"],
+              "type": "string",
+              "description": "Filter airdrops by their status: ONGOING, ENDED, or UPCOMING."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Alternatively filter airdrops by a cryptocurrency symbol. Example: 'BTC'."
+            }
+          },
+          "description": "Query parameters for retrieving airdrops.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_CATEGORIES",
+    "description": "Retrieve information about all coin categories available on CoinMarketCap, including a paginated list of cryptocurrency quotes and metadata for each category.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_CATEGORIES",
+      "canonical_tool_description_hash": "feb130cdb9f26733063de689d6f6c3e1afe25718302f766ee54762a748efae8f",
+      "canonical_tool_input_schema_hash": "1747551baf91f06240fa7303a796612113e616c979073749eafea63b680205df"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Filter categories by one or more comma-separated cryptocurrency CoinMarketCap IDs. Example: 1,2"
+            },
+            "slug": {
+              "type": "string",
+              "description": "Filter categories by a comma-separated list of cryptocurrency slugs. Example: bitcoin,ethereum"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "The number of results to return. Use this with the 'start' parameter to paginate."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Filter categories by one or more comma-separated cryptocurrency symbols. Example: BTC,ETH"
+            }
+          },
+          "description": "Query parameters for retrieving cryptocurrency categories.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_CATEGORY",
+    "description": "Returns information about a single coin category available on CoinMarketCap, including a paginated list of the cryptocurrency quotes and detailed metadata for the specified category. This endpoint is available on the Free, Hobbyist, Startup, Standard, Professional, and Enterprise plans, and data is updated only as needed (approximately every 30 seconds). The endpoint uses call credits calculated as 1 API call per request plus additional credits based on the number of cryptocurrencies returned and convert options used.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_CATEGORY",
+      "canonical_tool_description_hash": "adb2a83d2e60197788bcf234a00fab152386c1d41629c9a734566d4be496ceed",
+      "canonical_tool_input_schema_hash": "33702dce79075c3e8ceecc4815a026bf95e00b21116516011a0b48273606bda0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique Category ID. This parameter is required and identifies the coin category. The ID can be obtained using the Categories API. (COINMARKETCAP__CRYPTOCURRENCY_CATEGORIES)"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Optionally specify the number of coins to return for the category. Acceptable values range from 1 to 1000. Use this parameter together with 'start' to control pagination size. Default is 100."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of coins returned within the category. Must be an integer greater than or equal to 1. Default is 1."
+            },
+            "convert": {
+              "type": "string",
+              "default": "USD",
+              "description": "Optionally calculate market quotes in up to 120 currencies by passing a comma-separated list of cryptocurrency or fiat currency symbols. Each additional convert option beyond the first may require additional call credits. Defaults to 'USD' if not specified."
+            }
+          },
+          "description": "Query parameters for retrieving a single coin category. This includes the mandatory Category ID (retrieved via the Categories API) and optional pagination and conversion parameters.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_ID_MAP",
+    "description": "Returns a mapping of all cryptocurrencies to unique CoinMarketCap IDs. This endpoint provides each cryptocurrency's standard identifiers\u2014such as name, symbol, and token_address\u2014for secure identification in your application. By default, it returns cryptocurrencies with actively tracked markets on supported exchanges. You can also retrieve inactive cryptocurrencies by passing listing_status=inactive or registered but untracked cryptocurrencies by passing listing_status=untracked (multiple comma-separated values are allowed). Additional auxiliary fields (such as platform, first_historical_data, last_historical_data, and is_active) can be included via the aux parameter to slim down the payload or provide extra details. Mapping data is updated as needed (approximately every 30 seconds) and this endpoint is available on Basic, Hobbyist, Startup, Standard, Professional, and Enterprise plans. It consumes 1 API call credit per request regardless of query size.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_ID_MAP",
+      "canonical_tool_description_hash": "9a98c6f29ba3d0863115a32d80356390b7bf8fbb65624ac5b9ca037201266a99",
+      "canonical_tool_input_schema_hash": "7a51cf0324379e4ed151f9d4c2919225bdaa58817da670d48da057f0cf7a1b47"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "platform,first_historical_data,last_historical_data,is_active",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return with each cryptocurrency. By default, the response includes 'platform,first_historical_data,last_historical_data,is_active'. To include all available auxiliary fields, you can pass: 'platform,first_historical_data,last_historical_data,is_active,status'."
+            },
+            "sort": {
+              "enum": ["id", "cmc_rank"],
+              "type": "string",
+              "default": "id",
+              "description": "Determines the field by which to sort the list of cryptocurrencies. Acceptable values are 'id' or 'cmc_rank'. Default is 'id'."
+            },
+            "limit": {
+              "type": "integer",
+              "default": 5000,
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Acceptable values range from 1 to 5000. Use this parameter together with 'start' to control the pagination size."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start of the paginated list of items to return. This is a 1-based index and must be an integer greater than or equal to 1. Default is 1."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Optionally pass a comma-separated list of cryptocurrency symbols to specifically return CoinMarketCap IDs for. If this option is provided, all other query parameters (listing_status, start, limit, sort, aux) will be ignored."
+            },
+            "listing_status": {
+              "type": "string",
+              "default": "active",
+              "description": "Determines which cryptocurrencies are returned based on their market activity. By default, 'active' is used to return only cryptocurrencies with actively tracked markets. Pass 'inactive' to retrieve cryptocurrencies that are no longer active, or 'untracked' to get those listed but not meeting the methodology requirements for tracked markets. Multiple comma-separated values are allowed."
+            }
+          },
+          "description": "Query parameters for retrieving a mapping of all cryptocurrencies to their unique CoinMarketCap IDs. By default, only active cryptocurrencies (with tracked markets) are returned. You can modify this behavior with the listing_status parameter. Other parameters allow you to paginate the results, sort them by a specific field, filter by cryptocurrency symbols (which will override other query options), and select additional auxiliary fields to be returned.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_METADATA_V2",
+    "description": "Returns all static metadata available for one or more cryptocurrencies. This endpoint provides detailed information such as the cryptocurrency logo, description, official website URL, social links, and links to technical documentation. Identification can be performed using one or more of the following: CoinMarketCap IDs, slugs, symbols, or a contract address. At least one identifier (id, slug, symbol, or address) is required. Note that when requesting by symbol (which is not unique), the response will include an array of objects for each symbol. The skip_invalid flag allows the request to bypass validation errors for invalid cryptocurrencies, and the aux parameter can be used to limit or expand the supplemental data fields returned. This endpoint is available on Basic, Startup, Hobbyist, Standard, Professional, and Enterprise plans. Static data is updated as needed (approximately every 30 seconds), and plan credit use is 1 call credit per 100 cryptocurrencies returned (rounded up).",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_METADATA_V2",
+      "canonical_tool_description_hash": "0b6d78fd615f476daf38965e54f7b8b6b16651606378b563d4f4288279d7ffae",
+      "canonical_tool_input_schema_hash": "9b8d7b04ba81699a05e96b055d79ee8df73f9d94d0b53c5650fd1fbc0c93b07e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated CoinMarketCap cryptocurrency IDs. Example: '1,2'. These IDs uniquely identify cryptocurrencies in the CoinMarketCap database."
+            },
+            "aux": {
+              "type": "string",
+              "default": "urls,logo,description,tags,platform,date_added,notice",
+              "description": "A comma-separated list of supplemental data fields to include in the response. The default is 'urls,logo,description,tags,platform,date_added,notice'. To include all auxiliary fields, you can pass 'urls,logo,description,tags,platform,date_added,notice,status'."
+            },
+            "slug": {
+              "type": "string",
+              "description": "A comma-separated list of cryptocurrency slugs. Slugs are web-friendly versions of cryptocurrency names. Example: 'bitcoin,ethereum'."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "One or more comma-separated cryptocurrency symbols (ticker symbols). Example: 'BTC,ETH'. When requested by symbol, the response will include an array of objects since symbols are not unique."
+            },
+            "address": {
+              "type": "string",
+              "description": "A contract address for a cryptocurrency token. Example: '0xc40af1e4fecfa05ce6bab79dcd8b373d2e436c4e'. Use this parameter when you want to retrieve metadata for a token deployed on a specific blockchain."
+            },
+            "skip_invalid": {
+              "type": "boolean",
+              "default": false,
+              "description": "Set to true to relax request validation rules. When true, invalid cryptocurrency identifiers will be skipped rather than causing an error, allowing valid records to be returned. Default is false."
+            }
+          },
+          "description": "Query parameters for retrieving static metadata for one or more cryptocurrencies. At least one identifier is required to specify which cryptocurrencies to retrieve. Use the 'id' for unique CoinMarketCap IDs, 'slug' for URL-friendly names, 'symbol' for ticker symbols (note: this may return multiple entries per symbol), or 'address' for a contract address. The skip_invalid flag relaxes validation errors for invalid identifiers, and the aux parameter controls which supplemental fields are included in the response.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_LISTINGS_HISTORICAL",
+    "description": "CoinMarketCap Cryptocurrency Listings Historical API returns a ranked and sorted list of all cryptocurrencies for a historical UTC date. Daily snapshots reflect market data at the end of each UTC day.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_LISTINGS_HISTORICAL",
+      "canonical_tool_description_hash": "374febee966318be7f693f7ed86315dd960a037f2598f534b7e83fc1d371df81",
+      "canonical_tool_input_schema_hash": "417ce3af56f13e71706a5feccb30cc4a52e0ef717958b073396f851ae6d1c1f2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["date"],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "platform,tags,date_added,circulating_supply,total_supply,max_supply,cmc_rank,num_market_pairs",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return."
+            },
+            "date": {
+              "type": "string",
+              "description": "Date (Unix timestamp or ISO 8601) to reference day of snapshot. Recommended format: 'YYYY-MM-DD'."
+            },
+            "sort": {
+              "enum": [
+                "cmc_rank",
+                "name",
+                "symbol",
+                "market_cap",
+                "price",
+                "circulating_supply",
+                "total_supply",
+                "max_supply",
+                "num_market_pairs",
+                "volume_24h",
+                "percent_change_1h",
+                "percent_change_24h",
+                "percent_change_7d"
+              ],
+              "type": "string",
+              "default": "cmc_rank",
+              "description": "Field to sort the list of cryptocurrencies by."
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Range: 1 to 5000."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies by passing a comma-separated list of currency symbols."
+            },
+            "sort_dir": {
+              "enum": ["asc", "desc"],
+              "type": "string",
+              "default": "asc",
+              "description": "The direction in which to order cryptocurrencies against the specified sort."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol."
+            },
+            "cryptocurrency_type": {
+              "enum": ["all", "coins", "tokens"],
+              "type": "string",
+              "default": "all",
+              "description": "The type of cryptocurrency to include."
+            }
+          },
+          "description": "Query parameters for retrieving historical cryptocurrency listings.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_LISTINGS_NEW",
+    "description": "CoinMarketCap Cryptocurrency Listings New API returns a paginated list of the most recently added cryptocurrencies.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_LISTINGS_NEW",
+      "canonical_tool_description_hash": "6f487ebddccb5c58c3fba07118007f10954ba283da7c24e40c81b0a75bf749f1",
+      "canonical_tool_input_schema_hash": "c49abe6d31aff82c5b4152465a67ded29c7aaaf9f7ad978b01f8897e9d6e3c04"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Range: 1 to 5000."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies at once by passing a comma-separated list of cryptocurrency or fiat currency symbols."
+            },
+            "sort_dir": {
+              "enum": ["asc", "desc"],
+              "type": "string",
+              "default": "asc",
+              "description": "The direction in which to order cryptocurrencies against the specified sort."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol."
+            }
+          },
+          "description": "Query parameters for retrieving recently added cryptocurrencies.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_TRENDING_GAINERS_LOSERS",
+    "description": "CoinMarketCap Cryptocurrency Trending Gainers & Losers API returns a paginated list of trending cryptocurrencies sorted by the largest price gains or losses.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_TRENDING_GAINERS_LOSERS",
+      "canonical_tool_description_hash": "f8e06888ba1f3c61869fc854ae1cc69ebcd7b5c162810ab0ab78ada4ad489f25",
+      "canonical_tool_input_schema_hash": "95f7d179ddfc6e206cf8c2b0860540fe313a90cb5b3d3a7994a6e42deaa5951a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "sort": {
+              "enum": ["percent_change_24h"],
+              "type": "string",
+              "default": "percent_change_24h",
+              "description": "What field to sort the list of cryptocurrencies by."
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Range: 1 to 1000."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies at once by passing a comma-separated list of cryptocurrency or fiat currency symbols."
+            },
+            "sort_dir": {
+              "enum": ["asc", "desc"],
+              "type": "string",
+              "default": "asc",
+              "description": "The direction in which to order cryptocurrencies against the specified sort."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol."
+            },
+            "time_period": {
+              "enum": ["1h", "24h", "7d", "30d"],
+              "type": "string",
+              "default": "24h",
+              "description": "Adjusts the overall window of time for the biggest gainers and losers."
+            }
+          },
+          "description": "Query parameters for retrieving trending gainers & losers cryptocurrencies.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_TRENDING_LATEST",
+    "description": "CoinMarketCap Cryptocurrency Trending Latest API returns a paginated list of all trending cryptocurrency market data, determined and sorted by CoinMarketCap search volume.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_TRENDING_LATEST",
+      "canonical_tool_description_hash": "c56d97ada828bb02ac74d039ac2f370e313b13e49f21f7666fa67fe1bf2e710e",
+      "canonical_tool_input_schema_hash": "d486510687d6753fcaa9152a805ce2dcc132b70567b41b635830d868f3875d66"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Range: 1 to 1000."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies by passing a comma-separated list of cryptocurrency or fiat currency symbols."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol."
+            },
+            "time_period": {
+              "enum": ["24h", "30d", "7d"],
+              "type": "string",
+              "default": "24h",
+              "description": "Adjusts the overall window of time for the latest trending coins."
+            }
+          },
+          "description": "Query parameters for retrieving trending cryptocurrency market data sorted by search volume.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_TRENDING_MOST_VISITED",
+    "description": "CoinMarketCap Cryptocurrency Trending Most Visited API returns a paginated list of all trending cryptocurrency market data, determined and sorted by traffic to coin detail pages.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_TRENDING_MOST_VISITED",
+      "canonical_tool_description_hash": "8ea98d7c6966933cec17b3a6e544b1c83c0c6cac23ce45384d5e32c6aa7c11f5",
+      "canonical_tool_input_schema_hash": "fa4a500dbbc5c4ce8e192c8a91883bd4a19979b26698c269213e0154d567b19c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Range: 1 to 1000."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies by passing a comma-separated list of cryptocurrency or fiat currency symbols."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol."
+            },
+            "time_period": {
+              "enum": ["24h", "30d", "7d"],
+              "type": "string",
+              "default": "24h",
+              "description": "Adjusts the overall window of time for most visited currencies."
+            }
+          },
+          "description": "Query parameters for retrieving the most visited trending cryptocurrencies.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_MARKET_PAIRS_LATEST",
+    "description": "CoinMarketCap Market Pairs Latest v2 API lists all active market pairs that CoinMarketCap tracks for a given cryptocurrency or fiat currency. It returns the latest price and volume information for each market pair.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_MARKET_PAIRS_LATEST",
+      "canonical_tool_description_hash": "ea02872f8762518647925d25dd228205f86464c84f592ce1fce40a399d78e1f1",
+      "canonical_tool_input_schema_hash": "c99a91a9e1bea87c524b8c4111fc011afbe8266b395ada5ea3f0fd4883b394e9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "A cryptocurrency or fiat currency by CoinMarketCap ID to list market pairs for. Example: \"1\"."
+            },
+            "aux": {
+              "type": "string",
+              "default": "num_market_pairs,category,fee_type",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. For minimal auxiliary fields, use \"num_market_pairs,category,fee_type\"."
+            },
+            "slug": {
+              "type": "string",
+              "description": "Alternatively pass a cryptocurrency by slug. Example: \"bitcoin\"."
+            },
+            "sort": {
+              "enum": [
+                "volume_24h_strict",
+                "cmc_rank",
+                "cmc_rank_advanced",
+                "effective_liquidity",
+                "market_score",
+                "market_reputation"
+              ],
+              "type": "string",
+              "default": "volume_24h_strict",
+              "description": "Optionally specify the sort order of markets returned. By default a strict sort on 24-hour reported volume is applied."
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Range: 1 to 5000."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Alternatively pass a cryptocurrency by symbol. Fiat currencies are not supported by this field. Example: \"BTC\"."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies at once by passing a comma-separated list of cryptocurrency or fiat currency symbols."
+            },
+            "category": {
+              "enum": ["all", "spot", "derivatives", "otc", "perpetual"],
+              "type": "string",
+              "default": "all",
+              "description": "The category of trading this market falls under."
+            },
+            "fee_type": {
+              "enum": ["all", "percentage", "no-fees", "transactional-mining", "unknown"],
+              "type": "string",
+              "default": "all",
+              "description": "The fee type the exchange enforces for this market."
+            },
+            "sort_dir": {
+              "enum": ["asc", "desc"],
+              "type": "string",
+              "default": "desc",
+              "description": "Optionally specify the sort direction of markets returned."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol."
+            },
+            "matched_id": {
+              "type": "string",
+              "description": "Optionally include one or more fiat or cryptocurrency IDs to filter market pairs by. For example, ?id=1&matched_id=2781 would only return BTC markets that matched: \"BTC/USD\" or \"USD/BTC\". This parameter cannot be used when matched_symbol is used."
+            },
+            "matched_symbol": {
+              "type": "string",
+              "description": "Optionally include one or more fiat or cryptocurrency symbols to filter market pairs by. For example, ?symbol=BTC&matched_symbol=USD would only return BTC markets that matched: \"BTC/USD\" or \"USD/BTC\". This parameter cannot be used when matched_id is used."
+            }
+          },
+          "description": "Query parameters for retrieving the latest market pairs.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_OHLCV_HISTORICAL_V2",
+    "description": "CoinMarketCap OHLCV Historical v2 API returns historical OHLCV data along with market cap for one or more cryptocurrencies using time interval parameters. It supports daily and hourly periods along with flexible interval sampling.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_OHLCV_HISTORICAL_V2",
+      "canonical_tool_description_hash": "99cf38b4c98ec680f0b223f0285ed1a831fad2cc4d2e88f99321e9f35823affe",
+      "canonical_tool_input_schema_hash": "35752a01566f6497f59c4bc33459a40a9d48fa07641a47c70b7c1d8aa3787679"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated CoinMarketCap cryptocurrency IDs. Example: \"1,1027\"."
+            },
+            "slug": {
+              "type": "string",
+              "description": "Alternatively, a comma-separated list of cryptocurrency slugs. Example: \"bitcoin,ethereum\"."
+            },
+            "count": {
+              "type": "number",
+              "default": 10,
+              "maximum": 10000,
+              "minimum": 1,
+              "description": "Limit the number of time periods to return. The default is 10 items. Query limit is between 1 and 10000."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Alternatively, one or more comma-separated cryptocurrency symbols. Example: \"BTC,ETH\". At least one of 'id', 'slug', or 'symbol' is required."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 3 additional fiat or cryptocurrency currencies (comma-separated). Default market quotes are in USD."
+            },
+            "interval": {
+              "type": "string",
+              "description": "Adjust the frequency that 'time_period' is sampled. Supported values include calendar intervals (\"daily\", \"hourly\", \"weekly\", \"monthly\", \"yearly\") and relative intervals (e.g., \"1h\", \"2h\", \"1d\", \"7d\", \"30d\", etc.)."
+            },
+            "time_end": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to stop returning OHLCV time periods for (inclusive). Optional; defaults to current time if not provided. For daily data, use a date format like \"2018-09-19\" (without time)."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Cannot be used when 'convert' is provided."
+            },
+            "time_start": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to start returning OHLCV time periods for. For daily data, use a date format like \"2018-09-19\" (without time)."
+            },
+            "time_period": {
+              "enum": ["daily", "hourly"],
+              "type": "string",
+              "default": "daily",
+              "description": "Time period to return OHLCV data for. The default is \"daily\". If hourly, the open will be 01:00 and the close 01:59."
+            },
+            "skip_invalid": {
+              "type": "boolean",
+              "default": true,
+              "description": "Pass true to relax validation rules. When requesting multiple cryptocurrencies, invalid lookups will be skipped. Defaults to true."
+            }
+          },
+          "description": "Query parameters for retrieving historical OHLCV data.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_OHLCV_LATEST_V2",
+    "description": "CoinMarketCap OHLCV Latest v2 API returns the latest OHLCV (Open, High, Low, Close, Volume) market values for one or more cryptocurrencies for the current UTC day. Since the current day is active, these values are updated frequently. For finalized OHLCV data for the previous UTC day and historical values, use the /cryptocurrency/ohlcv/historical endpoint.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_OHLCV_LATEST_V2",
+      "canonical_tool_description_hash": "1398080c61d5aab2e4cfdc9ddc827d409ec71f6a7dd7c8033147983a2672f679",
+      "canonical_tool_input_schema_hash": "2d012d945c8060bf6b41f0876c09882c9a5ab581954ae46e600359e1551e8dc8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated cryptocurrency CoinMarketCap IDs. Example: \"1,2\"."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Alternatively, one or more comma-separated cryptocurrency symbols. Example: \"BTC,ETH\"."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies by passing a comma-separated list of currency symbols."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Cannot be used when 'convert' is provided."
+            },
+            "skip_invalid": {
+              "type": "boolean",
+              "default": true,
+              "description": "Pass true to relax validation rules. When requesting records on multiple cryptocurrencies, invalid lookups will be skipped. Defaults to true."
+            }
+          },
+          "description": "Query parameters for retrieving the latest OHLCV data. At least one of 'id' or 'symbol' is required.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_PRICE_PERFORMANCE_STATS_LATEST_V2",
+    "description": "CoinMarketCap Price Performance Stats v2 API returns price performance statistics for one or more cryptocurrencies, including launch price ROI and all-time high/low values. By default stats are returned for the 'all_time' period, but additional rolling time periods (e.g., yesterday, 24h, 7d, etc.) can be requested.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_PRICE_PERFORMANCE_STATS_LATEST_V2",
+      "canonical_tool_description_hash": "0d9bdb427a0587e30e23faedc0f68249d3d88485af824badfa138cdae9325180",
+      "canonical_tool_input_schema_hash": "ddc19d176e98bce28a12f8c047abf24af5341d8801eebd2d860a2a30f374b6a6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated cryptocurrency CoinMarketCap IDs. Example: \"1,2\"."
+            },
+            "slug": {
+              "type": "string",
+              "description": "Alternatively pass a comma-separated list of cryptocurrency slugs. Example: \"bitcoin,ethereum\"."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Alternatively pass one or more comma-separated cryptocurrency symbols. Example: \"BTC,ETH\". At least one of 'id', 'slug', or 'symbol' is required."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate quotes in up to 120 currencies at once by passing a comma-separated list of cryptocurrency or fiat currency symbols. Each additional convert option beyond the first requires an extra call credit."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate quotes by CoinMarketCap ID instead of symbol. Cannot be used when 'convert' is provided."
+            },
+            "time_period": {
+              "type": "string",
+              "description": "Specify one or more comma-delimited time periods to return stats for. Default is \"all_time\". For example: \"all_time,yesterday,24h,7d,30d,90d,365d\"."
+            },
+            "skip_invalid": {
+              "type": "boolean",
+              "default": true,
+              "description": "Pass true to relax request validation rules. If set to true, invalid lookups will be skipped allowing valid cryptocurrencies to still be returned."
+            }
+          },
+          "description": "Query parameters for retrieving price performance statistics.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_QUOTES_HISTORICAL_V2",
+    "description": "CoinMarketCap Quotes Historical v2 API returns an interval of historic market quotes for one or more cryptocurrencies based on provided time and interval parameters. A historic quote for every interval period between time_start and time_end will be returned.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_QUOTES_HISTORICAL_V2",
+      "canonical_tool_description_hash": "688d5bd65b05efd67258e3ae73e81981e9bcc0338481c45e6d8e657677cfd53a",
+      "canonical_tool_input_schema_hash": "a0718113093474197116bdc54ed05113d76082d849334f75641998d1c2341861"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated CoinMarketCap cryptocurrency IDs. Example: \"1,2\"."
+            },
+            "aux": {
+              "type": "string",
+              "default": "price,volume,market_cap,circulating_supply,total_supply,quote_timestamp,is_active,is_fiat",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Default: \"price,volume,market_cap,circulating_supply,total_supply,quote_timestamp,is_active,is_fiat\"."
+            },
+            "count": {
+              "type": "number",
+              "default": 10,
+              "maximum": 10000,
+              "minimum": 1,
+              "description": "The number of interval periods to return results for. Default is 10. Range: 1 to 10000."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Alternatively, one or more comma-separated cryptocurrency symbols. Example: \"BTC,ETH\". At least one of 'id' or 'symbol' is required."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 3 additional fiat currencies or cryptocurrencies by passing a comma-separated list of symbols. Defaults to USD if not provided."
+            },
+            "interval": {
+              "type": "string",
+              "description": "Interval of time to return data points for. Supported values include calendar intervals (e.g., \"daily\", \"hourly\", \"weekly\", \"monthly\", \"yearly\") and relative intervals (e.g., \"5m\", \"10m\", \"15m\", \"30m\", \"45m\", \"1h\", \"2h\", \"3h\", \"4h\", \"6h\", \"12h\", \"24h\", \"1d\", \"2d\", \"3d\", \"7d\", \"14d\", \"15d\", \"30d\", \"60d\", \"90d\", \"365d\")."
+            },
+            "time_end": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to stop returning quotes for (inclusive). Optional; if not provided, defaults to the current time."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Cannot be used when 'convert' is provided."
+            },
+            "time_start": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to start returning quotes for. Optional; if not provided, quotes are returned in reverse order from time_end."
+            },
+            "skip_invalid": {
+              "type": "boolean",
+              "default": true,
+              "description": "Pass true to relax request validation rules. Defaults to true."
+            }
+          },
+          "description": "Query parameters for retrieving historical market quotes.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_QUOTES_LATEST_V2",
+    "description": "CoinMarketCap Quotes Latest v2 API returns the latest market quote for one or more cryptocurrencies. Use the 'convert' option to return market values in multiple fiat and cryptocurrency conversions in the same call.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_QUOTES_LATEST_V2",
+      "canonical_tool_description_hash": "9621ea55697ea6ecab3c58a092b032c3efadfe2997081414744abd4cec5ff932",
+      "canonical_tool_input_schema_hash": "94c5d3577c2be5ababda2fe114b2408f9493877b68db34091b25737a76759537"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated cryptocurrency CoinMarketCap IDs. Example: \"1,2\"."
+            },
+            "aux": {
+              "type": "string",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Default: \"num_market_pairs,cmc_rank,date_added,tags,platform,max_supply,circulating_supply,total_supply,is_active,is_fiat\". Additional auxiliary fields can also be requested."
+            },
+            "slug": {
+              "type": "string",
+              "description": "Alternatively pass a comma-separated list of cryptocurrency slugs. Example: \"bitcoin,ethereum\"."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Alternatively pass one or more comma-separated cryptocurrency symbols. Example: \"BTC,ETH\". At least one of 'id', 'slug', or 'symbol' is required."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies at once by passing a comma-separated list of cryptocurrency or fiat currency symbols. Each additional convert option beyond the first requires an additional call credit. Basic tier users are limited to 1 convert options."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Ex: \"convert_id=1,2781\" would replace \"convert=BTC,USD\" in your query. This parameter cannot be used when convert is used. Basic tier users are limited to 1 convert options."
+            },
+            "skip_invalid": {
+              "type": "boolean",
+              "default": true,
+              "description": "Pass true to relax request validation rules. When requesting records on multiple cryptocurrencies, invalid lookups will be skipped allowing valid cryptocurrencies to still be returned."
+            }
+          },
+          "description": "Query parameters for retrieving the latest market quotes.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CRYPTOCURRENCY_QUOTES_HISTORICAL_V3",
+    "description": "CoinMarketCap Quotes Historical v3 API returns an interval of historic market quotes for one or more cryptocurrencies based on provided time and interval parameters. A historic quote for every interval period between time_start and time_end will be returned.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CRYPTOCURRENCY_QUOTES_HISTORICAL_V3",
+      "canonical_tool_description_hash": "c3f10caf32b143035ed5294b2a9668615e3c6edd9b3fe8ac039b6a2d55e7c2a5",
+      "canonical_tool_input_schema_hash": "d06dd293a7bdde1a1a4fae3a873d458ff645299b5195e9518f642940c7a89cd5"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated CoinMarketCap cryptocurrency IDs. Example: \"1,2\"."
+            },
+            "aux": {
+              "type": "string",
+              "default": "price,volume,market_cap,circulating_supply,total_supply,quote_timestamp,is_active,is_fiat",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Default: \"price,volume,market_cap,circulating_supply,total_supply,quote_timestamp,is_active,is_fiat\"."
+            },
+            "count": {
+              "type": "number",
+              "default": 10,
+              "maximum": 10000,
+              "minimum": 1,
+              "description": "The number of interval periods to return results for. Default is 10. Range: 1 to 10000."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Alternatively, one or more comma-separated cryptocurrency symbols. Example: \"BTC,ETH\". At least one of 'id' or 'symbol' is required."
+            },
+            "convert": {
+              "type": "string",
+              "description": "By default market quotes are returned in USD. Optionally calculate market quotes in up to 3 other fiat currencies or cryptocurrencies by passing a comma-separated list of symbols."
+            },
+            "interval": {
+              "type": "string",
+              "description": "Interval of time to return data points for. Supported values include calendar intervals (e.g., \"daily\", \"hourly\", \"weekly\", \"monthly\", \"yearly\") and relative intervals (e.g., \"5m\", \"10m\", \"15m\", \"30m\", \"45m\", \"1h\", \"2h\", \"3h\", \"4h\", \"6h\", \"12h\", \"24h\", \"1d\", \"2d\", \"3d\", \"7d\", \"14d\", \"15d\", \"30d\", \"60d\", \"90d\", \"365d\")."
+            },
+            "time_end": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to stop returning quotes for (inclusive). Optional; if not provided, defaults to the current time."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. This option cannot be used when 'convert' is provided."
+            },
+            "time_start": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to start returning quotes for. Optional; if not provided, quotes are returned in reverse order from time_end."
+            },
+            "skip_invalid": {
+              "type": "boolean",
+              "default": true,
+              "description": "Pass true to relax request validation rules. When requesting records on multiple cryptocurrencies, invalid lookups will be skipped. Defaults to true."
+            }
+          },
+          "description": "Query parameters for retrieving historical market quotes (v3).",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__DEX_METADATA",
+    "description": "Returns all static metadata for one or more decentralized exchanges (DEXes) tracked by CoinMarketCap. This endpoint provides details such as the exchange's launch date, logo URL, official website, social links, and market fee documentation URL. You must provide one or more exchange IDs (as a comma-separated string) via the 'id' parameter. Optionally, you can specify additional supplemental data fields using the 'aux' parameter. Valid 'aux' values include: 'urls', 'logo', 'description', 'date_launched', and 'notice'.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DEX_METADATA",
+      "canonical_tool_description_hash": "f5a7249263a17d906213630645a9795f41aa8ee5d014253d0c1922613a82ede8",
+      "canonical_tool_input_schema_hash": "52f81287e7faefe628bee8bdca774dc1e61d8802510a4ea72df053489d6f80c3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated CoinMarketCap cryptocurrency exchange IDs."
+            },
+            "aux": {
+              "type": "string",
+              "default": "",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Valid values include: 'urls', 'logo', 'description', 'date_launched', and 'notice'. Default is an empty string."
+            }
+          },
+          "description": "Query parameters for retrieving static metadata for decentralized exchanges. Provide one or more comma-separated CoinMarketCap cryptocurrency exchange IDs using the 'id' parameter. Optionally, specify a comma-separated list of supplemental data fields to return using the 'aux' parameter. Valid values for 'aux' are 'urls', 'logo', 'description', 'date_launched', and 'notice'.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__DEX_NETWORKS_LIST",
+    "description": "Returns a list of all networks mapped to unique CoinMarketCap IDs. Per best practices, it is recommended to use the CoinMarketCap ID instead of network symbols for secure identification with other endpoints and within your application logic. Each network returned includes typical identifiers such as name, symbol, and token_address for flexible mapping to an ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DEX_NETWORKS_LIST",
+      "canonical_tool_description_hash": "1f58f47a1fa596d5dbdb27e97c60337f46f7f63238e39d8f6a6a5c232a7fd7ba",
+      "canonical_tool_input_schema_hash": "760410de0a0906434cc7fc96fa6ca7d6e4fd83cff007d4b4ad0a52bbee7940a2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Valid values include: 'alternativeName', 'cryptocurrencyId', 'cryptocurrenySlug', 'wrappedTokenId', 'wrappedTokenSlug', 'tokenExplorerUrl', 'poolExplorerUrl', and 'transactionHashUrl'. Default is an empty string."
+            },
+            "sort": {
+              "enum": ["id", "name"],
+              "type": "string",
+              "default": "id",
+              "description": "Specifies the field by which to sort the list of networks. Valid values are 'id' and 'name'. Default is 'id'."
+            },
+            "limit": {
+              "type": "string",
+              "default": "100",
+              "description": "Optionally specify the number of results to return. Use this parameter along with 'start' to control the pagination size."
+            },
+            "start": {
+              "type": "string",
+              "default": "1",
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "sort_dir": {
+              "enum": ["desc", "asc"],
+              "type": "string",
+              "default": "desc",
+              "description": "Specifies the direction to order the networks based on the 'sort' field. Valid values are 'desc' and 'asc'. Default is 'desc'."
+            }
+          },
+          "description": "Query parameters for retrieving a list of networks with their unique CoinMarketCap IDs. You can optionally offset the start of the paginated list, specify the number of results to return, and sort the list by a specific field. Additionally, you may include a comma-separated list of supplemental data fields using the 'aux' parameter.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__DEX_LISTINGS_QUOTES",
+    "description": "Returns a paginated list of all decentralized cryptocurrency exchanges along with the latest aggregate market data for each exchange. This endpoint allows you to retrieve market data such as trading volume and market share for DEXes, and you can use the 'convert_id' option to return market values in multiple fiat and cryptocurrency conversions in a single call.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DEX_LISTINGS_QUOTES",
+      "canonical_tool_description_hash": "698d378c54e2d2838a7f979085fd1c4ad7736729738eaeb28ffbb77b2baeb7a3",
+      "canonical_tool_input_schema_hash": "e09cbbeb7990a8743becc721d6e567b5bf99c07ff07e0e9392f16c50b05479e6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Valid value is 'date_launched'. Default is an empty string."
+            },
+            "sort": {
+              "enum": ["name", "volume_24h", "market_share", "num_markets"],
+              "type": "string",
+              "default": "volume_24h",
+              "description": "Specifies the field by which to sort the list of exchanges. Valid values are 'name', 'volume_24h', 'market_share', and 'num_markets'. Default is 'volume_24h'."
+            },
+            "type": {
+              "enum": ["all", "orderbook", "swap", "aggregator"],
+              "type": "string",
+              "default": "all",
+              "description": "Specifies the category for the exchange. Valid values are 'all', 'orderbook', 'swap', and 'aggregator'. Default is 'all'."
+            },
+            "limit": {
+              "type": "string",
+              "default": "100",
+              "description": "Optionally specify the number of results to return. Use this parameter in combination with 'start' to control pagination size."
+            },
+            "start": {
+              "type": "string",
+              "default": "1",
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "sort_dir": {
+              "enum": ["desc", "asc"],
+              "type": "string",
+              "default": "desc",
+              "description": "Specifies the direction in which to order exchanges against the specified sort field. Valid values are 'desc' and 'asc'. Default is 'desc'."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 30 currencies at once by passing a comma-separated list of cryptocurrency or fiat currency IDs. Each additional convert option beyond the first requires an additional call credit. Each conversion is returned in its own 'quote' object."
+            }
+          },
+          "description": "Query parameters for retrieving the latest decentralized exchange listings. These parameters control pagination, sorting, filtering by exchange type, and the inclusion of supplemental data fields. Use 'start' and 'limit' to paginate the results; 'sort' and 'sort_dir' to order the list; 'type' to filter by exchange category; 'aux' to include additional fields (e.g. 'date_launched'); and 'convert_id' to perform market conversions using CoinMarketCap IDs.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__DEX_PAIRS_OHLCV_HISTORICAL",
+    "description": "CoinMarketCap DEX Pairs OHLCV Historical API returns historical OHLCV data along with market cap for any spot pairs using time interval parameters.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DEX_PAIRS_OHLCV_HISTORICAL",
+      "canonical_tool_description_hash": "7220c0088bea09fd746277c8d6cb30f4b262b8b53a7024f19d95db2740af9ee4",
+      "canonical_tool_input_schema_hash": "2152069ac2ef970fc3dfce4ba245108005d826bcf7eea18ed79853a4140cc61f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Valid values: \"pool_created\", \"percent_pooled_base_asset\", \"num_transactions_24h\", \"pool_base_asset\", \"pool_quote_asset\", \"24h_volume_quote_asset\", \"total_supply_quote_asset\", \"total_supply_base_asset\", \"holders\", \"buy_tax\", \"sell_tax\", \"security_scan\", \"24h_no_of_buys\", \"24h_no_of_sells\", \"24h_buy_volume\", \"24h_sell_volume\". Default: \"\"."
+            },
+            "count": {
+              "type": "string",
+              "default": "10",
+              "description": "Optionally limit the number of time periods to return results for. Default is 10 items. The current query limit is 500 items."
+            },
+            "interval": {
+              "type": "string",
+              "default": "daily",
+              "description": "Optionally adjust the interval that \"time_period\" is sampled. Default: \"daily\". Valid values: \"1m\", \"5m\", \"15m\", \"30m\", \"1h\", \"4h\", \"8h\", \"12h\", \"daily\", \"weekly\", \"monthly\"."
+            },
+            "time_end": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to stop returning OHLCV time periods for (inclusive). Optional; if not passed, defaults to the current time. For daily OHLCV, use an ISO date like \"2018-09-19\" without time."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Ex: convert_id=1,2781 would replace convert=BTC,USD in your query. Cannot be used when convert is used."
+            },
+            "network_id": {
+              "type": "string",
+              "description": "One or more CoinMarketCap cryptocurrency network ids."
+            },
+            "time_start": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to start returning OHLCV time periods for. Only the date portion is used for daily OHLCV; it is recommended to use an ISO date format like \"2018-09-19\" without time."
+            },
+            "time_period": {
+              "type": "string",
+              "default": "daily",
+              "description": "Time period to return OHLCV data for. Default: \"daily\". Valid values: \"daily\", \"hourly\", \"1m\", \"5m\", \"15m\", \"30m\", \"4h\", \"8h\", \"12h\", \"weekly\", \"monthly\". If hourly, the open will be 01:00 and the close 01:59. If daily, the open is 00:00:00 and the close is 23:59:99."
+            },
+            "network_slug": {
+              "type": "string",
+              "description": "Alternatively, one network name in URL friendly shorthand \"slug\" format (all lowercase, spaces replaced with hyphens). You can only choose either network_id or network_slug, not both."
+            },
+            "skip_invalid": {
+              "type": "string",
+              "description": "Pass true to relax request validation rules. When requesting records on multiple spot pairs, an error is returned if no match is found for one or more requested pairs. If set to true, invalid lookups will be skipped, returning only valid results."
+            },
+            "reverse_order": {
+              "type": "string",
+              "description": "Pass true to invert the order of a spot pair. For example, if a trading pair is set up as Token B/Token A in the contract (commonly referred to as Token A/Token B), reverse_order will return the true Token B/Token A pairing as it exists in the pool."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "One contract address. Example: \"0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640\". If network/dex/base asset/quote asset information is passed, contract_address cannot be passed. Note: contract_address is case sensitive for non-EVM chains and not case sensitive for EVM chains."
+            }
+          },
+          "description": "Query parameters for retrieving historical OHLCV data for DEX pairs.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__DEX_PAIRS_OHLCV_LATEST",
+    "description": "CoinMarketCap DEX Pairs OHLCV Latest API returns the latest OHLCV (Open, High, Low, Close, Volume) market values for one or more spot pairs for the current UTC day. Since the current UTC day is active, these values are updated frequently.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DEX_PAIRS_OHLCV_LATEST",
+      "canonical_tool_description_hash": "c270fa3ac42126dfb5a7c925795d1196f8420c83357787c1a57431a8b52fdd54",
+      "canonical_tool_input_schema_hash": "73faf9f0e67666c43af7bc462a351502c1813ee92a9b09adb87ae506eb2227ff"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Valid values: \"pool_created\", \"percent_pooled_base_asset\", \"num_transactions_24h\", \"pool_base_asset\", \"pool_quote_asset\", \"24h_volume_quote_asset\", \"total_supply_quote_asset\", \"total_supply_base_asset\", \"holders\", \"buy_tax\", \"sell_tax\", \"security_scan\", \"24h_no_of_buys\", \"24h_no_of_sells\", \"24h_buy_volume\", \"24h_sell_volume\"."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Example: \"convert_id=1,2781\" would replace convert=BTC,USD in your query. This parameter cannot be used when convert is used."
+            },
+            "network_id": {
+              "type": "string",
+              "description": "One or more CoinMarketCap cryptocurrency network ids."
+            },
+            "network_slug": {
+              "type": "string",
+              "description": "Alternatively, one network name in URL-friendly shorthand 'slug' format (all lowercase, spaces replaced with hyphens). You can only choose either network_id or network_slug, not both."
+            },
+            "skip_invalid": {
+              "type": "string",
+              "description": "Pass true to relax request validation rules. When requesting records on multiple spot pairs, an error is returned if no match is found for one or more pairs. If set to true, invalid lookups will be skipped, returning only valid results."
+            },
+            "reverse_order": {
+              "type": "string",
+              "description": "Pass true to invert the order of a spot pair. For example, if a trading pair is set up as Token B/Token A (commonly referred to as Token A/Token B), using reverse_order would return the true Token B/Token A pairing as it exists in the pool."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "One or more comma-separated contract addresses. Example: \"0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640\"."
+            }
+          },
+          "description": "Query parameters for retrieving the latest OHLCV market values for DEX pairs.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__DEX_PAIRS_QUOTES_LATEST",
+    "description": "Returns the latest market quote for one or more spot pairs on decentralized exchanges. This endpoint retrieves up-to-date market data for specified spot pairs, identified by one or more contract addresses. You can also specify the network using either a CoinMarketCap network ID or a URL-friendly network slug. Additionally, supplemental data fields can be requested via the 'aux' parameter. Use 'convert_id' to obtain market quotes in multiple fiat or cryptocurrency conversions (each conversion is returned in its own 'quote' object). The 'skip_invalid' flag relaxes validation errors for unmatched spot pairs, and 'reverse_order' allows inverting the order of a spot pair as defined in the smart contract.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DEX_PAIRS_QUOTES_LATEST",
+      "canonical_tool_description_hash": "8a61ac5223dd4d65c40389dd30c37da461fbbc72084c2ab6477f40afd227cddb",
+      "canonical_tool_input_schema_hash": "51ccbd5510ba9468e8379d7e86f719ac48edfc1d16346376bef136d1c764233d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Valid values include: 'pool_created', 'percent_pooled_base_asset', 'num_transactions_24h', 'pool_base_asset', 'pool_quote_asset', '24h_volume_quote_asset', 'total_supply_quote_asset', 'total_supply_base_asset', 'holders', 'buy_tax', 'sell_tax', 'security_scan', '24h_no_of_buys', '24h_no_of_sells', '24h_buy_volume', and '24h_sell_volume'. Default is an empty string."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. For example, 'convert_id=1,2781' would replace a convert query of 'BTC,USD'. This parameter cannot be used simultaneously with a 'convert' parameter."
+            },
+            "network_id": {
+              "type": "string",
+              "description": "One or more CoinMarketCap cryptocurrency network IDs associated with the spot pairs."
+            },
+            "network_slug": {
+              "type": "string",
+              "description": "Alternatively, specify a network by its URL-friendly slug (all lowercase, spaces replaced with hyphens). You can only choose either network_id or network_slug, not both."
+            },
+            "skip_invalid": {
+              "type": "string",
+              "default": "false",
+              "description": "Pass 'true' to relax request validation rules. When requesting records for multiple spot pairs, an error is returned if any requested pair is not found. If set to 'true', invalid lookups will be skipped, and valid spot pairs will still be returned."
+            },
+            "reverse_order": {
+              "type": "string",
+              "default": "false",
+              "description": "Pass 'true' to invert the order of a spot pair. For example, if a trading pair is defined in the contract as Token B/Token A but is commonly referred to as Token A/Token B, setting this parameter to 'true' will return the pair in its true order (Token B/Token A)."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "One or more comma-separated contract addresses for the spot pairs. Example: '0xabc123,0xdef456'."
+            }
+          },
+          "description": "Query parameters for retrieving the latest market quotes for one or more spot pairs on decentralized exchanges. Specify one or more contract addresses via 'contract_address'. Optionally, use 'network_id' or 'network_slug' to identify the blockchain network. Use 'aux' to request additional supplemental data fields, 'convert_id' to obtain multi-currency market quotes by CoinMarketCap ID, 'skip_invalid' to bypass errors for unmatched pairs, and 'reverse_order' to invert the order of a spot pair as stored in the contract.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__DEX_PAIRS_TRADE_LATEST",
+    "description": "Returns up to the latest 100 trades for a single spot pair on decentralized exchanges. This endpoint provides the most recent trade data including pricing and volume details for the specified spot pair. Use the 'convert_id' option to return market quotes in multiple fiat and cryptocurrency conversions in the same call, with each conversion returned in its own 'trade' object. The 'skip_invalid' parameter allows the request to bypass validation errors if no matching records are found for one or more requested spot pairs, and the 'reverse_order' parameter can be used to invert the order of a spot pair as defined in the smart contract.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DEX_PAIRS_TRADE_LATEST",
+      "canonical_tool_description_hash": "6184104e82c1968be0c4d272eeaa28eca982e97b81d629fa5743e5cc127250ee",
+      "canonical_tool_input_schema_hash": "862b4e099194d28bb6ed715434b6a5c5a6177c134d2e45b06d5c7024ed1ccc1d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["contract_address"],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Valid values include: 'transaction_hash' and 'blockchain_explorer_link'. Default is an empty string."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 30 currencies by passing a comma-separated list of cryptocurrency or fiat currency IDs. Each additional convert option beyond the first requires an additional call credit. For example: 'convert_id=1,2781'. This parameter cannot be used when a 'convert' parameter is provided."
+            },
+            "network_id": {
+              "type": "string",
+              "description": "One CoinMarketCap cryptocurrency network ID associated with the spot pair."
+            },
+            "network_slug": {
+              "type": "string",
+              "description": "Alternatively, specify the network using a URL-friendly slug (all lowercase, spaces replaced with hyphens). Example: 'ethereum'. You can only choose either network_id or network_slug, not both."
+            },
+            "skip_invalid": {
+              "type": "string",
+              "default": "false",
+              "description": "Pass 'true' to relax request validation rules. If no matching records are found for one or more requested spot pairs, setting this parameter to 'true' will skip invalid lookups and return only valid trades."
+            },
+            "reverse_order": {
+              "type": "string",
+              "default": "false",
+              "description": "Pass 'true' to invert the order of the spot pair. For instance, if the trading pair is stored in the contract as Token B/Token A but commonly referred to as Token A/Token B, setting this to 'true' will return the true order as Token B/Token A."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "One or more comma-separated contract addresses for the spot pair. Example: '0xabc123'. This parameter is required to specify the spot pair. Basic tier users are limited to 1 contract_address."
+            }
+          },
+          "description": "Query parameters for retrieving the latest trades for a spot pair on decentralized exchanges. Specify one or more contract addresses via 'contract_address' to identify the spot pair. Optionally, include the network identifier using 'network_id' or the network slug using 'network_slug'. Supplemental data fields can be requested using 'aux'. Use 'convert_id' to perform multi-currency market conversions, 'skip_invalid' to bypass errors for unmatched spot pairs, and 'reverse_order' to invert the spot pair order as stored in the contract.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__DEX_SPOT_PAIRS_LATEST",
+    "description": "Returns a paginated list of all active decentralized exchange (DEX) spot pairs along with the latest market data. This endpoint supports filtering by various identifiers for networks, DEX exchanges, base assets, and quote assets. At least one network identifier (network_id or network_slug), one DEX identifier (dex_id or dex_slug), and one base asset identifier (base_asset_id, base_asset_symbol, base_asset_contract_address, or base_asset_ucid) along with one quote asset identifier (quote_asset_id, quote_asset_symbol, quote_asset_contract_address, or quote_asset_ucid) are required.  Additional, you can use various filtering parameters (liquidity, volume, transactions, percent change) to narrow down the results. Sorting is available via the 'sort' and 'sort_dir' parameters, supplemental data fields can be requested using 'aux', 'reverse_order' allows inverting the order of a spot pair, and 'convert_id' enables multi-currency market conversions.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DEX_SPOT_PAIRS_LATEST",
+      "canonical_tool_description_hash": "9ca4f42d47a3ffd7492fe87a4243c94b2497368127a98ee5fd8bc4cf9f492f29",
+      "canonical_tool_input_schema_hash": "69429620a34f76127cbc63f7f2675a67b7dc9f99a7b4914ee2d2a1f956ad580c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Valid values include: 'pool_created', 'percent_pooled_base_asset', 'num_transactions_24h', 'pool_base_asset', 'pool_quote_asset', '24h_volume_quote_asset', 'total_supply_quote_asset', 'total_supply_base_asset', 'holders', 'buy_tax', 'sell_tax', 'security_scan', '24h_no_of_buys', '24h_no_of_sells', '24h_buy_volume', and '24h_sell_volume'. Default is an empty string."
+            },
+            "sort": {
+              "enum": [
+                "name",
+                "date_added",
+                "price",
+                "volume_24h",
+                "percent_change_1h",
+                "percent_change_24h",
+                "liquidity",
+                "fully_diluted_value",
+                "no_of_transactions_24h"
+              ],
+              "type": "string",
+              "default": "volume_24h",
+              "description": "Specifies the field by which to sort the list of DEX spot pairs. Valid values include 'name', 'date_added', 'price', 'volume_24h', 'percent_change_1h', 'percent_change_24h', 'liquidity', 'fully_diluted_value', and 'no_of_transactions_24h'. Default is 'volume_24h'."
+            },
+            "limit": {
+              "type": "string",
+              "default": "100",
+              "description": "Optionally specify the number of results to return. Use this parameter along with 'scroll_id' to control pagination. Default is '100'."
+            },
+            "dex_id": {
+              "type": "string",
+              "description": "One or more comma-separated CoinMarketCap DEX exchange IDs to filter results by."
+            },
+            "dex_slug": {
+              "type": "string",
+              "description": "Alternatively, one or more comma-separated DEX exchange names in URL-friendly slug format (all lowercase, spaces replaced with hyphens). At least one DEX identifier (id or slug) is required."
+            },
+            "sort_dir": {
+              "enum": ["desc", "asc"],
+              "type": "string",
+              "default": "desc",
+              "description": "Specifies the direction in which to order DEX spot pairs based on the 'sort' field. Valid values are 'desc' and 'asc'. Default is 'desc'."
+            },
+            "scroll_id": {
+              "type": "string",
+              "default": "",
+              "description": "After your initial query, the API returns a scroll_id with the result set. Use this scroll_id in subsequent requests to retrieve the next set of results as an alternative to traditional pagination."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. For example, 'convert_id=1,2781' would replace a convert query of 'BTC,USD'. This parameter cannot be used when a 'convert' parameter is provided."
+            },
+            "network_id": {
+              "type": "string",
+              "description": "One or more comma-separated CoinMarketCap cryptocurrency network IDs to filter results by."
+            },
+            "network_slug": {
+              "type": "string",
+              "description": "Alternatively, one or more comma-separated network names in URL-friendly slug format (all lowercase, spaces replaced with hyphens). At least one network identifier (id or slug) is required. You can only choose either network_id or network_slug, not both."
+            },
+            "base_asset_id": {
+              "type": "string",
+              "description": "One or more comma-separated CoinMarketCap cryptocurrency IDs for the base asset."
+            },
+            "liquidity_max": {
+              "type": "string",
+              "description": "Optionally specify a threshold for the maximum liquidity to filter results by."
+            },
+            "liquidity_min": {
+              "type": "string",
+              "description": "Optionally specify a threshold for the minimum liquidity to filter results by."
+            },
+            "reverse_order": {
+              "type": "string",
+              "default": "false",
+              "description": "Pass 'true' to invert the order of a spot pair. For example, if a trading pair is stored as Token B/Token A in the contract but commonly referred to as Token A/Token B, setting this parameter to 'true' will return the true order as Token B/Token A."
+            },
+            "quote_asset_id": {
+              "type": "string",
+              "description": "One or more comma-separated CoinMarketCap cryptocurrency IDs for the quote asset."
+            },
+            "volume_24h_max": {
+              "type": "string",
+              "description": "Optionally specify a threshold for the maximum 24-hour USD volume to filter results by."
+            },
+            "volume_24h_min": {
+              "type": "string",
+              "description": "Optionally specify a threshold for the minimum 24-hour USD volume to filter results by."
+            },
+            "base_asset_ucid": {
+              "type": "string",
+              "description": "One or more comma-separated unique CoinMarketCap cryptocurrency IDs for the base asset."
+            },
+            "quote_asset_ucid": {
+              "type": "string",
+              "description": "One or more comma-separated unique CoinMarketCap cryptocurrency IDs for the quote asset."
+            },
+            "base_asset_symbol": {
+              "type": "string",
+              "description": "Alternatively, one or more comma-separated base asset symbols in URL-friendly slug format (all lowercase, spaces replaced with hyphens). At least one base asset identifier (id or symbol) is required."
+            },
+            "quote_asset_symbol": {
+              "type": "string",
+              "description": "Alternatively, one or more comma-separated quote asset symbols in URL-friendly slug format (all lowercase, spaces replaced with hyphens). At least one quote asset identifier (id or symbol) is required."
+            },
+            "percent_change_24h_max": {
+              "type": "string",
+              "description": "Optionally specify a threshold for the maximum 24-hour percent change to filter results by."
+            },
+            "percent_change_24h_min": {
+              "type": "string",
+              "description": "Optionally specify a threshold for the minimum 24-hour percent change to filter results by."
+            },
+            "no_of_transactions_24h_max": {
+              "type": "string",
+              "description": "Optionally specify a threshold for the maximum number of transactions in the last 24 hours to filter results by."
+            },
+            "no_of_transactions_24h_min": {
+              "type": "string",
+              "description": "Optionally specify a threshold for the minimum number of transactions in the last 24 hours to filter results by."
+            },
+            "base_asset_contract_address": {
+              "type": "string",
+              "description": "Alternatively, a base asset contract address in URL-friendly slug format (all lowercase, spaces replaced with hyphens). At least one base asset identifier is required."
+            },
+            "quote_asset_contract_address": {
+              "type": "string",
+              "description": "Alternatively, a quote asset contract address in URL-friendly slug format (all lowercase, spaces replaced with hyphens). At least one quote asset identifier is required."
+            }
+          },
+          "description": "Query parameters for retrieving the latest listings of DEX spot pairs. Use one or more identifiers to filter results by network, DEX, base asset, and quote asset. You may also use 'scroll_id' for pagination, 'limit' to control result count, and additional filtering parameters for liquidity, volume, number of transactions, and percent change. Sorting options are available with 'sort' and 'sort_dir', while 'aux' can request supplemental data fields. The 'reverse_order' parameter inverts the pair order as defined in the smart contract, and 'convert_id' returns market quotes in additional currencies using CoinMarketCap IDs.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__EXCHANGE_ASSETS",
+    "description": "Returns the exchange assets in the form of token holdings. This endpoint provides detailed information such as the wallet address, associated cryptocurrency, blockchain platform, balance, and related data for an exchange's asset holdings. Note that only wallets containing at least 100,000 USD in balance are shown and that wallet balances may be delayed. Disclaimer: All information and data regarding the holdings in third-party wallet addresses are provided by those third parties to CoinMarketCap. CoinMarketCap does not verify or confirm the accuracy or timeliness of this information; it is provided 'as is' without warranty. CoinMarketCap shall have no responsibility or liability for these third parties\u2019 data or any inquiries into its completeness, accuracy, sufficiency, or timeliness.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EXCHANGE_ASSETS",
+      "canonical_tool_description_hash": "e128142bacbacac67f9223eb00805236811a5281d2d31cc9d98d3abb1613a0c0",
+      "canonical_tool_input_schema_hash": "c30f9de9879fd1cc9b64487a40819298e9b18609989f19ece37b6e24290677a8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "A CoinMarketCap exchange ID. Example: '270'."
+            }
+          },
+          "description": "Query parameters for retrieving the exchange assets. You must provide a CoinMarketCap exchange ID to specify which exchange's asset holdings to retrieve. Example: '270'.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__EXCHANGE_INFO",
+    "description": "Returns all static metadata for one or more cryptocurrency exchanges. This endpoint provides detailed information such as the exchange's launch date, logo, official website URL, social links, and market fee documentation URL. You can identify exchanges by providing one or more comma-separated exchange IDs (using the 'id' parameter) or by exchange slugs (using the 'slug' parameter in URL-friendly format). At least one identifier is required. Optionally, you may include supplemental data fields using the 'aux' parameter. Valid supplemental fields include 'urls', 'logo', 'description', 'date_launched', and 'notice'. To return all available auxiliary fields, use 'urls,logo,description,date_launched,notice,status'.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EXCHANGE_INFO",
+      "canonical_tool_description_hash": "759f1844704d5d6258eb970e7205b33210a4cb831a2b75395f920faa04c59c62",
+      "canonical_tool_input_schema_hash": "c52c3f32363a9e00cd602ccbbd8f39c0e44623173c8d81d14a0b043921fa0c7b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated CoinMarketCap cryptocurrency exchange IDs."
+            },
+            "aux": {
+              "type": "string",
+              "default": "urls,logo,description,date_launched,notice",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. The default is 'urls,logo,description,date_launched,notice'. To include all auxiliary fields, pass 'urls,logo,description,date_launched,notice,status'."
+            },
+            "slug": {
+              "type": "string",
+              "description": "Alternatively, one or more comma-separated exchange slugs in URL-friendly format (all lowercase, spaces replaced with hyphens). Example: 'binance,gdax'. At least one of 'id' or 'slug' is required."
+            }
+          },
+          "description": "Query parameters for retrieving static metadata for one or more exchanges. Provide either one or more comma-separated exchange IDs via the 'id' parameter or exchange slugs via the 'slug' parameter. Optionally, specify supplemental data fields using 'aux'.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__EXCHANGE_MAP",
+    "description": "Returns a paginated list of all active cryptocurrency exchanges by their unique CoinMarketCap IDs. This convenience endpoint is designed to help you lookup and utilize our unique exchange ID across all endpoints, ensuring reliable identification even if typical exchange identifiers change over time. By default, only exchanges with at least one actively tracked market are returned (listing_status = 'active'). You can also filter for inactive exchanges (listing_status = 'inactive') or for exchanges that are registered but not meeting the tracking methodology (listing_status = 'untracked'). Optionally, you may pass a comma-separated list of exchange slugs to restrict the list or use the 'aux' parameter to slim down the payload. Additionally, you can filter exchanges by a fiat or cryptocurrency ID using the 'crypto_id' parameter.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EXCHANGE_MAP",
+      "canonical_tool_description_hash": "a4794a2e33d844775ca12a15cadd197210ec424a8becad848961bd97b87347a7",
+      "canonical_tool_input_schema_hash": "561f76ec8fd2fa4e40a756b2043358f3dbca58caf3b7638ef5a97bdb93681a67"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "first_historical_data,last_historical_data,is_active",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. The default is 'first_historical_data,last_historical_data,is_active'. To include all available auxiliary fields, pass 'first_historical_data,last_historical_data,is_active,status'."
+            },
+            "slug": {
+              "type": "string",
+              "description": "Optionally, provide a comma-separated list of exchange slugs (URL-friendly, all lowercase with spaces replaced by dashes) to filter the results. If specified, all other query options will be ignored."
+            },
+            "sort": {
+              "enum": ["id", "volume_24h"],
+              "type": "string",
+              "default": "id",
+              "description": "Specifies the field by which to sort the list of exchanges. Valid values are 'id' and 'volume_24h'. Default is 'id'."
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Valid values range from 1 to 5000. Use this together with 'start' to control the pagination size."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return. Default is 1."
+            },
+            "crypto_id": {
+              "type": "string",
+              "description": "Optionally, pass one fiat or cryptocurrency ID to filter the exchanges. For example, 'crypto_id=1' will return only exchanges that have BTC in their market pairs."
+            },
+            "listing_status": {
+              "type": "string",
+              "default": "active",
+              "description": "Filter exchanges by their listing status. By default, 'active' is used to return only exchanges with at least one actively tracked market. You can also pass 'inactive' to get exchanges that are no longer active or 'untracked' to get exchanges registered but not meeting methodology requirements. Multiple comma-separated values are allowed."
+            }
+          },
+          "description": "Query parameters for retrieving the CoinMarketCap ID map for cryptocurrency exchanges. By default, only active exchanges (listing_status = 'active') are returned. You may optionally specify a comma-separated list of listing statuses (e.g. 'active,inactive,untracked'). If you provide the 'slug' parameter, it will filter the results to only include the specified exchanges and ignore other query filters. The 'start' and 'limit' parameters enable pagination, 'sort' allows sorting by either 'id' or 'volume_24h', 'aux' lets you include supplemental fields, and 'crypto_id' filters the exchanges by the presence of a specific cryptocurrency in their markets.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__EXCHANGE_LISTINGS_LATEST",
+    "description": "CoinMarketCap Listings Latest API returns a paginated list of all cryptocurrency exchanges including the latest aggregate market data for each exchange. Use the 'convert' option to return market values in multiple fiat and cryptocurrency conversions in the same call. NOTE: Use this endpoint for a sorted and paginated list of exchanges. For market data on specific exchanges, use /v1/exchange/quotes/latest. The response data between these endpoints is otherwise the same. 'exchange_score' will be deprecated on 4 November 2024 and will return null after that date.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EXCHANGE_LISTINGS_LATEST",
+      "canonical_tool_description_hash": "917c5cd342f16215cda81daf6a55433a9e17b4cd2184d4939d32a42af2fb48aa",
+      "canonical_tool_input_schema_hash": "6c2c1c0725cc000da5067a60ce8633718de3e1a9029102537fd0b24a91ff64ba"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "num_market_pairs,traffic_score,rank,exchange_score,effective_liquidity_24h",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Default: \"num_market_pairs,traffic_score,rank,exchange_score,effective_liquidity_24h\"."
+            },
+            "sort": {
+              "enum": ["volume_24h", "name", "volume_24h_adjusted", "exchange_score"],
+              "type": "string",
+              "default": "volume_24h",
+              "description": "What field to sort the list of exchanges by."
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Range: 1 to 5000."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies at once by passing a comma-separated list of cryptocurrency or fiat currency symbols. Each additional convert option beyond the first requires an additional call credit."
+            },
+            "category": {
+              "enum": ["all", "spot", "derivatives", "dex", "lending"],
+              "type": "string",
+              "default": "all",
+              "description": "The category for this exchange."
+            },
+            "sort_dir": {
+              "enum": ["asc", "desc"],
+              "type": "string",
+              "description": "The direction in which to order exchanges against the specified sort."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Ex: convert_id=1,2781 would replace convert=BTC,USD in your query. This parameter cannot be used when convert is used."
+            },
+            "market_type": {
+              "enum": ["all", "fees", "no_fees"],
+              "type": "string",
+              "default": "all",
+              "description": "The type of exchange markets to include in rankings. This field is deprecated. Please use 'all' for accurate sorting."
+            }
+          },
+          "description": "Query parameters for retrieving the latest cryptocurrency exchange listings with market data.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__EXCHANGE_MARKET_PAIRS_LATEST",
+    "description": "CoinMarketCap Market Pairs Latest API returns all active market pairs tracked for a given exchange, including the latest price and volume data for each market. Use the 'convert' option to return market values in multiple fiat and cryptocurrency conversions in the same call.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EXCHANGE_MARKET_PAIRS_LATEST",
+      "canonical_tool_description_hash": "0866da85669030fc2745a92758ba7aac5fde4e7ff335996daac24d980f7afecc",
+      "canonical_tool_input_schema_hash": "19ba45c038b9798c582ab425fc9ffa89dd074ab83eea626b4cf5d72ea0ab1d77"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "A CoinMarketCap exchange ID. Example: \"1\"."
+            },
+            "aux": {
+              "type": "string",
+              "default": "num_market_pairs,category,fee_type",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Default is \"num_market_pairs,category,fee_type\". Additional fields such as \"market_url\", \"currency_name\", \"currency_slug\", \"price_quote\", \"effective_liquidity\", \"market_score\", \"market_reputation\" may be included."
+            },
+            "slug": {
+              "type": "string",
+              "description": "Alternatively, an exchange slug (URL-friendly lowercase shorthand version of the name with spaces replaced with hyphens). Example: \"binance\". One of 'id' or 'slug' is required."
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Range: 1 to 5000."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies by passing a comma-separated list of cryptocurrency or fiat currency symbols. Each additional convert option beyond the first requires an additional call credit."
+            },
+            "category": {
+              "enum": ["all", "spot", "derivatives", "otc", "futures", "perpetual"],
+              "type": "string",
+              "default": "all",
+              "description": "The category of trading the market falls under."
+            },
+            "fee_type": {
+              "enum": ["all", "percentage", "no-fees", "transactional-mining", "unknown"],
+              "type": "string",
+              "default": "all",
+              "description": "The fee type enforced by the exchange for this market."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Example: \"convert_id=1,2781\" would replace convert=BTC,USD. Cannot be used when convert is provided."
+            },
+            "matched_id": {
+              "type": "string",
+              "description": "Optionally include one or more comma-delimited fiat or cryptocurrency IDs to filter market pairs. For example, ?matched_id=2781 returns only BTC markets matching \"BTC/USD\" or \"USD/BTC\". Cannot be used with matched_symbol."
+            },
+            "matched_symbol": {
+              "type": "string",
+              "description": "Optionally include one or more comma-delimited fiat or cryptocurrency symbols to filter market pairs. For example, ?matched_symbol=USD returns only BTC markets matching \"BTC/USD\" or \"USD/BTC\". Cannot be used with matched_id."
+            }
+          },
+          "description": "Query parameters for retrieving market pairs for a given exchange.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__EXCHANGE_QUOTES_HISTORICAL",
+    "description": "CoinMarketCap Exchange Quotes Historical API returns an interval of historic quotes for one or more exchanges based on provided time and interval parameters. A historic quote for every interval period between time_start and time_end will be returned.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EXCHANGE_QUOTES_HISTORICAL",
+      "canonical_tool_description_hash": "476db6429e1154653ecd4eb1afe704a8fd195bc9c21234717682002a871811bd",
+      "canonical_tool_input_schema_hash": "3729416929636849644dec07095c747b20cbca337b22cbad80b720ef679fbc60"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated exchange CoinMarketCap ids. Example: \"24,270\"."
+            },
+            "slug": {
+              "type": "string",
+              "description": "Alternatively, one or more comma-separated exchange slugs in URL-friendly shorthand (all lowercase, spaces replaced with hyphens). Example: \"binance,kraken\". At least one of 'id' or 'slug' is required."
+            },
+            "count": {
+              "type": "number",
+              "default": 10,
+              "maximum": 10000,
+              "minimum": 1,
+              "description": "The number of interval periods to return results for. Default is 10. Range: 1 to 10000."
+            },
+            "convert": {
+              "type": "string",
+              "description": "By default market quotes are returned in USD. Optionally calculate market quotes in up to 3 other fiat currencies or cryptocurrencies by passing a comma-separated list of symbols."
+            },
+            "interval": {
+              "type": "string",
+              "description": "Interval of time to return data points for. Supported values include calendar intervals (e.g., \"hourly\", \"daily\", \"weekly\", \"monthly\", \"yearly\") and relative intervals (e.g., \"5m\", \"10m\", \"15m\", \"30m\", \"45m\", \"1h\", \"2h\", \"3h\", \"4h\", \"6h\", \"12h\", \"24h\", \"1d\", \"2d\", \"3d\", \"7d\", \"14d\", \"15d\", \"30d\", \"60d\", \"90d\", \"365d\")."
+            },
+            "time_end": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to stop returning quotes for (inclusive). Optional; if not provided, defaults to the current time."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Example: \"convert_id=1,2781\" would replace convert=BTC,USD in your query. This parameter cannot be used when convert is provided."
+            },
+            "time_start": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to start returning quotes for. Optional; if not provided, quotes are returned in reverse from time_end."
+            }
+          },
+          "description": "Query parameters for retrieving historical quotes for exchanges.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__EXCHANGE_QUOTES_LATEST",
+    "description": "CoinMarketCap Quotes Latest API returns the latest aggregate market data for one or more exchanges. Use the 'convert' option to return market values in multiple fiat and cryptocurrency conversions in the same call. NOTE: 'exchange_score' will be deprecated on 4 November 2024.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EXCHANGE_QUOTES_LATEST",
+      "canonical_tool_description_hash": "4720506806a23b8204e27cd052cd35466d4b785398e8c767f3b42df4356fffc1",
+      "canonical_tool_input_schema_hash": "e0f1ad95282b902728eaf6f7ec8ca797cb33fb77c6b289254cb462c256612298"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated CoinMarketCap exchange IDs. Example: \"1,2\"."
+            },
+            "aux": {
+              "type": "string",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Default: \"num_market_pairs,traffic_score,rank,exchange_score,liquidity_score,effective_liquidity_24h\"."
+            },
+            "slug": {
+              "type": "string",
+              "description": "Alternatively, pass a comma-separated list of exchange slugs (URL-friendly, all lowercase with spaces replaced by hyphens). Example: \"binance,gdax\". At least one of 'id' or 'slug' is required."
+            },
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies at once by passing a comma-separated list of cryptocurrency or fiat currency symbols. Each additional convert option beyond the first requires an additional call credit."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Ex: \"convert_id=1,2781\" would replace \"convert=BTC,USD\" in your query. This parameter cannot be used when 'convert' is provided."
+            }
+          },
+          "description": "Query parameters for retrieving the latest aggregate market data for exchanges.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__GLOBAL_METRICS_QUOTES_HISTORICAL",
+    "description": "CoinMarketCap Global Metrics Quotes Historical API returns an interval of historical global cryptocurrency market metrics based on provided time and interval parameters. A historic quote for every interval period between time_start and time_end will be returned.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GLOBAL_METRICS_QUOTES_HISTORICAL",
+      "canonical_tool_description_hash": "3b388b7d856a05bdbd37dffe9f81db055bf65bd925f3a3b2b2640f4cdf226c3b",
+      "canonical_tool_input_schema_hash": "3f6f003008391b54a6ab7e22c7922d248460ba872d91bd15e146c4d4a91f1820"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "aux": {
+              "type": "string",
+              "default": "btc_dominance,eth_dominance,active_cryptocurrencies,active_exchanges,active_market_pairs,total_volume_24h,total_volume_24h_reported,altcoin_market_cap,altcoin_volume_24h,altcoin_volume_24h_reported",
+              "description": "Optionally specify a comma-separated list of supplemental data fields to return. Default: \"btc_dominance,eth_dominance,active_cryptocurrencies,active_exchanges,active_market_pairs,total_volume_24h,total_volume_24h_reported,altcoin_market_cap,altcoin_volume_24h,altcoin_volume_24h_reported\"."
+            },
+            "count": {
+              "type": "number",
+              "default": 10,
+              "maximum": 10000,
+              "minimum": 1,
+              "description": "The number of interval periods to return results for. Optional; default is 10. Range: 1 to 10000."
+            },
+            "convert": {
+              "type": "string",
+              "description": "By default market quotes are returned in USD. Optionally calculate market quotes in up to 3 other fiat currencies or cryptocurrencies by passing a comma-separated list of symbols."
+            },
+            "interval": {
+              "type": "string",
+              "default": "1d",
+              "description": "Interval of time to return data points for. Default is \"1d\". Valid values include calendar intervals (e.g., \"hourly\", \"daily\", \"weekly\", \"monthly\", \"yearly\") and relative intervals (e.g., \"5m\", \"10m\", \"15m\", \"30m\", \"45m\", \"1h\", \"2h\", \"3h\", \"4h\", \"6h\", \"12h\", \"24h\", \"1d\", \"2d\", \"3d\", \"7d\", \"14d\", \"15d\", \"30d\", \"60d\", \"90d\", \"365d\")."
+            },
+            "time_end": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to stop returning quotes for (inclusive). Optional; if not supplied, defaults to the current time."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Ex: \"convert_id=1,2781\" replaces convert=BTC,USD in your query. This parameter cannot be used when convert is provided."
+            },
+            "time_start": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to start returning quotes for. Optional; if not supplied, quotes are returned in reverse order from time_end."
+            }
+          },
+          "description": "Query parameters for retrieving historical global cryptocurrency market metrics.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__GLOBAL_METRICS_QUOTES_LATEST",
+    "description": "CoinMarketCap Global Metrics Quotes Latest API returns the latest global cryptocurrency market metrics. Use the 'convert' option to return market values in multiple fiat and cryptocurrency conversions in the same call.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GLOBAL_METRICS_QUOTES_LATEST",
+      "canonical_tool_description_hash": "e5123293f34acc8d7bdb96dd7c3311c9ea0da9b43cb86a132af5d9031b9e8f9c",
+      "canonical_tool_input_schema_hash": "c01100c665e0af978ecfe7d00d5425c6718627e4d94a0b224eae171a56321762"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "convert": {
+              "type": "string",
+              "description": "Optionally calculate market quotes in up to 120 currencies by passing a comma-separated list of cryptocurrency or fiat currency symbols. Each additional convert option beyond the first requires an additional call credit."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. Ex: \"convert_id=1,2781\" would replace convert=BTC,USD in your query. This parameter cannot be used when convert is used."
+            }
+          },
+          "description": "Query parameters for retrieving the latest global cryptocurrency market metrics.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CMC100_INDEX_HISTORICAL",
+    "description": "Returns an interval of historic CoinMarketCap 100 Index values based on the interval parameter. This endpoint retrieves historical index data for the CoinMarketCap 100 Index. You may specify the starting timestamp (time_start) and ending timestamp (time_end) to define the period for which to return data. If time_start is not provided, the API returns quotes in reverse order starting from time_end. The 'count' parameter specifies the number of interval periods to return (default is 5 items; if time_start and time_end are supplied, the limit is 10 with count starting from time_start). The 'interval' parameter allows you to adjust the granularity of the data (valid values are '5m', '15m', or 'daily').\n\nData provided by CoinMarketCap.com. For commercial agreement details, please refer to https://pro.coinmarketcap.com/user-agreement-commercial/.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CMC100_INDEX_HISTORICAL",
+      "canonical_tool_description_hash": "5c0f5d337e65bb108d110ae2043a983875ee4526a11b4cfc6315bb48cc0dfa1b",
+      "canonical_tool_input_schema_hash": "cf079a0aca575be301ce6daf71d26b683f743ce4c669aa4bd5e9cd97d5ff9267"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "count": {
+              "type": "string",
+              "default": "5",
+              "description": "The number of interval periods to return. Optional; required if neither time_start nor time_end is supplied. The default is 5 items. If both time_start and time_end are provided, the query limit is 10 and the count starts from time_start."
+            },
+            "interval": {
+              "type": "string",
+              "description": "Optionally adjust the interval of the returned data. Valid values are '5m' for 5 minutes, '15m' for 15 minutes, or 'daily' for daily intervals."
+            },
+            "time_end": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to stop returning CoinMarketCap 100 Index data for (inclusive). Optional; if not provided, defaults to the current time. When omitted with time_start, results are returned in reverse order from this time."
+            },
+            "time_start": {
+              "type": "string",
+              "description": "Timestamp (Unix or ISO 8601) to start returning CoinMarketCap 100 Index data for. Optional; if not provided, results are returned in reverse order from time_end."
+            }
+          },
+          "description": "Query parameters for retrieving historical CoinMarketCap 100 Index data. 'time_start' is the timestamp (Unix or ISO 8601) to begin returning index data. 'time_end' is the timestamp (Unix or ISO 8601) to stop returning data (inclusive). If 'time_start' is omitted, the endpoint returns quotes in reverse order starting from 'time_end'. The 'count' parameter specifies the number of interval periods to return (default is 5 items, or up to 10 if both 'time_start' and 'time_end' are provided). The 'interval' parameter adjusts the data granularity; valid values are '5m', '15m', and 'daily'.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__CMC100_INDEX_LATEST",
+    "description": "Returns the latest CoinMarketCap 100 Index value along with its current constituents and their respective weights. This endpoint is updated every 5 minutes and is available on the Basic, Startup, Hobbyist, Standard, Professional, and Enterprise plans. Data provided by CoinMarketCap.com. Your product must display the attribution: 'Data provided by CoinMarketCap.com' with a hyperlink to https://coinmarketcap.com.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CMC100_INDEX_LATEST",
+      "canonical_tool_description_hash": "8b39fae556444b9a4d88ecf0ed0e51cfd9cb96bc68c86b5d30f9ed7caa3c8028",
+      "canonical_tool_input_schema_hash": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    },
+    "input_schema": {}
+  },
+  {
+    "name": "COINMARKETCAP__CMC_CRYPTO_FEAR_GREED_HISTORICAL",
+    "description": "Returns a paginated list of all CMC Crypto Fear and Greed Index values recorded at 12am UTC. This endpoint provides historical index data along with its classification (e.g., 'Fear' or 'Greed'). It is available on the Basic, Startup, Hobbyist, Standard, Professional, and Enterprise plans and is updated every 15 seconds. Plan credit use is 1 call credit per request. Data provided by CoinMarketCap.com. Your product must display the attribution 'Data provided by CoinMarketCap.com' with a hyperlink to https://coinmarketcap.com.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CMC_CRYPTO_FEAR_GREED_HISTORICAL",
+      "canonical_tool_description_hash": "8874c8bca90c2d95976082e317b5d86fb37209d43813aa834ba346240b8e3259",
+      "canonical_tool_input_schema_hash": "0cb1844ca963038cfa1eb78f030151ef23f8f5f1727137b5e8f84660a0ca8f8e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "description": "Optionally specify the number of historical data records to return. Valid range is 1 to 500. Default is 50."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the historical data records to return. Must be at least 1. Default is 1."
+            }
+          },
+          "description": "Query parameters for retrieving historical CMC Crypto Fear and Greed Index data recorded at 12am UTC. Use 'start' to specify the 1-based index offset of the paginated list and 'limit' to define the number of results to return. If not provided, 'start' defaults to 1 and 'limit' defaults to 50.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__FIAT_MAP",
+    "description": "Returns a mapping of all supported fiat currencies to unique CoinMarketCap IDs. This endpoint is designed to help you reliably identify fiat assets using their CMC ID rather than currency symbols, which may change over time. By default, it returns data for fiat currencies with updated mapping data every 30 seconds. Optionally, you can include precious metals by setting 'include_metals' to true. This endpoint is available on Basic, Hobbyist, Startup, Standard, Professional, and Enterprise plans.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "FIAT_MAP",
+      "canonical_tool_description_hash": "7bf5357a4cb17eb8349504d0c6533ed6f3ac89271e6e6516fb15f75d3b33f1e6",
+      "canonical_tool_input_schema_hash": "4f29069490963c9eeb5c8f1019ee93ddb61c331a21d4784201432f01cc421a0b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "sort": {
+              "enum": ["id", "name"],
+              "type": "string",
+              "default": "id",
+              "description": "Specifies the field by which to sort the list of fiat currencies. Valid values are 'id' and 'name'. Default is 'id'."
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Optionally specify the number of results to return. Valid values range from 1 to 5000."
+            },
+            "start": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "description": "Optionally offset the start (1-based index) of the paginated list of items to return. Must be at least 1."
+            },
+            "include_metals": {
+              "type": "boolean",
+              "default": false,
+              "description": "Pass true to include precious metals in the response."
+            }
+          },
+          "description": "Query parameters for retrieving the CoinMarketCap ID map for fiat currencies. 'start' specifies the 1-based index offset for pagination. 'limit' defines the number of results to return. 'sort' determines the field by which to sort the list (either by 'id' or 'name'), and 'include_metals' specifies whether to include precious metals in the response.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__PRICE_CONVERSION_V2",
+    "description": "Converts an amount of a base cryptocurrency or fiat currency into one or more target currencies using the latest market rates (or historical rates if a timestamp is provided). Basic tier users are limited to 1 convert symbol/id. Specify the amount to convert along with either the CoinMarketCap currency ID (id) or its symbol (symbol) as the source. Optionally, provide a timestamp (time) to retrieve historical conversion values. You can convert the source amount into up to 120 different fiat or cryptocurrency symbols by using the 'convert' parameter. Alternatively, you can use 'convert_id' to obtain market quotes by CoinMarketCap IDs instead of symbols; note that 'convert' and 'convert_id' cannot be used together. Latest market rate conversions are accurate to within 1 minute, while historical conversions are similarly precise (with non-USD fiat conversions having a 5-minute specificity).",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PRICE_CONVERSION_V2",
+      "canonical_tool_description_hash": "0566ee7f5efc6befc447bdeb32db25e219c888b86b321d9977274eefe413bad2",
+      "canonical_tool_input_schema_hash": "a138778a61460b6193dc11311e13103dfd57c88d3e130d31a64ef488fccb6158"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["amount"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The CoinMarketCap currency ID of the base cryptocurrency or fiat to convert from. Example: \"1\". (Either 'id' or 'symbol' is required.)"
+            },
+            "time": {
+              "type": "string",
+              "description": "Optional timestamp (Unix or ISO 8601) to reference historical pricing during conversion. If not provided, the current time will be used."
+            },
+            "amount": {
+              "type": "number",
+              "description": "The amount of the base currency to convert. Must be between 1e-8 and 1000000000000. Example: 10.43."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Alternatively, the currency symbol of the base cryptocurrency or fiat to convert from. Example: \"BTC\". (Either 'id' or 'symbol' is required; note that if requested by symbol, the response may include an array of objects.)"
+            },
+            "convert": {
+              "type": "string",
+              "description": "Comma-separated list of fiat or cryptocurrency symbols to convert the base amount into. Up to 120 symbols may be provided, but basic tier users are limited to 1 convert symbol. Each conversion is returned in its own 'quote' object."
+            },
+            "convert_id": {
+              "type": "string",
+              "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. For example, 'convert_id=1' would replace a convert query of 'BTC'. But basic tier users are limited to 1 convert_id. This parameter cannot be used when 'convert' is provided."
+            }
+          },
+          "description": "Query parameters for converting a specified amount from one currency to one or more target currencies. 'amount' is required along with either 'id' (the CoinMarketCap currency ID) or 'symbol' (the currency symbol) for the base currency. Optionally, 'time' can be provided for historical conversions, 'convert' for target currency symbols, and 'convert_id' for target currency IDs (mutually exclusive with 'convert').",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__BLOCKCHAIN_STATISTICS_LATEST",
+    "description": "CoinMarketCap Statistics Latest API returns the latest blockchain statistics data for one or more blockchains. Bitcoin, Litecoin, and Ethereum are currently supported. Additional blockchains will be made available on a regular basis.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BLOCKCHAIN_STATISTICS_LATEST",
+      "canonical_tool_description_hash": "0e5ee9697bf0103e7eca74836eb5e0b893add278c5914e49513ca7d34d466cca",
+      "canonical_tool_input_schema_hash": "7232d82345e1a4139ab25b30cc9686588bd3c4cb55743916f0c2ca6e56737b0a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "One or more comma-separated cryptocurrency CoinMarketCap IDs to return blockchain data for. Pass 1,2,1027 to request all currently supported blockchains."
+            },
+            "slug": {
+              "type": "string",
+              "description": "Alternatively, pass a comma-separated list of cryptocurrency slugs. Pass bitcoin,litecoin,ethereum to request all currently supported blockchains."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Alternatively, pass one or more comma-separated cryptocurrency symbols. Pass BTC,LTC,ETH to request all currently supported blockchains."
+            }
+          },
+          "description": "Query parameters for retrieving the latest blockchain statistics.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "COINMARKETCAP__KEY_INFO",
+    "description": "Returns API key details and usage statistics, including your current rate limit and daily/monthly credit usage for your API plan. Use this endpoint to programmatically monitor your key usage and ensure you remain within the allowed limits. This endpoint updates in real time with each request and does not consume any API call credits, though it does count toward your minute-based rate limit. You may also view your API key details in the Developer Portal dashboard at https://pro.coinmarketcap.com/account. Data provided by CoinMarketCap.com.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "KEY_INFO",
+      "canonical_tool_description_hash": "3cdab886ed91874a8a9e0fa4c3de32c4b3ffe6ac68621d3a27741e2187f230e7",
+      "canonical_tool_input_schema_hash": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    },
+    "input_schema": {}
+  }
+]

--- a/backend/mcp_servers/context7/tools.json
+++ b/backend/mcp_servers/context7/tools.json
@@ -16,9 +16,7 @@
           "description": "Library name to search for and retrieve a Context7-compatible library ID."
         }
       },
-      "required": [
-        "libraryName"
-      ],
+      "required": ["libraryName"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -48,9 +46,7 @@
           "description": "Maximum number of tokens of documentation to retrieve (default: 10000). Higher values provide more context but consume more tokens."
         }
       },
-      "required": [
-        "context7CompatibleLibraryID"
-      ],
+      "required": ["context7CompatibleLibraryID"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }

--- a/backend/mcp_servers/daytona/tools.json
+++ b/backend/mcp_servers/daytona/tools.json
@@ -1,0 +1,365 @@
+[
+  {
+    "name": "DAYTONA__GET_WORKSPACE",
+    "description": "Get detailed information about a specific workspace by its ID. Returns workspace configuration, status, and metadata.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_WORKSPACE",
+      "canonical_tool_description_hash": "2f36923915210d3f97a000999cedba82e9bef54ac8c8ce5d811bdc22ca9e715e",
+      "canonical_tool_input_schema_hash": "c0d1a71ae2a99f76333f7a4600c4370b4c335973e3aedf03010c0254faf0452c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["workspaceId"],
+          "properties": {
+            "workspaceId": {
+              "type": "string",
+              "description": "ID of the workspace"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "verbose": {
+              "type": "boolean",
+              "description": "Include verbose output"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "X-Daytona-Organization-ID": {
+              "type": "string",
+              "description": "Use with JWT to specify the organization ID"
+            }
+          },
+          "description": "header parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DAYTONA__LIST_WORKSPACES",
+    "description": "List all workspaces. Returns workspace details including ID, status, and configuration.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_WORKSPACES",
+      "canonical_tool_description_hash": "e6f8b2d0eaa47de8ff393627b55a534e664157f358b46ca91e2b7490aaf715ea",
+      "canonical_tool_input_schema_hash": "53df80557a6ed2d77a92a1d123c55de82375aa5e1228dc279fc84e17caceeb02"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "labels": {
+              "type": "string",
+              "description": "Filter workspaces by labels"
+            },
+            "verbose": {
+              "type": "boolean",
+              "description": "Include verbose output"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "X-Daytona-Organization-ID": {
+              "type": "string",
+              "description": "Use with JWT to specify the organization ID"
+            }
+          },
+          "description": "header parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DAYTONA__CREATE_WORKSPACE",
+    "description": "Create a new workspace in Daytona. Configure workspace settings for running AI-generated code in isolated environments.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_WORKSPACE",
+      "canonical_tool_description_hash": "341001327ce1fcfdefe378ebaa54eedc046dea5a1c71795136c02fb6963dea70",
+      "canonical_tool_input_schema_hash": "1d930fa58c3989cda7ff6825ea52a1c957f3f2424159b36325a2f1d8c160022d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name", "imageId"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the workspace"
+            },
+            "size": {
+              "type": "string",
+              "description": "Size of the workspace (e.g., 'small', 'medium', 'large')"
+            },
+            "labels": {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "description": "Labels to associate with the workspace",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "imageId": {
+              "type": "string",
+              "description": "ID of the image to use for the workspace"
+            },
+            "autoStop": {
+              "type": "integer",
+              "description": "Auto-stop interval in minutes"
+            }
+          },
+          "additionalProperties": true
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "X-Daytona-Organization-ID": {
+              "type": "string",
+              "description": "Use with JWT to specify the organization ID"
+            }
+          },
+          "description": "header parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DAYTONA__DELETE_WORKSPACE",
+    "description": "Delete a specific workspace by its ID. Permanently removes the workspace and all associated resources.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_WORKSPACE",
+      "canonical_tool_description_hash": "039814b7d9c0727d071a0800718fb35b610a589750e94e7c35336d2a1e2fc119",
+      "canonical_tool_input_schema_hash": "4a6f5c3bb729ccfe3f820391c26185e1554452db15af3562ea45e5f7b0c5e3e1"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["workspaceId"],
+          "properties": {
+            "workspaceId": {
+              "type": "string",
+              "description": "ID of the workspace"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["force"],
+          "properties": {
+            "force": {
+              "type": "boolean",
+              "description": "Force deletion of the workspace"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "X-Daytona-Organization-ID": {
+              "type": "string",
+              "description": "Use with JWT to specify the organization ID"
+            }
+          },
+          "description": "header parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DAYTONA__START_WORKSPACE",
+    "description": "Start a specific workspace by its ID. Initializes and starts the workspace environment.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "START_WORKSPACE",
+      "canonical_tool_description_hash": "9de5a311f9ab301075b14957eab51cc181372139c75b0c039287683bc0530914",
+      "canonical_tool_input_schema_hash": "cac97e4e2081159bedb8506b92b06a716ce7b01215dd1c57b3dbfeca83c40298"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["workspaceId"],
+          "properties": {
+            "workspaceId": {
+              "type": "string",
+              "description": "ID of the workspace"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "X-Daytona-Organization-ID": {
+              "type": "string",
+              "description": "Use with JWT to specify the organization ID"
+            }
+          },
+          "description": "header parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DAYTONA__STOP_WORKSPACE",
+    "description": "Stop a specific workspace by its ID. Shuts down the workspace environment to save resources.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "STOP_WORKSPACE",
+      "canonical_tool_description_hash": "3139a88025763acc1fb8dde693daa83565552846fdd28872b64d6306f8f00dbc",
+      "canonical_tool_input_schema_hash": "cac97e4e2081159bedb8506b92b06a716ce7b01215dd1c57b3dbfeca83c40298"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["workspaceId"],
+          "properties": {
+            "workspaceId": {
+              "type": "string",
+              "description": "ID of the workspace"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "X-Daytona-Organization-ID": {
+              "type": "string",
+              "description": "Use with JWT to specify the organization ID"
+            }
+          },
+          "description": "header parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DAYTONA__EXECUTE_COMMAND",
+    "description": "Execute a command synchronously inside a workspace. Runs shell commands and returns the output.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EXECUTE_COMMAND",
+      "canonical_tool_description_hash": "4919cc38ca8593e04b7cc6c45345aa6ee442d5353c6e6e44a1bbc103c20bf87d",
+      "canonical_tool_input_schema_hash": "55103f9bcf768debd994e7df6c2d845a1fb514dd4349a8f9543435447b5d0913"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["command"],
+          "properties": {
+            "cwd": {
+              "type": "string",
+              "description": "The working directory for command execution"
+            },
+            "env": {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "description": "Environment variables for the command",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "command": {
+              "type": "string",
+              "description": "The command to execute in the workspace"
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "Timeout in seconds for the command execution"
+            }
+          },
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["workspaceId"],
+          "properties": {
+            "workspaceId": {
+              "type": "string",
+              "description": "ID of the workspace where the command will be executed"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "X-Daytona-Organization-ID": {
+              "type": "string",
+              "description": "Use with JWT to specify the organization ID"
+            }
+          },
+          "description": "header parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/dexscreener/tools.json
+++ b/backend/mcp_servers/dexscreener/tools.json
@@ -1,0 +1,211 @@
+[
+  {
+    "name": "DEXSCREENER__GET_PAIRS_BY_ADDRESS",
+    "description": "Get one or multiple pairs by chain and pair address. Rate-limited to 300 requests per minute.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PAIRS_BY_ADDRESS",
+      "canonical_tool_description_hash": "f643eb0f404596bf3100acba09a30a6b383dca42f8c45a568daf757de1a0ac06",
+      "canonical_tool_input_schema_hash": "7f978beb7e4d12e3db988c7713acdb1cd55f7454be78d5ebabf7d4ba5d93186e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["chainId", "pairId"],
+          "properties": {
+            "pairId": {
+              "type": "string",
+              "description": "The pair address to retrieve"
+            },
+            "chainId": {
+              "type": "string",
+              "description": "The blockchain ID (e.g., 'solana', 'ethereum')"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DEXSCREENER__SEARCH_PAIRS",
+    "description": "Search for pairs matching a query. Rate-limited to 300 requests per minute.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_PAIRS",
+      "canonical_tool_description_hash": "361064927d5ec22cb50047f2bdb80fe7496f0141d728bbda99a87fbdf85c5101",
+      "canonical_tool_input_schema_hash": "ec044522a66515500e5d400c0e6521c719c959aa98103a5aa66f5b19b68844f3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "The search query (e.g., 'SOL/USDC')"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DEXSCREENER__GET_TOKEN_PROFILES",
+    "description": "Get the latest token profiles from DexScreener. Rate-limited to 60 requests per minute.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_TOKEN_PROFILES",
+      "canonical_tool_description_hash": "4779d48f244adc93a55b781cfa5f6b815934bcd8c09ab364ebb1906523b9649c",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DEXSCREENER__GET_TOKEN_BOOSTS",
+    "description": "Get the latest boosted tokens from DexScreener. Rate-limited to 60 requests per minute.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_TOKEN_BOOSTS",
+      "canonical_tool_description_hash": "865d13b9752d8e20eeeb5f5d23629f5545d2d6d093ecb9e076a26cf51ee94c75",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DEXSCREENER__GET_TOP_TOKEN_BOOSTS",
+    "description": "Get the tokens with most active boosts from DexScreener. Rate-limited to 60 requests per minute.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_TOP_TOKEN_BOOSTS",
+      "canonical_tool_description_hash": "627e752f9c8ea22135fc98f2be23b8e02296d84ea33f5e5ca3b83ad5c2e2c01b",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DEXSCREENER__CHECK_TOKEN_ORDERS",
+    "description": "Check orders paid for a specific token. Rate-limited to 60 requests per minute.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CHECK_TOKEN_ORDERS",
+      "canonical_tool_description_hash": "4b8f1a918c91b109d376a22f07342ba30abd7ac7b15f6091be99f284704fe259",
+      "canonical_tool_input_schema_hash": "36f937c566aeacbf5d66ab1e6ae42e67d230d4b508947607a45c4d86305a01f5"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["chainId", "tokenAddress"],
+          "properties": {
+            "chainId": {
+              "type": "string",
+              "description": "The blockchain ID (e.g., 'solana', 'ethereum')"
+            },
+            "tokenAddress": {
+              "type": "string",
+              "description": "The token address to check orders for"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DEXSCREENER__GET_TOKEN_POOLS",
+    "description": "Get the pools of a given token address. Rate-limited to 300 requests per minute.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_TOKEN_POOLS",
+      "canonical_tool_description_hash": "9f0ad39a46d8b32f363732cb1109934ab5b36c83c7a89ab508b1e969eeac97f4",
+      "canonical_tool_input_schema_hash": "52422370abb0c65a22c65be3a402d0bc6fe6c412a0dc93080a77571f11109a00"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["chainId", "tokenAddress"],
+          "properties": {
+            "chainId": {
+              "type": "string",
+              "description": "The blockchain ID (e.g., 'solana', 'ethereum')"
+            },
+            "tokenAddress": {
+              "type": "string",
+              "description": "The token address to get pools for"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DEXSCREENER__GET_PAIRS_BY_TOKEN",
+    "description": "Get one or multiple pairs by token address. Rate-limited to 300 requests per minute.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PAIRS_BY_TOKEN",
+      "canonical_tool_description_hash": "5b78564f7bb90d427e3cbafc7d5efe45a83deff5c2c85d69075ea5cb600d910d",
+      "canonical_tool_input_schema_hash": "364b84d3aeb2249243e5f4e8981d0c818c1e4c9b1a0b7b51dc0a93880c89baa2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["chainId", "tokenAddresses"],
+          "properties": {
+            "chainId": {
+              "type": "string",
+              "description": "The blockchain ID (e.g., 'solana', 'ethereum')"
+            },
+            "tokenAddresses": {
+              "type": "string",
+              "description": "One or multiple comma-separated token addresses (up to 30 addresses)"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/dify/tools.json
+++ b/backend/mcp_servers/dify/tools.json
@@ -1,0 +1,376 @@
+[
+  {
+    "name": "DIFY__SEND_CHAT_MESSAGE",
+    "description": "Send a chat message using the Dify API",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND_CHAT_MESSAGE",
+      "canonical_tool_description_hash": "f320702cca52e2a973b1607de847bf50501e0b73ad5599d598a22369c187f6d4",
+      "canonical_tool_input_schema_hash": "fd4c6a7368179703267e9b079371deaec79ee88bb86d2dd1f52bd0dfe47e1dd7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["query", "user"],
+          "properties": {
+            "user": {
+              "type": "string",
+              "example": "user_123456789",
+              "description": "Unique identifier for the user"
+            },
+            "files": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["type", "transfer_method", "url"],
+                "required": ["type", "transfer_method", "url"],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "description": "URL of the file if using remote_url transfer method"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "Type of the file (e.g., 'image', 'document')"
+                  },
+                  "transfer_method": {
+                    "type": "string",
+                    "description": "Method used to transfer the file (e.g., 'remote_url', 'local_file')"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "Files to be sent with the message"
+            },
+            "query": {
+              "type": "string",
+              "example": "What is the weather today?",
+              "description": "The query string to send to the chat"
+            },
+            "inputs": {
+              "type": "object",
+              "example": {
+                "device_type": "mobile",
+                "user_location": "New York",
+                "user_preference": "detailed specs",
+                "preferred_language": "English"
+              },
+              "required": [],
+              "properties": {
+                "device_type": {
+                  "type": "string",
+                  "example": "mobile",
+                  "description": "Type of device the user is using"
+                },
+                "user_location": {
+                  "type": "string",
+                  "example": "New York",
+                  "description": "User's geographical location information"
+                },
+                "user_preference": {
+                  "type": "string",
+                  "example": "detailed specs",
+                  "description": "User's preference settings"
+                },
+                "preferred_language": {
+                  "type": "string",
+                  "example": "English",
+                  "description": "User's preferred language"
+                }
+              },
+              "description": "Allows passing various variable values defined by the App. The inputs parameter contains multiple key/value pairs, where each key corresponds to a specific variable and each value is the specific value for that variable. Default {}",
+              "additionalProperties": true
+            },
+            "response_mode": {
+              "type": "string",
+              "default": "streaming",
+              "description": "Response mode - 'streaming' returns chunks as they're generated, 'blocking' returns complete response"
+            },
+            "conversation_id": {
+              "type": "string",
+              "example": "conv_123456789",
+              "description": "ID of the conversation to continue"
+            },
+            "auto_generate_name": {
+              "type": "boolean",
+              "default": true,
+              "description": "Automatically generate a title for the conversation"
+            }
+          },
+          "description": "Chat message parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DIFY__STOP_RESPONSE",
+    "description": "Stop a response for a given task ID",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "STOP_RESPONSE",
+      "canonical_tool_description_hash": "f5e95bf61e5dbcae182af415b385e25edce807250dce865eaea14b28adefcf33",
+      "canonical_tool_input_schema_hash": "91279f6cb61ad4ffd256ef7c43ac513a27c018208d749d58552aaef4624827d4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body", "path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["user"],
+          "properties": {
+            "user": {
+              "type": "string",
+              "example": "user_123456789",
+              "description": "Unique identifier for the user"
+            }
+          },
+          "description": "Parameters to stop the response",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["task_id"],
+          "properties": {
+            "task_id": {
+              "type": "string",
+              "example": "task_123456789",
+              "description": "ID of the task to stop"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DIFY__GET_CONVERSATION_LIST",
+    "description": "Retrieve a list of conversations for a user",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CONVERSATION_LIST",
+      "canonical_tool_description_hash": "929901fe0fe32fc0aca16cbd32ce7cfdb2cfd2119ecf65d073d0d6a0793ac249",
+      "canonical_tool_input_schema_hash": "7671d9a6a9f4d118499f00c834574ea1e159e4081fdfd6502975f3013afe444a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["user"],
+          "properties": {
+            "user": {
+              "type": "string",
+              "description": "User ID"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 20,
+              "description": "Limit on the number of conversations"
+            },
+            "last_id": {
+              "type": "string",
+              "description": "Last conversation ID for pagination"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DIFY__SEND_FEEDBACK",
+    "description": "Send feedback for a specific message",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND_FEEDBACK",
+      "canonical_tool_description_hash": "c23f99f911c100c6597a0a1290e937472a78b065a8dd92ba75aad0daf5ee82b2",
+      "canonical_tool_input_schema_hash": "d14f3a7f91b3822067fcafa5f010af1b25d2225275bfb78d9357d94f690f7f67"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body", "path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["rating", "user"],
+          "properties": {
+            "user": {
+              "type": "string",
+              "description": "User ID"
+            },
+            "rating": {
+              "type": "string",
+              "description": "Rating of the message"
+            },
+            "content": {
+              "type": "string",
+              "description": "Feedback content"
+            }
+          },
+          "description": "Feedback parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "ID of the message to send feedback for"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DIFY__DELETE_CONVERSATION",
+    "description": "Delete a specific conversation",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_CONVERSATION",
+      "canonical_tool_description_hash": "d494b0ef9c26915ad6ef7545595e04156520a93b4a0f4a0a3ee1b156cc7dda67",
+      "canonical_tool_input_schema_hash": "14dcccbea378c7f2deaefea894582104f8660d0bec1897bde5c2b09e158b3d88"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body", "path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["user"],
+          "properties": {
+            "user": {
+              "type": "string",
+              "description": "User ID"
+            }
+          },
+          "description": "Parameters for deleting the conversation",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["conversation_id"],
+          "properties": {
+            "conversation_id": {
+              "type": "string",
+              "description": "ID of the conversation to delete"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DIFY__GET_MESSAGES",
+    "description": "Retrieve a list of messages for a specific conversation",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_MESSAGES",
+      "canonical_tool_description_hash": "5fae11090f08fe17cabc4448c4c9435fcc85b1afba9b1747013c62b8ac461aef",
+      "canonical_tool_input_schema_hash": "f77049637e408ad598c319b79b03d4e5762a6a3b2212d8be1824bdb4ce3f8888"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["user"],
+          "properties": {
+            "user": {
+              "type": "string",
+              "description": "User ID"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 20,
+              "description": "Limit on the number of messages"
+            },
+            "first_id": {
+              "type": "string",
+              "description": "First message ID for pagination"
+            },
+            "conversation_id": {
+              "type": "string",
+              "description": "ID of the conversation to retrieve messages for"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "DIFY__UPDATE_CONVERSATION_NAME",
+    "description": "Update the name of a specific conversation",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_CONVERSATION_NAME",
+      "canonical_tool_description_hash": "13c4f658dcbd74af0b01367dc40fa1989cc227378233b5609c22ec824c263374",
+      "canonical_tool_input_schema_hash": "0e5f26c03c7c8dad6d21237060f7959aa9a2cbc148eec76b39c65ca3c3d99387"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body", "path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["user"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "example": "test",
+              "description": "New name for the conversation"
+            },
+            "user": {
+              "type": "string",
+              "example": "abc-123",
+              "description": "Unique identifier for the user"
+            },
+            "auto_generate": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether to automatically generate the name"
+            }
+          },
+          "description": "Parameters for updating the conversation name",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["conversation_id"],
+          "properties": {
+            "conversation_id": {
+              "type": "string",
+              "example": "1b12a04e-a4e9-47a1-869c-eb91da7e545a",
+              "description": "ID of the conversation to update"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/discord/tools.json
+++ b/backend/mcp_servers/discord/tools.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "DISCORD__GET_CURRENT_USER",
+    "description": "Get a user object for the current user.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CURRENT_USER",
+      "canonical_tool_description_hash": "c60412789b5fda01cd52e3bbbce334ac56ded8deefa039fda6226208552abcc8",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/eleven_labs/tools.json
+++ b/backend/mcp_servers/eleven_labs/tools.json
@@ -1,0 +1,532 @@
+[
+  {
+    "name": "ELEVEN_LABS__GET_VOICE_SETTINGS",
+    "description": "Retrieves the settings for a specific voice, including stability, similarity boost, style, speaker boost, and speed parameters.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_VOICE_SETTINGS",
+      "canonical_tool_description_hash": "9c56bdcc1ca425a9dd5232e48b8d7845eee00952d2133075b8b309c7d31fa073",
+      "canonical_tool_input_schema_hash": "dc6a6055102ba25f7a40b3910b700ef351638215864717afc06bbc59a83fe30d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["voice_id"],
+          "properties": {
+            "voice_id": {
+              "type": "string",
+              "description": "The ID of the voice whose settings are to be retrieved. Use the Get Voices endpoint to list all available voices."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ELEVEN_LABS__CREATE_SPEECH",
+    "description": "Converts text into speech using a specified voice and returns base64-encoded audio in the specified output format (see output_format).",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_SPEECH",
+      "canonical_tool_description_hash": "bef466418d761789622ea22f6c28f229e05434936aa3710a8fff360c00720ef4",
+      "canonical_tool_input_schema_hash": "e10320fc25d8c003206f95af5bb5d2168621f93c63bdedc30c0f6b57982b5f54"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["voice_id", "text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The text that will be converted into speech."
+        },
+        "model_id": {
+          "type": "string",
+          "default": "eleven_multilingual_v2",
+          "description": "Identifier of the model that will be used. Defaults to eleven_multilingual_v2."
+        },
+        "voice_id": {
+          "type": "string",
+          "description": "ID of the voice to be used. Use the List voices endpoint to find available voices."
+        },
+        "output_format": {
+          "enum": [
+            "mp3_22050_32",
+            "mp3_44100_32",
+            "mp3_44100_64",
+            "mp3_44100_96",
+            "mp3_44100_128",
+            "mp3_44100_192",
+            "pcm_8000",
+            "pcm_16000",
+            "pcm_22050",
+            "pcm_24000",
+            "pcm_44100",
+            "pcm_48000",
+            "ulaw_8000",
+            "alaw_8000",
+            "opus_48000_32",
+            "opus_48000_64",
+            "opus_48000_96",
+            "opus_48000_128",
+            "opus_48000_192"
+          ],
+          "type": "string",
+          "default": "mp3_44100_128",
+          "description": "Output format of the generated audio. Formatted as codec_sample_rate_bitrate. So an mp3 with 22.05kHz sample rate at 32kbs is represented as mp3_22050_32. MP3 with 192kbps bitrate requires you to be subscribed to Creator tier or above. PCM with 44.1kHz sample rate requires you to be subscribed to Pro tier or above. Note that the \u03bc-law format (sometimes written mu-law, often approximated as u-law) is commonly used for Twilio audio inputs."
+        },
+        "voice_settings": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "speed": {
+              "type": "number",
+              "maximum": 1.2,
+              "minimum": 0.7,
+              "description": "Controls the speed of the voice output."
+            },
+            "style": {
+              "type": "number",
+              "maximum": 1,
+              "minimum": 0,
+              "description": "Controls the style of the voice output."
+            },
+            "stability": {
+              "type": "number",
+              "maximum": 1,
+              "minimum": 0,
+              "description": "Controls the stability of the voice output."
+            },
+            "similarity_boost": {
+              "type": "number",
+              "maximum": 1,
+              "minimum": 0,
+              "description": "Controls the similarity boost of the voice output."
+            },
+            "use_speaker_boost": {
+              "type": "boolean",
+              "description": "Whether to use speaker boost."
+            }
+          },
+          "description": "Voice settings overriding stored settings for the given voice. They are applied only on the given request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ELEVEN_LABS__LIST_VOICES",
+    "description": "Retrieves a list of all available voices for a user with search, filtering, and pagination capabilities.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_VOICES",
+      "canonical_tool_description_hash": "01816ec31b7d65815d8c48a7558dae24ff3add2dbb8eb597e1d0d4657e2296c9",
+      "canonical_tool_input_schema_hash": "93bede50c1b6b59329bfcfc25e971af2ab2b5eacacd422254c3727c592e17356"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "sort": {
+              "type": "string",
+              "description": "Field by which to sort the results."
+            },
+            "search": {
+              "type": "string",
+              "description": "Search term to filter voices by name."
+            },
+            "category": {
+              "type": "string",
+              "description": "Category to filter voices."
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "Number of results to return per page."
+            },
+            "voice_type": {
+              "type": "string",
+              "description": "Type of voice to filter results."
+            },
+            "sort_direction": {
+              "type": "string",
+              "description": "Direction of sorting, either 'asc' or 'desc'."
+            },
+            "next_page_token": {
+              "type": "string",
+              "description": "Token for fetching the next page of results."
+            },
+            "fine_tuning_state": {
+              "type": "string",
+              "description": "Filter voices by their fine-tuning state."
+            },
+            "include_total_count": {
+              "type": "boolean",
+              "default": true,
+              "description": "Indicates whether to include the total count of voices in the response."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ELEVEN_LABS__EDIT_VOICE_SETTINGS",
+    "description": "Edits the settings for a specific voice, including parameters such as stability, similarity boost, style, speaker boost, and speed.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EDIT_VOICE_SETTINGS",
+      "canonical_tool_description_hash": "68a48f0ca9c257ff3ea71bb107fba0e299853ee5239155959125c6d0157a3cd6",
+      "canonical_tool_input_schema_hash": "1c766f523974a76efaa2d745103bd1dd1356b0da277448c55ef2ffaa8d689994"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "header", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "speed": {
+              "type": "number",
+              "default": 1.0,
+              "maximum": 1.2,
+              "minimum": 0.7,
+              "description": "Controls the speed of the generated speech. Values range from 0.7 to 1.2, with 1.0 being the default speed. Lower values create slower, more deliberate speech while higher values produce faster-paced speech. Extreme values can impact the quality of the generated speech."
+            },
+            "style": {
+              "type": "number",
+              "maximum": 1,
+              "minimum": 0,
+              "description": "Determines the style exaggeration of the voice. This setting attempts to amplify the style of the original speaker. It does consume additional computational resources and might increase latency if set to anything other than 0."
+            },
+            "stability": {
+              "type": "number",
+              "maximum": 1,
+              "minimum": 0,
+              "description": "Determines how stable the voice is and the randomness between each generation. Lower values introduce a broader emotional range for the voice. Higher values can result in a monotonous voice with limited emotion."
+            },
+            "similarity_boost": {
+              "type": "number",
+              "maximum": 1,
+              "minimum": 0,
+              "description": "Determines how closely the AI should adhere to the original voice when attempting to replicate it."
+            },
+            "use_speaker_boost": {
+              "type": "boolean",
+              "description": "This setting boosts the similarity to the original speaker. Using this setting requires a slightly higher computational load, which in turn increases latency."
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["voice_id"],
+          "properties": {
+            "voice_id": {
+              "type": "string",
+              "description": "The ID of the voice whose settings are to be edited. Use the Get Voices endpoint to list all available voices."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": ["Content-Type"],
+          "properties": {
+            "Content-Type": {
+              "type": "string",
+              "default": "application/json",
+              "description": "The content type of the request, typically application/json."
+            }
+          },
+          "description": "Header parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ELEVEN_LABS__STREAM_TEXT_TO_SPEECH",
+    "description": "Converts text into speech using a selected voice and returns the result as a streamed audio response.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "STREAM_TEXT_TO_SPEECH",
+      "canonical_tool_description_hash": "e2970ed7a6fdfc0d4652dce3ea6cb87529041718fc62b443f774eae877309cb0",
+      "canonical_tool_input_schema_hash": "5858c646d9fcaadac7471c27565519a2068ad7a1b0f1ca60d3adfea5756dec94"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "header", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["text"],
+          "properties": {
+            "seed": {
+              "type": "integer",
+              "description": "Used for deterministic audio generation"
+            },
+            "text": {
+              "type": "string",
+              "description": "Text to convert to speech"
+            },
+            "model_id": {
+              "type": "string",
+              "description": "Model to use for speech synthesis"
+            },
+            "next_text": {
+              "type": "string",
+              "description": "Next text for continuity"
+            },
+            "language_code": {
+              "type": "string",
+              "description": "ISO 639-1 language code to enforce a language"
+            },
+            "previous_text": {
+              "type": "string",
+              "description": "Previous text for continuity"
+            },
+            "use_pvc_as_ivc": {
+              "type": "boolean",
+              "description": "Use IVC version instead of PVC (deprecated)"
+            },
+            "voice_settings": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "speed": {
+                  "type": "number",
+                  "maximum": 2.0,
+                  "minimum": 0.5,
+                  "description": "Controls the speed of the voice output."
+                },
+                "style": {
+                  "type": "number",
+                  "maximum": 1,
+                  "minimum": 0,
+                  "description": "Controls the style of the voice output."
+                },
+                "stability": {
+                  "type": "number",
+                  "maximum": 1,
+                  "minimum": 0,
+                  "description": "Controls the stability of the voice output."
+                },
+                "similarity_boost": {
+                  "type": "number",
+                  "maximum": 1,
+                  "minimum": 0,
+                  "description": "Controls the similarity boost of the voice output."
+                },
+                "use_speaker_boost": {
+                  "type": "boolean",
+                  "description": "Whether to use speaker boost."
+                }
+              },
+              "description": "Custom voice settings",
+              "additionalProperties": false
+            },
+            "next_request_ids": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "IDs of subsequent audio requests"
+            },
+            "previous_request_ids": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "IDs of previous audio requests"
+            },
+            "apply_text_normalization": {
+              "enum": ["auto", "on", "off"],
+              "type": "string",
+              "description": "Controls text normalization"
+            },
+            "apply_language_text_normalization": {
+              "type": "boolean",
+              "description": "Language-specific text normalization"
+            },
+            "pronunciation_dictionary_locators": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "version_id": {
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "Pronunciation dictionaries to apply"
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["voice_id"],
+          "properties": {
+            "voice_id": {
+              "type": "string",
+              "description": "ID of the voice to be used"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "output_format": {
+              "type": "string",
+              "description": "Audio format (e.g., mp3_44100_128)"
+            },
+            "enable_logging": {
+              "type": "boolean",
+              "description": "Enable request logging. When false, zero retention mode is used."
+            },
+            "optimize_streaming_latency": {
+              "type": "integer",
+              "description": "Latency optimization level (0\u20134). Deprecated."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "Content-Type": {
+              "type": "string",
+              "default": "application/json"
+            }
+          },
+          "description": "Header parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ELEVEN_LABS__SPEECH_TO_SPEECH_CONVERT",
+    "description": "Transforms audio from one voice to another while maintaining full control over emotion, timing, and delivery.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SPEECH_TO_SPEECH_CONVERT",
+      "canonical_tool_description_hash": "90f27b02ab5617be02ce27310c81999cdfe9069b8447f8a6917782b2811f4587",
+      "canonical_tool_input_schema_hash": "eede9af4c57c0222c4d2407dbda84990fc14aab4918f30d7a9cc4d0c45db4247"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "header", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["audio"],
+          "properties": {
+            "seed": {
+              "type": "integer",
+              "description": "If specified, the system will attempt to sample deterministically, such that repeated requests with the same seed and parameters should return the same result. Determinism is not guaranteed. Must be an integer between 0 and 4294967295."
+            },
+            "audio": {
+              "type": "string",
+              "format": "binary",
+              "description": "The audio file which holds the content and emotion that will control the generated speech."
+            },
+            "model_id": {
+              "type": "string",
+              "default": "eleven_english_sts_v2",
+              "description": "Identifier of the model to be used. You can query available models using GET /v1/models. The model needs to support speech-to-speech, which can be checked using the can_do_voice_conversion property."
+            },
+            "voice_settings": {
+              "type": "string",
+              "description": "Voice settings overriding stored settings for the given voice. Applied only to the current request. Needs to be sent as a JSON-encoded string."
+            },
+            "remove_background_noise": {
+              "type": "boolean",
+              "default": false,
+              "description": "If set, will remove the background noise from your audio input using the audio isolation model. Only applies to Voice Changer."
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["voice_id"],
+          "properties": {
+            "voice_id": {
+              "type": "string",
+              "description": "ID of the voice to be used. Use the Get voices endpoint to list all available voices."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "output_format": {
+              "enum": ["mp3_44100_128", "mp3_22050_32", "mp3_44100_192", "pcm_44100", "mulaw_8000"],
+              "type": "string",
+              "default": "mp3_44100_128",
+              "description": "Output format of the generated audio, formatted as codec_sample_rate_bitrate. For example, 'mp3_22050_32' represents an MP3 with a 22.05kHz sample rate at 32kbps. Some formats require specific subscription tiers."
+            },
+            "enable_logging": {
+              "type": "boolean",
+              "default": true,
+              "description": "When set to false, zero retention mode will be used for the request, making history features unavailable. Zero retention mode may only be used by enterprise customers."
+            },
+            "optimize_streaming_latency": {
+              "type": "integer",
+              "deprecated": true,
+              "description": "Latency optimization level. Deprecated. Possible values: 0 (default mode, no latency optimizations), 1 (normal latency optimizations), 2 (strong latency optimizations), 3 (max latency optimizations), 4 (max latency optimizations with text normalizer turned off)."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": ["Content-Type"],
+          "properties": {
+            "Content-Type": {
+              "type": "string",
+              "default": "multipart/form-data",
+              "description": "Content type of the request."
+            }
+          },
+          "description": "Header parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/feishu/tools.json
+++ b/backend/mcp_servers/feishu/tools.json
@@ -1,0 +1,289 @@
+[
+  {
+    "name": "FEISHU__SEND_MESSAGE",
+    "description": "Send a message to a Feishu user or chat using their open_id.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND_MESSAGE",
+      "canonical_tool_description_hash": "8fa7bbc59c4edd6128b475d513de25cec25dc3e949830906992292acc33389e5",
+      "canonical_tool_input_schema_hash": "481af6e165801bcf65fccf09bebbde94942acdda9186884a5f710e8f2e43bf3b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["receive_id", "msg_type", "content"],
+          "properties": {
+            "uuid": {
+              "type": "string",
+              "description": "Optional unique identifier for the message"
+            },
+            "content": {
+              "type": "string",
+              "description": "JSON string of the message content. For text messages, use format: {\"text\":\"your message\"}"
+            },
+            "msg_type": {
+              "enum": ["text", "post", "image", "file", "audio", "media", "sticker", "interactive"],
+              "type": "string",
+              "default": "text",
+              "description": "Type of the message"
+            },
+            "receive_id": {
+              "type": "string",
+              "description": "ID of the message receiver"
+            }
+          },
+          "description": "Body parameters for the message request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["receive_id_type"],
+          "properties": {
+            "receive_id_type": {
+              "enum": ["open_id", "user_id", "union_id", "email", "chat_id"],
+              "type": "string",
+              "default": "open_id",
+              "description": "Type of the receive_id, e.g., 'open_id', 'user_id', 'union_id', 'email', or 'chat_id'"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FEISHU__REPLY_MESSAGE",
+    "description": "Reply to a specific message in Feishu",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REPLY_MESSAGE",
+      "canonical_tool_description_hash": "b65df41994f4af57a61284e1efa62f9dbec4ee6ddda2c30cf023991a1a171561",
+      "canonical_tool_input_schema_hash": "732e5eaa1ebca382384d9b96d29b396bff4c7d6e5b3f1e2f0fac700f26e357ac"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body", "path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["content", "msg_type"],
+          "properties": {
+            "uuid": {
+              "type": "string",
+              "example": "a0d69e20-1dd1-458b-k525-dfeca4015204",
+              "description": "Custom unique string for deduplication. Requests with the same uuid will only successfully reply one message within 1 hour."
+            },
+            "content": {
+              "type": "string",
+              "example": "{\"text\":\"test content\"}",
+              "description": "Message content in JSON format. The value should correspond to msg_type. For example, if msg_type is 'text', this should be a text content in JSON format."
+            },
+            "msg_type": {
+              "type": "string",
+              "example": "text",
+              "description": "Type of the message. Options: text, post, image, file, audio, media, sticker, interactive, share_chat, share_user"
+            },
+            "reply_in_thread": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to reply in thread format"
+            }
+          },
+          "description": "Message reply parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "example": "om_dc13264520392913993dd051dba21dcf",
+              "description": "ID of the message to reply to"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FEISHU__EDIT_MESSAGE",
+    "description": "Edit an existing message in Feishu",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EDIT_MESSAGE",
+      "canonical_tool_description_hash": "c2279cef812be9e0717b5acf5b615f751eb5078d4ef08503e8d6b3fe889aed78",
+      "canonical_tool_input_schema_hash": "72f3595afc1baf8dc58ad672d3c9bdee4027ffdb5100dd64575dfa4e73b5d3c8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["msg_type", "content"],
+          "properties": {
+            "content": {
+              "type": "string",
+              "description": "JSON string of the message content. For text messages, use format: {\"text\":\"your message\"}"
+            },
+            "msg_type": {
+              "enum": ["text", "post"],
+              "type": "string",
+              "default": "text",
+              "description": "Type of the message"
+            }
+          },
+          "description": "Body parameters for the edit request",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "ID of the message to edit"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FEISHU__FORWARD_MESSAGE",
+    "description": "Forward a message to another user or chat in Feishu",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "FORWARD_MESSAGE",
+      "canonical_tool_description_hash": "82018a5be35d02a3a31a8daa6d96fd2e4824103a47be21000c59c32de0ee5416",
+      "canonical_tool_input_schema_hash": "2a705a29ef8c3af4b92af716de1e47564d35b616bf1e4bed7848746146c6ee5a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["receive_id"],
+          "properties": {
+            "receive_id": {
+              "type": "string",
+              "example": "ou_a0553eda9014c201e6969b478895c230",
+              "description": "ID of the message receiver, must match the type specified in receive_id_type"
+            }
+          },
+          "description": "Body parameters for the forward request",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "example": "om_dc13264520392913993dd051dba21dcf",
+              "description": "ID of the message to forward. Can be obtained from: 1) Response of send message API, 2) Message event, 3) Get chat history API"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["receive_id_type"],
+          "properties": {
+            "uuid": {
+              "type": "string",
+              "example": "b13g2t38-1jd2-458b-8djf-dtbca5104204",
+              "maxLength": 50,
+              "description": "Custom unique string for deduplication. Requests with the same uuid will only successfully forward one message within 1 hour"
+            },
+            "receive_id_type": {
+              "enum": ["open_id", "user_id", "union_id", "email", "chat_id", "thread_id"],
+              "type": "string",
+              "default": "open_id",
+              "example": "open_id",
+              "description": "Type of the receive_id. Options: open_id, user_id, union_id, email, chat_id, thread_id"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FEISHU__MERGE_FORWARD_MESSAGE",
+    "description": "Merge and forward multiple messages to another user or chat in Feishu",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "MERGE_FORWARD_MESSAGE",
+      "canonical_tool_description_hash": "0976dcfb53622f7cdd24237952699ddf20fe709901a7f784cd4af721e9a977c1",
+      "canonical_tool_input_schema_hash": "ad679081ad673384c0f4c5baa0071c734cb7713e2039e5d7d6f3fa63c7ef363c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["receive_id", "message_id_list"],
+          "properties": {
+            "receive_id": {
+              "type": "string",
+              "example": "oc_a0553eda9014c201e6969b478895c230",
+              "description": "ID of the message receiver, must match the type specified in receive_id_type"
+            },
+            "message_id_list": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "example": ["om_dc13264520392913993dd051dba21dcf"],
+              "maxItems": 100,
+              "minItems": 1,
+              "description": "List of message IDs to forward. All messages must be from the same chat. IDs can be obtained from: 1) Response of send message API, 2) Message event, 3) Get chat history API"
+            }
+          },
+          "description": "Body parameters for the merge forward request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["receive_id_type"],
+          "properties": {
+            "uuid": {
+              "type": "string",
+              "example": "b13g2t38-1jd2-458b-8djf-dtbca5104204",
+              "maxLength": 50,
+              "description": "Custom unique string for deduplication. Requests with the same uuid will only successfully merge forward one message within 1 hour"
+            },
+            "receive_id_type": {
+              "enum": ["open_id", "user_id", "union_id", "email", "chat_id", "thread_id"],
+              "type": "string",
+              "default": "open_id",
+              "example": "open_id",
+              "description": "Type of the receive_id. Options: open_id, user_id, union_id, email, chat_id, thread_id"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/figma/tools.json
+++ b/backend/mcp_servers/figma/tools.json
@@ -1,0 +1,409 @@
+[
+  {
+    "name": "FIGMA__GET_FILE",
+    "description": "Retrieves the document structure of a Figma file based on the given file key. Returns the entire document as JSON including nodes, their names, and types.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_FILE",
+      "canonical_tool_description_hash": "e7bfdda68715e4cfacb4115d33a05d7d595a261d231e875c893c8a1d0c820cf8",
+      "canonical_tool_input_schema_hash": "604072b6d518e674a3fb27c1207bb06e3348c331215631102cf5d7754f1aabcd"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["file_key"],
+          "properties": {
+            "file_key": {
+              "type": "string",
+              "description": "The key of the file to retrieve."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "ids": {
+              "type": "string",
+              "description": "Comma-separated list of node IDs to include in the response."
+            },
+            "depth": {
+              "type": "integer",
+              "description": "Depth to traverse the node tree. Default is 1."
+            },
+            "version": {
+              "type": "string",
+              "description": "Specific version ID to retrieve. If not provided, the latest version is returned."
+            },
+            "geometry": {
+              "type": "string",
+              "description": "Set to 'paths' to include vector geometry data."
+            },
+            "branch_data": {
+              "type": "boolean",
+              "description": "Whether to include metadata about branches. Default is false."
+            },
+            "plugin_data": {
+              "type": "string",
+              "description": "Comma-separated list of plugin IDs to retrieve plugin data for."
+            }
+          },
+          "description": "Optional query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FIGMA__GET_FILE_NODES",
+    "description": "Retrieves the nodes present in a Figma file based on the given file key and node IDs.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_FILE_NODES",
+      "canonical_tool_description_hash": "a91594b56409f4c9ef875f788b85bd4452907c0027975940d6189ce55339e28e",
+      "canonical_tool_input_schema_hash": "ff06220cf226a0b08d68930d36a289b682720081ea47400ad3cba9241656adac"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["file_key"],
+          "properties": {
+            "file_key": {
+              "type": "string",
+              "description": "The key of the file containing the nodes."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["ids"],
+          "properties": {
+            "ids": {
+              "type": "string",
+              "description": "Comma-separated list of node IDs to retrieve."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FIGMA__GET_IMAGE",
+    "description": "Retrieves images rendered from a Figma file based on the given file key and node IDs.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_IMAGE",
+      "canonical_tool_description_hash": "1f77cad21fa6fc3aeb508c0a07b830417bc1bdee35f08a2bc0a9c67edae36dc6",
+      "canonical_tool_input_schema_hash": "dfe9c04dd601c415eb9d10138aec3160fb4208a44e3c29f8021174bf21d7e3d9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["file_key"],
+          "properties": {
+            "file_key": {
+              "type": "string",
+              "description": "The key of the file containing the images."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["ids"],
+          "properties": {
+            "ids": {
+              "type": "string",
+              "description": "Comma-separated list of node IDs to render."
+            },
+            "scale": {
+              "type": "number",
+              "description": "Scale factor for the rendered images. Defaults to 1."
+            },
+            "format": {
+              "type": "string",
+              "description": "Image format to return. Options are 'jpg', 'png', 'svg', etc."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FIGMA__GET_FILE_VERSIONS",
+    "description": "Retrieves the version history of a Figma file based on the given file key.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_FILE_VERSIONS",
+      "canonical_tool_description_hash": "a0570a5781825158126d5f117d01ffbb29ee1eef75f60bfdfd54d395ee7f90a5",
+      "canonical_tool_input_schema_hash": "b0e79392362f8df725afd63b444b33424b7a810c32efd4e26385021abe7d96f5"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["file_key"],
+          "properties": {
+            "file_key": {
+              "type": "string",
+              "description": "The key of the file whose versions are to be retrieved."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FIGMA__GET_TEAM_PROJECTS",
+    "description": "Retrieves a list of projects within a team based on the given team ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_TEAM_PROJECTS",
+      "canonical_tool_description_hash": "0a077e3d95e32ea39ff6bc1eb304f10b5c4d303ce4630e591b18ca76c3acb7b0",
+      "canonical_tool_input_schema_hash": "f2ba1c98c0e00a2133566513a66385a64998ab492cbcd2a8c1e81eceda22f2ff"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The ID of the team to retrieve projects from."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FIGMA__GET_PROJECT_FILES",
+    "description": "Lists the files in a given project based on the project ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PROJECT_FILES",
+      "canonical_tool_description_hash": "87643a2b04ba86ec2bacc697f321f0c1d2298c71e2f5b2204c90a73662d17f8b",
+      "canonical_tool_input_schema_hash": "068762ab360d11b8868989057708bb785af09d00c00d43fb8591c8b4e0388a4b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["project_id"],
+          "properties": {
+            "project_id": {
+              "type": "string",
+              "description": "The ID of the project whose files should be listed."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FIGMA__GET_COMMENTS",
+    "description": "Retrieves all comments from a Figma file, including their content and author information.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_COMMENTS",
+      "canonical_tool_description_hash": "8ae2652cc2a4544b15ab5e8fb7a54d8d217bc793b4f04c067ff0970667f247e0",
+      "canonical_tool_input_schema_hash": "9b2799b2c69193f6df28c1c7923723c697f4662aa2690e17aef2d0bc516f6fd7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["file_key"],
+          "properties": {
+            "file_key": {
+              "type": "string",
+              "description": "The key of the file whose comments are to be retrieved."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FIGMA__GET_IMAGE_FILLS",
+    "description": "Returns download links for all images present in image fills in a document.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_IMAGE_FILLS",
+      "canonical_tool_description_hash": "49b672fefe87f92913546241d201ac0aa10595e3b7116bf00654e06a96230aab",
+      "canonical_tool_input_schema_hash": "9a05b499010900a6edea57f85acc531e2c7532bce6a30ebe07979315e35e244c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["file_key"],
+          "properties": {
+            "file_key": {
+              "type": "string",
+              "description": "The key of the file to get image fills from."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FIGMA__GET_FILE_COMPONENT_SETS",
+    "description": "Returns a list of component sets in a file, indicating which components belong to which component set.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_FILE_COMPONENT_SETS",
+      "canonical_tool_description_hash": "2b5c3f1f58a371e91ce23aaa022de4a0bce6f539c2013c52bdf22355dc635f65",
+      "canonical_tool_input_schema_hash": "195fcb5fbf16192dec89f42e6c33026f7cb76fe969cad1f8adcf138b44875128"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["file_key"],
+          "properties": {
+            "file_key": {
+              "type": "string",
+              "description": "The key of the file to get component sets from."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FIGMA__GET_STYLE",
+    "description": "Retrieves a specific style node from a Figma file based on the given file key and node ID. Returns detailed information about the style, including its properties and metadata.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_STYLE",
+      "canonical_tool_description_hash": "29e5494244a439b522ac97307ad5e616d1534a70c315593dac03696d39ed5284",
+      "canonical_tool_input_schema_hash": "437dcad053bbd405fad514b6dc36fc0083107a56d6a248863ff7fb3d84ca5505"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["file_key"],
+          "properties": {
+            "file_key": {
+              "type": "string",
+              "description": "The key of the file containing the style."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["ids"],
+          "properties": {
+            "ids": {
+              "type": "string",
+              "description": "The ID of the style node to retrieve."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "FIGMA__GET_COMPONENT",
+    "description": "Retrieves a specific component node from a Figma file based on the given file key and node ID. Returns detailed information about the component, including its properties and metadata.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_COMPONENT",
+      "canonical_tool_description_hash": "e536b07ae03af7bfa360fb11be7be5fbfc8c98b0b75adaab24b5099bfc4cb82a",
+      "canonical_tool_input_schema_hash": "b2a5eb2d46842f78fa345e85c45902469eb1f35a5d3c27640860b3d584480af8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["file_key"],
+          "properties": {
+            "file_key": {
+              "type": "string",
+              "description": "The key of the file containing the component."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["ids"],
+          "properties": {
+            "ids": {
+              "type": "string",
+              "description": "The ID of the component node to retrieve."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/gmail/tools.json
+++ b/backend/mcp_servers/gmail/tools.json
@@ -101,5 +101,828 @@
       },
       "additionalProperties": false
     }
+  },
+  {
+    "name": "GMAIL__MESSAGES_GET",
+    "description": "Gets the specified message",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "MESSAGES_GET",
+      "canonical_tool_description_hash": "b52644cad4cab0d73fc4c6115662f26eb494936e368c310d19d00283b7992a81",
+      "canonical_tool_input_schema_hash": "f229f219dd59d6ae2434245c7e08c737f5578828777db26e3f4de0687519bf44"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the message to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["format"],
+          "properties": {
+            "format": {
+              "enum": ["full", "metadata", "minimal", "raw"],
+              "type": "string",
+              "default": "full",
+              "description": "The format to return the message in"
+            },
+            "metadataHeaders": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "When given and format is metadata, only include headers specified"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__MESSAGES_TRASH",
+    "description": "Moves the specified message to the trash",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "MESSAGES_TRASH",
+      "canonical_tool_description_hash": "8b90c9f7bef19dc8f4353df451fd2a6aaf28062fca5043b2587b80a18237e602",
+      "canonical_tool_input_schema_hash": "796b02d49e49564ef27d9c4f5add6508da5ffbe20bfa70b0f6868bf1e78662d8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the message to trash"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__MESSAGES_UNTRASH",
+    "description": "Removes the specified message from the trash",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "MESSAGES_UNTRASH",
+      "canonical_tool_description_hash": "60d9ec7f245619ee65f38d72683624829d55feeb8ddd196defe46816f8b590ef",
+      "canonical_tool_input_schema_hash": "622e84ddaa5439533f4aa9a10f1d37e0da08842dc4c401103dc7b73a97a4a792"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the message to untrash"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__LABELS_LIST",
+    "description": "Lists all labels in the user's mailbox",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LABELS_LIST",
+      "canonical_tool_description_hash": "71ea62684c970faf8aa2734f89e774615c619f048a4b30ffaefb658c6fada120",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__LABELS_GET",
+    "description": "Gets the specified label",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LABELS_GET",
+      "canonical_tool_description_hash": "d2ed992a4987e218c845964cebe368b0e68de2cc53f45ac2d1521ab02ab8a3ae",
+      "canonical_tool_input_schema_hash": "c13602b55bf3a8bb109a1a57c442987ad2023b68b0e3e96ee104719c5ad3ac8c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the label to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__DRAFTS_GET",
+    "description": "Gets the specified draft",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DRAFTS_GET",
+      "canonical_tool_description_hash": "d51acf1d5b7fdf1470e05938eae06fd4c7efeb6aa56fff60d1ac437efa47182f",
+      "canonical_tool_input_schema_hash": "f36de29c5357752693adc5017d88baefa781adcb36539d214c9342e335520b93"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the draft to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "format": {
+              "enum": ["full", "metadata", "minimal", "raw"],
+              "type": "string",
+              "default": "full",
+              "description": "The format to return the draft message in"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__LABELS_CREATE",
+    "description": "Creates a new label",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LABELS_CREATE",
+      "canonical_tool_description_hash": "08d4e6cd81d85ed70d4f5c885144eb511a0af946779e4347578ba530b84d83e7",
+      "canonical_tool_input_schema_hash": "392d7b9abab991e1155e4f273bd3764caf5dbbf5f665498fee88a3ed686463ff"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The display name of the label"
+            },
+            "color": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "textColor": {
+                  "type": "string",
+                  "description": "The text color of the label"
+                },
+                "backgroundColor": {
+                  "type": "string",
+                  "description": "The background color of the label"
+                }
+              },
+              "description": "The color to assign to the label",
+              "additionalProperties": false
+            },
+            "labelListVisibility": {
+              "enum": ["labelHide", "labelShow", "labelShowIfUnread"],
+              "type": "string",
+              "default": "labelShow",
+              "description": "The visibility of the label in the label list in the Gmail web interface"
+            },
+            "messageListVisibility": {
+              "enum": ["hide", "show"],
+              "type": "string",
+              "default": "show",
+              "description": "The visibility of the label in the message list in the Gmail web interface"
+            }
+          },
+          "description": "Label data",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__LABELS_UPDATE",
+    "description": "Updates the specified label",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LABELS_UPDATE",
+      "canonical_tool_description_hash": "1bdd2fde243eb4e395c06454f06a246336ba1607730cdc69e1c7c226e1e66dc8",
+      "canonical_tool_input_schema_hash": "f387c5997e5a7245ee0fc4f80ebf23e913b046891b979680dbdf559550ac9adb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The display name of the label"
+            },
+            "color": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "textColor": {
+                  "type": "string",
+                  "description": "The text color of the label"
+                },
+                "backgroundColor": {
+                  "type": "string",
+                  "description": "The background color of the label"
+                }
+              },
+              "description": "The color to assign to the label",
+              "additionalProperties": false
+            },
+            "labelListVisibility": {
+              "enum": ["labelHide", "labelShow", "labelShowIfUnread"],
+              "type": "string",
+              "description": "The visibility of the label in the label list in the Gmail web interface"
+            },
+            "messageListVisibility": {
+              "enum": ["hide", "show"],
+              "type": "string",
+              "description": "The visibility of the label in the message list in the Gmail web interface"
+            }
+          },
+          "description": "Label data",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the label to update"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__LABELS_DELETE",
+    "description": "Deletes the specified label",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LABELS_DELETE",
+      "canonical_tool_description_hash": "e7ba895c9695628c7b974ba5387f6afdb4635d4040e10e2350f03002fec31a3b",
+      "canonical_tool_input_schema_hash": "234a17c784397fd8680af114ff4a41dc5082c9172da97c8dc8617e3c9e53761f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the label to delete"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__MESSAGES_MODIFY",
+    "description": "Modifies the labels on the specified message",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "MESSAGES_MODIFY",
+      "canonical_tool_description_hash": "c2d311447a7dcb1bedc210b937d2c7a79329477a0daebe82d7c0a2b6ee776622",
+      "canonical_tool_input_schema_hash": "4152c20e686f09081307675d6c900ce6431a4d351e48438ab7cb2e5bc55a531d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "addLabelIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [],
+              "description": "A list of label IDs to add to the message"
+            },
+            "removeLabelIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [],
+              "description": "A list of label IDs to remove from the message"
+            }
+          },
+          "description": "Message modification data",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the message to modify"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__DRAFTS_LIST",
+    "description": "Lists the drafts in the user's mailbox",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DRAFTS_LIST",
+      "canonical_tool_description_hash": "6568fa2d244602f53429de5bec263d120d826efc552a925a19b6f872fe5e6665",
+      "canonical_tool_input_schema_hash": "4010e3afeb78d871c2d3272329047dc534bddf48004e353d708b3154da136b54"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "Only return drafts matching the specified query. Supports the same query format as the Gmail search box."
+            },
+            "pageToken": {
+              "type": "string",
+              "default": null,
+              "description": "Page token to retrieve a specific page of results"
+            },
+            "maxResults": {
+              "type": "integer",
+              "default": 100,
+              "description": "Maximum number of drafts to return. Default is 100."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__DRAFTS_CREATE",
+    "description": "create an email draft on behalf of the user",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DRAFTS_CREATE",
+      "canonical_tool_description_hash": "f4673d5b736c80bd5c7408361f9f0263ea4698c64ca7a64e37ec2f24fa7210f8",
+      "canonical_tool_input_schema_hash": "6f664efb5f98e1c0b1275d097750ca7e57aa4af1684e0a895074c8407b6436a6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["sender", "recipient", "body"],
+      "properties": {
+        "cc": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "email"
+          },
+          "description": "The email addresses of the cc recipients."
+        },
+        "bcc": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "email"
+          },
+          "description": "The email addresses of the bcc recipients."
+        },
+        "body": {
+          "type": "string",
+          "description": "The body content of the email, for now only plain text is supported."
+        },
+        "sender": {
+          "type": "string",
+          "default": "me",
+          "description": "The user's email address where the email will be sent from. The special value me can be used to indicate the authenticated user."
+        },
+        "subject": {
+          "type": "string",
+          "description": "The subject of the email."
+        },
+        "recipient": {
+          "type": "string",
+          "format": "email",
+          "description": "The email address of the recipient."
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__DRAFTS_UPDATE",
+    "description": "create an email draft on behalf of the user",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DRAFTS_UPDATE",
+      "canonical_tool_description_hash": "f4673d5b736c80bd5c7408361f9f0263ea4698c64ca7a64e37ec2f24fa7210f8",
+      "canonical_tool_input_schema_hash": "52b62e8debcd750dd6fe210c744e8964a3d586bd21af1a3730f7d35a81d9cf57"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["draft_id", "sender", "recipient", "body"],
+      "properties": {
+        "cc": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "email"
+          },
+          "description": "The email addresses of the cc recipients."
+        },
+        "bcc": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "email"
+          },
+          "description": "The email addresses of the bcc recipients."
+        },
+        "body": {
+          "type": "string",
+          "description": "The body content of the email, for now only plain text is supported."
+        },
+        "sender": {
+          "type": "string",
+          "default": "me",
+          "description": "The user's email address where the email will be sent from. The special value me can be used to indicate the authenticated user."
+        },
+        "subject": {
+          "type": "string",
+          "description": "The subject of the email."
+        },
+        "draft_id": {
+          "type": "string",
+          "description": "The ID of the draft to update"
+        },
+        "recipient": {
+          "type": "string",
+          "format": "email",
+          "description": "The email address of the recipient."
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__DRAFTS_DELETE",
+    "description": "Deletes the specified draft",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DRAFTS_DELETE",
+      "canonical_tool_description_hash": "9f814a1e92445a0c632f51123a706631420e7625414acf5c7d0fb285dfbb98a9",
+      "canonical_tool_input_schema_hash": "4ee563bc85b22f36695567e559e2e7a759ded6257edca2e842e04da2c936afe5"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the draft to delete"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__DRAFTS_SEND",
+    "description": "Sends the specified draft",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DRAFTS_SEND",
+      "canonical_tool_description_hash": "e36e351153884914a49339074bb20b5409ee6572bb53ecad660093898c20fff4",
+      "canonical_tool_input_schema_hash": "16acef7545cc886edd0d322ef80669e46591ec20636f156f62e2a422389059dc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the draft to send"
+            }
+          },
+          "description": "Draft data",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__THREADS_LIST",
+    "description": "Lists the threads in the user's mailbox",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "THREADS_LIST",
+      "canonical_tool_description_hash": "4fb5f33d0bb675cf8b90e65727b219b6ff63423657f12c44826f4a8195f525bb",
+      "canonical_tool_input_schema_hash": "ecd1d6f76388dceadeb6fb3204ab54981b7cf862bd3bef8d7f4d10b32d439007"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "Only return threads matching the specified query. Supports the same query format as the Gmail search box."
+            },
+            "labelIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return threads with labels that match all of the specified label IDs."
+            },
+            "pageToken": {
+              "type": "string",
+              "default": null,
+              "description": "Page token to retrieve a specific page of results"
+            },
+            "maxResults": {
+              "type": "integer",
+              "default": 100,
+              "description": "Maximum number of threads to return. Default is 100."
+            },
+            "includeSpamTrash": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include threads from SPAM and TRASH in the results."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__THREADS_GET",
+    "description": "Gets the specified thread",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "THREADS_GET",
+      "canonical_tool_description_hash": "a49535078b23127de2d90398b20481eb6daee4a32f90d0c460bd7e0ae5267356",
+      "canonical_tool_input_schema_hash": "dc85f821f2fcd97f8b8a8bd758e9552cc05d0742f6a6a1376c1abf58e613409d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the thread to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__THREADS_MODIFY",
+    "description": "Modifies the labels applied to the thread",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "THREADS_MODIFY",
+      "canonical_tool_description_hash": "d7dea84511d64307c96843fbd7e70cd19a7bf5026955139096feb2481d4fb7f9",
+      "canonical_tool_input_schema_hash": "57786f0de13e39d1f397a0df43b038f140099767116f8c71a69b88a4de1c1c51"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "addLabelIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "A list of IDs of labels to add to this thread"
+            },
+            "removeLabelIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "A list of IDs of labels to remove from this thread"
+            }
+          },
+          "description": "Request body",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the thread to modify"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__THREADS_TRASH",
+    "description": "Moves the specified thread to the trash",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "THREADS_TRASH",
+      "canonical_tool_description_hash": "f249ffd4ac5736bfd1de0c900b8e3fa298c1604bf563ed89db2867d268b31409",
+      "canonical_tool_input_schema_hash": "844b8b3f12a9dab6c6dc02c07e5bd020400251e114115e4b25ae938d571411fa"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the thread to trash"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__THREADS_UNTRASH",
+    "description": "Removes the specified thread from the trash",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "THREADS_UNTRASH",
+      "canonical_tool_description_hash": "3e0d864209efae8a8dfd9a09bd50a10b987ef64e55bacc302972c1b7b943b8db",
+      "canonical_tool_input_schema_hash": "76b1a3db696dad13b8e30c8fcc63f5b92b5ac949df2f291dcf7a2944d1319263"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the thread to untrash"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GMAIL__THREADS_DELETE",
+    "description": "Immediately and permanently deletes the specified thread",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "THREADS_DELETE",
+      "canonical_tool_description_hash": "1d42aa478a36cb674b4dd15c61f7419c600d38aac2cceecf6458d1ad54b40790",
+      "canonical_tool_input_schema_hash": "62119adaeb3b5eaeb434abe3b788c0ad13392cb0745ca1ec0fa0c33a8b70929e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the thread to delete"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
   }
 ]

--- a/backend/mcp_servers/google_analytics_admin/tools.json
+++ b/backend/mcp_servers/google_analytics_admin/tools.json
@@ -1,0 +1,227 @@
+[
+  {
+    "name": "GOOGLE_ANALYTICS_ADMIN__ACCOUNTS_LIST",
+    "description": "Lists all accounts available to the current user",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ACCOUNTS_LIST",
+      "canonical_tool_description_hash": "e605bb7a6dda60e2fa01929655c60c6f0dd6d07c85cbbda24aa2a7f55f7b5b39",
+      "canonical_tool_input_schema_hash": "aa5fc970cef53e6b1d6cf9c9e82830dc6e1ec3d8e9eb69b00b99034651b58fa6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "pageSize": {
+              "type": "integer",
+              "default": 50,
+              "description": "Maximum number of accounts to return"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Token for next page of results"
+            },
+            "showDeleted": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to include deleted accounts"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_ANALYTICS_ADMIN__PROPERTIES_LIST",
+    "description": "Lists properties under the specified account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PROPERTIES_LIST",
+      "canonical_tool_description_hash": "b07835233c3dfe19efcc5a0f60b204fa99bdaaee1fdcc7633ddd31da217682ce",
+      "canonical_tool_input_schema_hash": "5fffbacd0476da72d31590a96b67f319b1107454f3f657cc0ee7d8278eab6542"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["filter"],
+          "properties": {
+            "filter": {
+              "type": "string",
+              "description": "Filter expression to filter properties"
+            },
+            "pageSize": {
+              "type": "integer",
+              "default": 50,
+              "description": "Maximum number of properties to return"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Token for next page of results"
+            },
+            "showDeleted": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to include deleted properties"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_ANALYTICS_ADMIN__DATA_STREAMS_LIST",
+    "description": "Lists data streams under the specified property",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DATA_STREAMS_LIST",
+      "canonical_tool_description_hash": "15fb88ed0f7f6d1e5596f230bce479fe7f2d001a5ed98a6b376da96d0c28f0b5",
+      "canonical_tool_input_schema_hash": "a058f542dd4e5ab416eb102f1f3425cebdb181e533307f746972dbb17fa60827"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["parent"],
+          "properties": {
+            "parent": {
+              "type": "string",
+              "description": "Parent resource name (format: properties/1234)"
+            }
+          },
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "pageSize": {
+              "type": "integer",
+              "default": 50,
+              "description": "Maximum number of data streams to return"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Token for next page of results"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_ANALYTICS_ADMIN__CUSTOM_DIMENSIONS_CREATE",
+    "description": "Creates a custom dimension for the specified property",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CUSTOM_DIMENSIONS_CREATE",
+      "canonical_tool_description_hash": "5e36dfcf0e928fe9c7f21eded0238db108e6c91541fe50d58bb18d2f7311266c",
+      "canonical_tool_input_schema_hash": "4547901d6fe6e2aa5c6ac6bc01f766bd6978f550290f8066605439da97623dd0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["parameterName", "displayName", "scope"],
+          "properties": {
+            "scope": {
+              "enum": ["DIMENSION_SCOPE_UNSPECIFIED", "EVENT", "USER", "ITEM"],
+              "type": "string",
+              "description": "Required. Immutable. The scope of this dimension."
+            },
+            "description": {
+              "type": "string",
+              "description": "Optional. Description for this custom dimension. Maximum length of 150 characters."
+            },
+            "displayName": {
+              "type": "string",
+              "description": "Required. Display name for this custom dimension as shown in the Google Analytics UI. Maximum length of 82 characters, including alphanumeric, spaces, and underscores (must start with a letter). System-generated old display names may contain square brackets, but updates to this field will not allow square brackets."
+            },
+            "parameterName": {
+              "type": "string",
+              "description": "Required. Immutable. The parameter name for this custom dimension. For user-level scope, this is the user property name. For event-level scope, this is the event parameter name. For item-level scope, this is the parameter name found in the 'ecommerce items' array. Can only contain alphanumeric characters and underscores (must start with a letter). Maximum length of 24 characters for user-level scope, 40 characters for event-level scope."
+            },
+            "disallowAdsPersonalization": {
+              "type": "boolean",
+              "description": "Optional. If set to true, sets this dimension as NPA and avoids it being used for ads personalization. Currently only supported for user-level scope custom dimensions."
+            }
+          },
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["parent"],
+          "properties": {
+            "parent": {
+              "type": "string",
+              "description": "Parent resource name (format: properties/1234)"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_ANALYTICS_ADMIN__GOOGLE_ADS_LINKS_LIST",
+    "description": "Lists Google Ads links under the specified property",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GOOGLE_ADS_LINKS_LIST",
+      "canonical_tool_description_hash": "025db0ff48e4566b886de8276ed5d1c54950188479b778dfd449c7f341ce28b2",
+      "canonical_tool_input_schema_hash": "f6fea7efb11a5661a7c7244813a3c7a08c6ff92e0fa4edc3fdb8aedf95e12d16"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["parent"],
+          "properties": {
+            "parent": {
+              "type": "string",
+              "example": "property/485415204",
+              "description": "Required. Parent property name (format: properties/1234)"
+            }
+          },
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "pageSize": {
+              "type": "integer",
+              "default": 50,
+              "description": "Maximum number of resources to return (max 200, values above will be coerced to max)"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Pagination token from previous response"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/google_calendar/tools.json
+++ b/backend/mcp_servers/google_calendar/tools.json
@@ -1,0 +1,713 @@
+[
+  {
+    "name": "GOOGLE_CALENDAR__CALENDARLIST_LIST",
+    "description": "Returns the calendars on the user's calendar list",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CALENDARLIST_LIST",
+      "canonical_tool_description_hash": "937c87845113bda1f1ead1fae720dbef755a489b79d1505b465dc517f84ff976",
+      "canonical_tool_input_schema_hash": "187e96e815045f3dc7f4340b58725c0fd677e64f46ca436ca754e4078a419a5c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "pageToken": {
+              "type": "string",
+              "description": "Token specifying which result page to return."
+            },
+            "syncToken": {
+              "type": "string",
+              "description": "Token obtained from the nextSyncToken field returned on the last page of results from the previous list request. It makes the result of this list request contain only entries that have changed since then. If only read-only fields such as calendar properties or ACLs have changed, the entry won't be returned. All entries deleted and hidden since the previous list request will always be in the result set and it is not allowed to set showDeleted neither showHidden to False. To ensure client state consistency minAccessRole query parameter cannot be specified together with nextSyncToken. If the syncToken expires, the server will respond with a 410 GONE response code and the client should clear its storage and perform a full synchronization without any syncToken."
+            },
+            "maxResults": {
+              "type": "integer",
+              "default": 100,
+              "description": "Maximum number of entries returned on one result page. By default the value is 100 entries. The page size can never exceed 250 entries."
+            },
+            "showHidden": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to show hidden entries"
+            },
+            "showDeleted": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to include deleted calendar list entries in the result."
+            },
+            "minAccessRole": {
+              "enum": ["freeBusyReader", "owner", "reader", "writer"],
+              "type": "string",
+              "description": "The minimum access role for the user in the returned entries. The default is no restriction. 'freeBusyReader': The user can read free/busy information. 'owner': The user can read and modify events and access control lists. 'reader': The user can read events that are not private. 'writer': The user can read and modify events."
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_CALENDAR__CALENDARLIST_GET",
+    "description": "Returns a calendar from the user's calendar list.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CALENDARLIST_GET",
+      "canonical_tool_description_hash": "8848ac4fa83bdcbb20ee913078b9ac76e7c00e33f09e662fe7c767a246e6f13d",
+      "canonical_tool_input_schema_hash": "704952d8f2a35532da87597df4f172f92904a5ab3a3a9a50ffd70c47ab6855e8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["calendarId"],
+          "properties": {
+            "calendarId": {
+              "type": "string",
+              "default": "primary",
+              "description": "Calendar identifier. To retrieve calendar IDs call the calendarList.list method. If you want to access the primary calendar of the currently logged in user, use the 'primary' keyword."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_CALENDAR__CALENDARS_GET",
+    "description": "Returns metadata for a calendar.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CALENDARS_GET",
+      "canonical_tool_description_hash": "f8786696967c8e4a47c49ad5ec036746304b93a2b3033697cd13e9ba8a7cb9c0",
+      "canonical_tool_input_schema_hash": "e469a5485ac6e246ae2bbcd0f33a292d394fdc1c792098669ee417ea25bc9c3c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["calendarId"],
+          "properties": {
+            "calendarId": {
+              "type": "string",
+              "description": "Calendar identifier. To retrieve calendar IDs call the calendarList.list method. If you want to access the primary calendar of the currently logged-in user, use the 'primary' keyword."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_CALENDAR__FREEBUSY_QUERY",
+    "description": "Returns free/busy information for a set of calendars.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "FREEBUSY_QUERY",
+      "canonical_tool_description_hash": "9220b7ecc895288397d4d951b790dd1248d918bed1d6dc4639345b8a62031425",
+      "canonical_tool_input_schema_hash": "3acbc479faf7e5aa99bb44c4aa12042f6f9243364123e9306025660e66aebba2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["timeMin", "timeMax", "timeZone", "items"],
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "The identifier of a calendar or a group."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "List of calendars and/or groups to query."
+            },
+            "timeMax": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The end of the interval for the query formatted as per RFC3339."
+            },
+            "timeMin": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The start of the interval for the query formatted as per RFC3339."
+            },
+            "timeZone": {
+              "type": "string",
+              "default": "UTC",
+              "description": "Time zone used in the response. Optional. The default is UTC."
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_CALENDAR__EVENTS_LIST",
+    "description": "Returns events on the specified calendar",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EVENTS_LIST",
+      "canonical_tool_description_hash": "a7541a3e6ef134ce3eab1e40da56c1233fe14d2e22cb4a4d96c269e9dc75cb7a",
+      "canonical_tool_input_schema_hash": "092f5dd705be5c2b1de1676ba8a88dfd4cafce36782de0c3e89c4bf87750591e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["calendarId"],
+          "properties": {
+            "calendarId": {
+              "type": "string",
+              "default": "primary",
+              "description": "Calendar identifier. Use 'primary' for the primary calendar."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "Free text search to find matching events."
+            },
+            "orderBy": {
+              "enum": ["startTime", "updated"],
+              "type": "string",
+              "description": "Order of returned events."
+            },
+            "timeMax": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Upper bound for event start time (RFC3339)."
+            },
+            "timeMin": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Lower bound for event end time (RFC3339)."
+            },
+            "timeZone": {
+              "type": "string",
+              "description": "Time zone used in the response."
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Token for pagination."
+            },
+            "syncToken": {
+              "type": "string",
+              "description": "Token for incremental synchronization."
+            },
+            "maxResults": {
+              "type": "integer",
+              "default": 250,
+              "description": "Maximum number of events returned per page. Default is 250, max is 2500."
+            },
+            "updatedMin": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Lower bound for last event modification time (RFC3339)."
+            },
+            "showDeleted": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include deleted events in results."
+            },
+            "singleEvents": {
+              "type": "boolean",
+              "default": false,
+              "description": "Expand recurring events into instances."
+            },
+            "showHiddenInvitations": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include hidden invitations in results."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_CALENDAR__EVENTS_GET",
+    "description": "Returns an event based on its Google Calendar ID",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EVENTS_GET",
+      "canonical_tool_description_hash": "5b9c351da0029cab0990b826c70c667fcf02d8bf1c63978f8e1ce2ae97f22001",
+      "canonical_tool_input_schema_hash": "304ac0116c1b13239bca5cfb874f8e917e8ad87eaba10bbe3282a98b4eddeeba"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["calendarId", "eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "Event identifier."
+            },
+            "calendarId": {
+              "type": "string",
+              "description": "Calendar identifier. Use 'primary' for the primary calendar."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "timeZone": {
+              "type": "string",
+              "description": "Time zone used in the response. Defaults to the calendar's time zone."
+            },
+            "maxAttendees": {
+              "type": "integer",
+              "description": "Maximum number of attendees to include in the response."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_CALENDAR__EVENTS_INSERT",
+    "description": "Creates an event in the specified calendar",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EVENTS_INSERT",
+      "canonical_tool_description_hash": "4164d214c1ad2a078a4a2e6516b5f4c5fd815f238568c916ccfdb8a34fdba76c",
+      "canonical_tool_input_schema_hash": "33dde67d3703da7a4c8d2d096fed8b5f0115fe82e07ab96028d06f726a0edc97"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["start", "end"],
+          "properties": {
+            "end": {
+              "type": "object",
+              "required": ["dateTime", "timeZone"],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "End time in RFC3339 format."
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Time zone for the end time."
+                }
+              },
+              "description": "End date/time of the event.",
+              "additionalProperties": false
+            },
+            "start": {
+              "type": "object",
+              "required": ["dateTime", "timeZone"],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Start time in RFC3339 format."
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Time zone for the start time."
+                }
+              },
+              "description": "Start date/time of the event.",
+              "additionalProperties": false
+            },
+            "summary": {
+              "type": "string",
+              "description": "Title of the event."
+            },
+            "location": {
+              "type": "string",
+              "description": "Geographic location of the event."
+            },
+            "attendees": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email of the attendee."
+                  },
+                  "optional": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether the attendee is optional."
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "description": "Attendee's name."
+                  },
+                  "responseStatus": {
+                    "enum": ["needsAction", "declined", "tentative", "accepted"],
+                    "type": "string",
+                    "description": "Attendee's response status."
+                  }
+                }
+              },
+              "description": "List of attendees for the event."
+            },
+            "eventType": {
+              "enum": [
+                "birthday",
+                "default",
+                "focusTime",
+                "fromGmail",
+                "outOfOffice",
+                "workingLocation"
+              ],
+              "type": "string",
+              "default": "default",
+              "description": "Specific type of event."
+            },
+            "visibility": {
+              "enum": ["default", "public", "private", "confidential"],
+              "type": "string",
+              "default": "default",
+              "description": "Visibility of the event."
+            },
+            "description": {
+              "type": "string",
+              "description": "Detailed description of the event."
+            },
+            "guestsCanModify": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether attendees can modify the event."
+            },
+            "guestsCanInviteOthers": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether attendees can invite others."
+            },
+            "guestsCanSeeOtherGuests": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether attendees can see other guests."
+            }
+          },
+          "description": "Event data to be created",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["calendarId"],
+          "properties": {
+            "calendarId": {
+              "type": "string",
+              "description": "Calendar identifier. Use 'primary' for the primary calendar."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "sendUpdates": {
+              "enum": ["all", "externalOnly", "none"],
+              "type": "string",
+              "default": "none",
+              "description": "Controls notifications for event creation."
+            },
+            "maxAttendees": {
+              "type": "integer",
+              "description": "Maximum number of attendees to include in the response."
+            },
+            "supportsAttachments": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether the API client supports event attachments."
+            },
+            "conferenceDataVersion": {
+              "type": "integer",
+              "default": 0,
+              "maximum": 1,
+              "minimum": 0,
+              "description": "Version number of conference data supported by the API client."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_CALENDAR__EVENTS_UPDATE",
+    "description": "Updates an existing event in the specified calendar",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EVENTS_UPDATE",
+      "canonical_tool_description_hash": "6a5828a25e723b201784070f77ec216b0bcd0fabddae23896e6abf1165d28cfb",
+      "canonical_tool_input_schema_hash": "cb4de39c330e712a677cf30763b298aa7dc48d7976f66277d62dfc37f9af424d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["start", "end"],
+          "properties": {
+            "end": {
+              "type": "object",
+              "required": ["dateTime", "timeZone"],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "End time in RFC3339 format."
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Time zone for the end time."
+                }
+              },
+              "description": "End date/time of the event.",
+              "additionalProperties": false
+            },
+            "start": {
+              "type": "object",
+              "required": ["dateTime", "timeZone"],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Start time in RFC3339 format."
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Time zone for the start time."
+                }
+              },
+              "description": "Start date/time of the event.",
+              "additionalProperties": false
+            },
+            "summary": {
+              "type": "string",
+              "description": "Title of the event."
+            },
+            "location": {
+              "type": "string",
+              "description": "Geographic location of the event."
+            },
+            "attendees": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email of the attendee."
+                  },
+                  "optional": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether the attendee is optional."
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "description": "Attendee's name."
+                  },
+                  "responseStatus": {
+                    "enum": ["needsAction", "declined", "tentative", "accepted"],
+                    "type": "string",
+                    "description": "Attendee's response status."
+                  }
+                }
+              },
+              "description": "List of attendees for the event."
+            },
+            "eventType": {
+              "enum": [
+                "birthday",
+                "default",
+                "focusTime",
+                "fromGmail",
+                "outOfOffice",
+                "workingLocation"
+              ],
+              "type": "string",
+              "default": "default",
+              "description": "Specific type of event."
+            },
+            "visibility": {
+              "enum": ["default", "public", "private", "confidential"],
+              "type": "string",
+              "default": "default",
+              "description": "Visibility of the event."
+            },
+            "description": {
+              "type": "string",
+              "description": "Detailed description of the event."
+            },
+            "guestsCanModify": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether attendees can modify the event."
+            },
+            "guestsCanInviteOthers": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether attendees can invite others."
+            },
+            "guestsCanSeeOtherGuests": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether attendees can see other guests."
+            }
+          },
+          "description": "Event data to be updated",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["calendarId", "eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "Event identifier."
+            },
+            "calendarId": {
+              "type": "string",
+              "description": "Calendar identifier. Use 'primary' for the primary calendar."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "sendUpdates": {
+              "enum": ["all", "externalOnly", "none"],
+              "type": "string",
+              "default": "none",
+              "description": "Controls notifications for event updates."
+            },
+            "maxAttendees": {
+              "type": "integer",
+              "description": "Maximum number of attendees to include in the response."
+            },
+            "supportsAttachments": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether the API client supports event attachments."
+            },
+            "conferenceDataVersion": {
+              "type": "integer",
+              "default": 0,
+              "maximum": 1,
+              "minimum": 0,
+              "description": "Version number of conference data supported by the API client."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_CALENDAR__EVENTS_DELETE",
+    "description": "Deletes an event from the specified calendar",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EVENTS_DELETE",
+      "canonical_tool_description_hash": "6cbf695aa30be5da1ee64cd421bf87e2214c356ca874466cc2bb82ea893f93a6",
+      "canonical_tool_input_schema_hash": "21c15af1bc4787165cb5018cf711d09e871a14f9e10ab35c439847a6ebe27626"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["calendarId", "eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "Event identifier."
+            },
+            "calendarId": {
+              "type": "string",
+              "description": "Calendar identifier. Use 'primary' for the primary calendar."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "sendUpdates": {
+              "enum": ["all", "externalOnly", "none"],
+              "type": "string",
+              "default": "none",
+              "description": "Controls notifications for event deletion."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/google_docs/tools.json
+++ b/backend/mcp_servers/google_docs/tools.json
@@ -1,0 +1,135 @@
+[
+  {
+    "name": "GOOGLE_DOCS__DOCUMENTS_CREATE",
+    "description": "Creates a blank document using the provided title.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DOCUMENTS_CREATE",
+      "canonical_tool_description_hash": "f76831a36570e4dfdf200be838bd045724599be9b3bf49ca93f16cf378cf5cbf",
+      "canonical_tool_input_schema_hash": "f54c872b8638ce166167723707eb44b2c8130ba992c92d4fcad12565b51e56be"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["title"],
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "The title of the document."
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_DOCS__DOCUMENTS_UPDATE",
+    "description": "Applies one or more updates to a Google Document using the batchUpdate method. Only supports inserting text now.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DOCUMENTS_UPDATE",
+      "canonical_tool_description_hash": "833bd2e7a92f05c51d82ac62823467977b49f28266fe445f4bb63314085e391d",
+      "canonical_tool_input_schema_hash": "9f9bd0a24d1f08ec2732a3e315c7ba1214e66f5e0d858616d819e03e6b8a2d0c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["requests"],
+          "properties": {
+            "requests": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "insertText": {
+                    "type": "object",
+                    "visible": ["text"],
+                    "required": ["location", "text"],
+                    "properties": {
+                      "text": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "object",
+                        "required": ["index"],
+                        "properties": {
+                          "index": {
+                            "type": "integer",
+                            "default": 1,
+                            "description": "The index at which to insert the text. The default is 1, so the text is inserted at the beginning of the document."
+                          },
+                          "tabId": {
+                            "type": "string",
+                            "description": "The ID of the tab to insert the text into."
+                          },
+                          "segmentId": {
+                            "type": "string",
+                            "description": "The ID of the header, footer, footnote, or endnote to insert the text into."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "description": "A list of update requests to apply to the document."
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["documentId"],
+          "properties": {
+            "documentId": {
+              "type": "string",
+              "description": "The ID of the Google Document to update."
+            }
+          },
+          "description": "Path parameters for the request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_DOCS__DOCUMENTS_GET",
+    "description": "Retrieves the latest version of the specified Google Document.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DOCUMENTS_GET",
+      "canonical_tool_description_hash": "bb9d264fa9fa8f897ccd8dbca33aba94eb6b8248688e6bde9965b75f84ac0252",
+      "canonical_tool_input_schema_hash": "fb3ab886226f3ff49bb494445ef5d6a84558fb27ecb5fe99bece1e466b5fde2e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["documentId"],
+          "properties": {
+            "documentId": {
+              "type": "string",
+              "description": "The ID of the document to retrieve."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/google_maps/tools.json
+++ b/backend/mcp_servers/google_maps/tools.json
@@ -1,0 +1,303 @@
+[
+  {
+    "name": "GOOGLE_MAPS__TEXT_SEARCH",
+    "description": "Returns a list of places based on a text string (e.g. 'pizza in Sydney' or 'shops near Main St').",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TEXT_SEARCH",
+      "canonical_tool_description_hash": "248baa9822bf32d01283efd0d7b1a0b6d8f3bff0bea566e7c0993e4713b9909a",
+      "canonical_tool_input_schema_hash": "2b1ab1afc2dd76c3590aa5bdbbea23ae363e171f2dbf3174be09f6aea53e4861"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["query"],
+          "properties": {
+            "type": {
+              "enum": [
+                "accounting",
+                "airport",
+                "amusement_park",
+                "aquarium",
+                "art_gallery",
+                "atm",
+                "bakery",
+                "bank",
+                "bar",
+                "beauty_salon",
+                "bicycle_store",
+                "book_store",
+                "bowling_alley",
+                "bus_station",
+                "cafe",
+                "campground",
+                "car_dealer",
+                "car_rental",
+                "car_repair",
+                "car_wash",
+                "casino",
+                "cemetery",
+                "church",
+                "city_hall",
+                "clothing_store",
+                "convenience_store",
+                "courthouse",
+                "dentist",
+                "department_store",
+                "doctor",
+                "drugstore",
+                "electrician",
+                "electronics_store",
+                "embassy",
+                "fire_station",
+                "florist",
+                "funeral_home",
+                "furniture_store",
+                "gas_station",
+                "gym",
+                "hair_care",
+                "hardware_store",
+                "hindu_temple",
+                "home_goods_store",
+                "hospital",
+                "insurance_agency",
+                "jewelry_store",
+                "laundry",
+                "lawyer",
+                "library",
+                "light_rail_station",
+                "liquor_store",
+                "local_government_office",
+                "locksmith",
+                "lodging",
+                "meal_delivery",
+                "meal_takeaway",
+                "mosque",
+                "movie_rental",
+                "movie_theater",
+                "moving_company",
+                "museum",
+                "night_club",
+                "painter",
+                "park",
+                "parking",
+                "pet_store",
+                "pharmacy",
+                "physiotherapist",
+                "plumber",
+                "police",
+                "post_office",
+                "primary_school",
+                "real_estate_agency",
+                "restaurant",
+                "roofing_contractor",
+                "rv_park",
+                "school",
+                "secondary_school",
+                "shoe_store",
+                "shopping_mall",
+                "spa",
+                "stadium",
+                "storage",
+                "store",
+                "subway_station",
+                "supermarket",
+                "synagogue",
+                "taxi_stand",
+                "tourist_attraction",
+                "train_station",
+                "transit_station",
+                "travel_agency",
+                "university",
+                "veterinary_care",
+                "zoo"
+              ],
+              "type": "string",
+              "description": "Restricts results to places matching the specified type."
+            },
+            "query": {
+              "type": "string",
+              "description": "The text string to search for (e.g. 'restaurants in Sydney' or 'shops at 123 Main St'). Google recommends using Place Autocomplete instead of text search when possible."
+            },
+            "radius": {
+              "type": "integer",
+              "description": "Defines the distance (in meters) within which to return place results, relative to the specified location. Maximum allowed radius is 50,000 meters."
+            },
+            "opennow": {
+              "type": "boolean",
+              "description": "Returns only those places that are open for business at the time the query is sent."
+            },
+            "language": {
+              "type": "string",
+              "default": "en",
+              "description": "The language in which to return results."
+            },
+            "location": {
+              "type": "string",
+              "description": "The latitude/longitude around which to retrieve place information (e.g. '-33.8670522,151.1957362')."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MAPS__GET_DIRECTIONS",
+    "description": "Get walking directions between two locations using Google Maps API",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DIRECTIONS",
+      "canonical_tool_description_hash": "83f4dc146a3bd1592a8677bc9ef14141989e049c3af1bb73f91734e9c208f847",
+      "canonical_tool_input_schema_hash": "ceef37b84994f817c6b292a5312addefadf5be577c40abaedfa0bf34b8c66dc1"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["origin", "destination"],
+          "properties": {
+            "mode": {
+              "enum": ["walking", "driving", "bicycling", "transit"],
+              "type": "string",
+              "default": "walking",
+              "description": "Travel mode"
+            },
+            "origin": {
+              "type": "string",
+              "example": "Tokyo Station",
+              "description": "Starting point address or coordinates"
+            },
+            "destination": {
+              "type": "string",
+              "example": "Sensoji Temple",
+              "description": "End point address or coordinates"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MAPS__REVERSE_GEOCODE",
+    "description": "Get address information from latitude/longitude coordinates using Google Maps Geocoding API",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REVERSE_GEOCODE",
+      "canonical_tool_description_hash": "0c40ce3c061a46faa6305380a0447bd2550433c374f288dc73f9f1cef02608c3",
+      "canonical_tool_input_schema_hash": "1ed58d743bbfb90eb5b3798cbc96cb9918e81a04305dbb4e90779ce46aaddb4a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["latlng"],
+          "properties": {
+            "latlng": {
+              "type": "string",
+              "example": "48.8584,2.2945",
+              "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$",
+              "description": "Latitude and longitude coordinates (comma-separated)"
+            },
+            "language": {
+              "type": "string",
+              "default": "en",
+              "description": "Language for results (e.g., 'en', 'fr')"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MAPS__GET_STATIC_MAP",
+    "description": "Generate a static map image using Google Maps Static API",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_STATIC_MAP",
+      "canonical_tool_description_hash": "e3dafbdfff09e88ce043258182ba96dfecfb531f1566269ff0c4cb2d868645b3",
+      "canonical_tool_input_schema_hash": "783752d43eb3260b0a1b7c124ed072d41af828b4658c2378c3c1f7db53026771"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["center", "size"],
+          "properties": {
+            "size": {
+              "type": "string",
+              "example": "600x300",
+              "pattern": "^\\d+x\\d+$",
+              "description": "Image dimensions in pixels (widthxheight)"
+            },
+            "zoom": {
+              "type": "integer",
+              "default": 13,
+              "maximum": 21,
+              "minimum": 0,
+              "description": "Zoom level (0-21)"
+            },
+            "center": {
+              "type": "string",
+              "example": "40.7128,-74.0060",
+              "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$",
+              "description": "Center point coordinates (lat,lng)"
+            },
+            "markers": {
+              "type": "string",
+              "example": "color:red|40.7128,-74.0060",
+              "description": "Marker style and locations"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MAPS__GET_ELEVATION",
+    "description": "Retrieve elevation data for specific locations using Google Maps Elevation API",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ELEVATION",
+      "canonical_tool_description_hash": "08ce2f2a7311fc6e49d9ca504cd26de4898981cf3ddcd01a2f83ed6cb75ce5f8",
+      "canonical_tool_input_schema_hash": "f61763f1c5d0ceeced38cb0f7a8a02f2f9034714667c5ffb21c811d4dcca56cb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["locations"],
+          "properties": {
+            "locations": {
+              "type": "string",
+              "example": "35.68,139.76|40.71,-74.01",
+              "pattern": "^([-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)(\\|[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?))*)$",
+              "description": "Pipe-separated latitude/longitude coordinate pairs"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/google_meet/tools.json
+++ b/backend/mcp_servers/google_meet/tools.json
@@ -1,0 +1,447 @@
+[
+  {
+    "name": "GOOGLE_MEET__CONFERENCE_RECORDS_LIST",
+    "description": "Lists the conference records. By default, ordered by start time and in descending order.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONFERENCE_RECORDS_LIST",
+      "canonical_tool_description_hash": "d5a0258d2e261c283bf5f77e813c262e20caa4ac09f2a33ebe1570c3570353ce",
+      "canonical_tool_input_schema_hash": "815af01d0d6f896eb8b9b3ccc58200e1cb51f33a23279affa50a73c7dc73219d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "filter": {
+              "type": "string",
+              "description": "User specified filtering condition. For example: 'space.name = \"spaces/NAME\"', 'space.meeting_code = \"abc-mnop-xyz\"', 'start_time>=\"2024-01-01T00:00:00.000Z\" AND start_time<=\"2024-01-02T00:00:00.000Z\"', 'end_time IS NULL'"
+            },
+            "pageSize": {
+              "type": "integer",
+              "default": 25,
+              "description": "Maximum number of conference records to return. The service might return fewer than this value. If unspecified, at most 25 conference records are returned. The maximum value is 100."
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Page token returned from previous List Call."
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MEET__CONFERENCE_RECORDS_GET",
+    "description": "Gets a conference record by conference ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONFERENCE_RECORDS_GET",
+      "canonical_tool_description_hash": "a21c83e4756bb62d2a03bc889cc0b84e988a3ad29a65d2431dd3eda91c7718c4",
+      "canonical_tool_input_schema_hash": "e143ff2fec179c6af7c795515e458da49a0ea42a28ae90319710c3963a52d495"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "pattern": "^conferenceRecords/[^/]+$",
+              "description": "The resource name of the conference record, format: conferenceRecords/{conference_record}"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MEET__PARTICIPANTS_LIST",
+    "description": "Lists the participants in a conference record.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PARTICIPANTS_LIST",
+      "canonical_tool_description_hash": "8a878ab11a6c4b36f8065b129338cbd2bb851980cb7ae308fe7d2eb5ff4a1d04",
+      "canonical_tool_input_schema_hash": "c131e3468d1309c27f5371af7ee520333a935e6e0ad70373a6303530c942575b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["parent"],
+          "properties": {
+            "parent": {
+              "type": "string",
+              "pattern": "^conferenceRecords/[^/]+$",
+              "description": "Conference record ID. Format: conferenceRecords/{conference_record}"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "filter": {
+              "type": "string",
+              "description": "Filter condition. Example: latest_end_time IS NULL returns active participants"
+            },
+            "pageSize": {
+              "type": "integer",
+              "default": 100,
+              "description": "Maximum number of participants to return per page. Default 100, maximum 250."
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Page token for pagination"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MEET__PARTICIPANTS_GET",
+    "description": "Gets a participant by participant ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PARTICIPANTS_GET",
+      "canonical_tool_description_hash": "c41bb533e1a2fcd572dffe898d82f50992266da3600cf5feab8b7fd68df56790",
+      "canonical_tool_input_schema_hash": "d102568bffa1271560c31ee2a3a38fe665de86e1f9be70234db2a1b676f4640e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "pattern": "^conferenceRecords/[^/]+/participants/[^/]+$",
+              "description": "Participant resource name. Format: conferenceRecords/{conference_record}/participants/{participant}"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MEET__PARTICIPANT_SESSIONS_LIST",
+    "description": "Lists the participant sessions of a participant in a conference record.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PARTICIPANT_SESSIONS_LIST",
+      "canonical_tool_description_hash": "c92440884979ebf4c8e991538d624c41dd22593b6898626496ec91d25cd4a132",
+      "canonical_tool_input_schema_hash": "9b0f3202822bb79d8732029a908f6cbb27440d6e97864c31c75dd71ba3c63d29"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["parent"],
+          "properties": {
+            "parent": {
+              "type": "string",
+              "pattern": "^conferenceRecords/[^/]+/participants/[^/]+$",
+              "description": "Participant resource name. Format: conferenceRecords/{conference_record}/participants/{participant}"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "filter": {
+              "type": "string",
+              "description": "Filter condition. Example: end_time IS NULL returns active sessions"
+            },
+            "pageSize": {
+              "type": "integer",
+              "default": 100,
+              "description": "Maximum number of sessions to return per page"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Page token for pagination"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MEET__SPACES_GET",
+    "description": "Gets details about a meeting space.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SPACES_GET",
+      "canonical_tool_description_hash": "629ab2f781a262a656ed70717808bdb942329866f963ae0c90b176a84f0b3a4a",
+      "canonical_tool_input_schema_hash": "1f3f11439812f3059b7b3aabf00f345fdf856f0bb04549ed2e1dabaa7234ed42"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "pattern": "^spaces/[^/]+$",
+              "description": "Resource name of the space. Format: spaces/{space}"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MEET__SPACES_CREATE",
+    "description": "Creates a space.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SPACES_CREATE",
+      "canonical_tool_description_hash": "156c4ead96e5fc920380fcf04bddc0c6fd1557debc5cce7489afacaf7ed2d937",
+      "canonical_tool_input_schema_hash": "8cca1c2e862d2fb515e672b9d34553523e45c47d0c0043aed0a01113291b0774"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "config": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "moderation": {
+                  "enum": ["MODERATION_UNSPECIFIED", "OFF", "ON"],
+                  "type": "string",
+                  "description": "The pre-configured moderation mode for the Meeting"
+                },
+                "artifactConfig": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "smartNotesConfig": {
+                      "type": "object",
+                      "required": [],
+                      "properties": {
+                        "autoSmartNotesGeneration": {
+                          "enum": ["AUTO_GENERATION_TYPE_UNSPECIFIED", "ON", "OFF"],
+                          "type": "string",
+                          "description": "Defines whether to automatically generate a summary and recap"
+                        }
+                      },
+                      "description": "Configuration related to smart notes in a meeting space",
+                      "additionalProperties": false
+                    }
+                  },
+                  "description": "Configuration related to meeting artifacts potentially generated by this meeting space",
+                  "additionalProperties": false
+                }
+              },
+              "description": "Configuration pertaining to the meeting space",
+              "additionalProperties": false
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MEET__RECORDINGS_LIST",
+    "description": "Lists recordings from a conference record.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RECORDINGS_LIST",
+      "canonical_tool_description_hash": "853857012b4f502b64e6399d44962a267ffa43d541fe120a85fcdb7da3be1703",
+      "canonical_tool_input_schema_hash": "08f9898606adab1e7ebc0a959879273f13cd30371322988ce93494c69d645c12"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["parent"],
+          "properties": {
+            "parent": {
+              "type": "string",
+              "pattern": "^conferenceRecords/[^/]+$",
+              "description": "Conference record ID. Format: conferenceRecords/{conference_record}"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "pageSize": {
+              "type": "integer",
+              "default": 25,
+              "description": "Maximum number of recordings to return per page"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Page token for pagination"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MEET__RECORDINGS_GET",
+    "description": "Gets details of a specific recording including Google Drive links.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RECORDINGS_GET",
+      "canonical_tool_description_hash": "e9be36bf2cd4d7ce2dc778de5e761a09f9eb65b0b41f3e8f6109315a21a86cc2",
+      "canonical_tool_input_schema_hash": "ca19bc891464c22fa8d4f5c9ce5da8a733af28a33a796ef0ca2b9ec791d7c463"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "pattern": "^conferenceRecords/[^/]+/recordings/[^/]+$",
+              "description": "Recording resource name. Format: conferenceRecords/{conference_record}/recordings/{recording}"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_MEET__SPACES_CONFIGURE_SMART_NOTES",
+    "description": "Configures smart notes settings for a meeting space.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SPACES_CONFIGURE_SMART_NOTES",
+      "canonical_tool_description_hash": "f3f879438c27f2d39c494dbbf9a659c5b9fac70b441808efb49093c86f66477b",
+      "canonical_tool_input_schema_hash": "7684ca59f6683cb57c6961190f24e763408c0f53f4e6558677150515ffda6b4e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "config": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "artifactConfig": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "smartNotesConfig": {
+                      "type": "object",
+                      "required": [],
+                      "properties": {
+                        "autoSmartNotesGeneration": {
+                          "enum": ["AUTO_GENERATION_TYPE_UNSPECIFIED", "ON", "OFF"],
+                          "type": "string",
+                          "description": "Defines whether to automatically generate a summary and recap of the meeting"
+                        }
+                      },
+                      "description": "Configuration related to smart notes in a meeting space",
+                      "additionalProperties": false
+                    }
+                  },
+                  "description": "Configuration related to meeting artifacts potentially generated by this meeting space",
+                  "additionalProperties": false
+                }
+              },
+              "description": "Configuration pertaining to the meeting space",
+              "additionalProperties": false
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "pattern": "^spaces/[^/]+$",
+              "description": "Resource name of the space. Format: spaces/{space}"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "updateMask": {
+              "type": "string",
+              "description": "Fields to be updated. For example: config.artifactConfig.smartNotesConfig.autoSmartNotesGeneration"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/google_sheets/tools.json
+++ b/backend/mcp_servers/google_sheets/tools.json
@@ -1,0 +1,824 @@
+[
+  {
+    "name": "GOOGLE_SHEETS__SPREADSHEET_CREATE",
+    "description": "Creates a new spreadsheet with specified properties and sheets",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SPREADSHEET_CREATE",
+      "canonical_tool_description_hash": "984d83c406c94a2fe4f927e2595123c7df4d05b851a28c3fac89caad3918ca63",
+      "canonical_tool_input_schema_hash": "9989dd80ebd729342f574f31eab962b7e24cdbd5ab1707e0a3d9308d807462f7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["properties"],
+          "properties": {
+            "sheets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["properties"],
+                "required": ["properties"],
+                "properties": {
+                  "properties": {
+                    "type": "object",
+                    "visible": ["title", "index", "sheetId", "sheetType", "gridProperties"],
+                    "required": [],
+                    "properties": {
+                      "index": {
+                        "type": "integer",
+                        "description": "The index of the sheet within the spreadsheet"
+                      },
+                      "title": {
+                        "type": "string",
+                        "description": "The title of the sheet"
+                      },
+                      "sheetId": {
+                        "type": "integer",
+                        "description": "The ID of the sheet"
+                      },
+                      "sheetType": {
+                        "enum": ["GRID", "OBJECT"],
+                        "type": "string",
+                        "description": "The type of sheet"
+                      },
+                      "gridProperties": {
+                        "type": "object",
+                        "visible": [
+                          "rowCount",
+                          "columnCount",
+                          "frozenRowCount",
+                          "frozenColumnCount",
+                          "hideGridlines"
+                        ],
+                        "required": [],
+                        "properties": {
+                          "rowCount": {
+                            "type": "integer",
+                            "description": "The number of rows in the grid"
+                          },
+                          "columnCount": {
+                            "type": "integer",
+                            "description": "The number of columns in the grid"
+                          },
+                          "hideGridlines": {
+                            "type": "boolean",
+                            "description": "True if the gridlines are hidden"
+                          },
+                          "frozenRowCount": {
+                            "type": "integer",
+                            "description": "The number of rows that are frozen in the grid"
+                          },
+                          "frozenColumnCount": {
+                            "type": "integer",
+                            "description": "The number of columns that are frozen in the grid"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The sheets in this spreadsheet"
+            },
+            "properties": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "description": "The title of the spreadsheet"
+                },
+                "locale": {
+                  "type": "string",
+                  "description": "The locale of the spreadsheet in one of the following formats: an ISO 639-1 language code such as 'en', or an ISO 639-1 language code plus an ISO 3166-1 alpha-2 country code, such as 'en_US'"
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "The time zone of the spreadsheet, in CLDR format such as 'America/New_York'"
+                },
+                "autoRecalc": {
+                  "enum": ["ON_CHANGE", "MINUTE", "HOUR"],
+                  "type": "string",
+                  "description": "The amount of time to wait before volatile functions are recalculated"
+                },
+                "iterativeCalculationSettings": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "maxIterations": {
+                      "type": "integer",
+                      "description": "When iterative calculation is enabled and the results differ between attempts, the maximum number of times to recalculate"
+                    },
+                    "convergenceThreshold": {
+                      "type": "number",
+                      "description": "When iterative calculation is enabled, the minimum change between iterative calculations for the calculation to converge"
+                    }
+                  },
+                  "description": "Settings to control how iterative calculations are performed",
+                  "additionalProperties": false
+                }
+              },
+              "description": "Properties of the spreadsheet",
+              "additionalProperties": false
+            },
+            "dataSources": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["dataSourceId", "spec"],
+                "required": ["dataSourceId", "spec"],
+                "properties": {
+                  "spec": {
+                    "type": "object",
+                    "visible": ["parameters"],
+                    "required": [],
+                    "properties": {
+                      "parameters": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "visible": ["name", "value"],
+                          "required": ["name", "value"],
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "The name of the parameter"
+                            },
+                            "value": {
+                              "type": "string",
+                              "description": "The value of the parameter"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "description": "Parameters for the data source"
+                      }
+                    },
+                    "description": "The specification of the data source",
+                    "additionalProperties": false
+                  },
+                  "dataSourceId": {
+                    "type": "string",
+                    "description": "The ID of the data source"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "Data sources associated with the spreadsheet"
+            },
+            "namedRanges": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["namedRangeId", "name", "range"],
+                "required": ["name", "range"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the named range"
+                  },
+                  "range": {
+                    "type": "object",
+                    "visible": [
+                      "sheetId",
+                      "startRowIndex",
+                      "endRowIndex",
+                      "startColumnIndex",
+                      "endColumnIndex"
+                    ],
+                    "required": ["sheetId"],
+                    "properties": {
+                      "sheetId": {
+                        "type": "integer",
+                        "description": "The sheet this range is on"
+                      },
+                      "endRowIndex": {
+                        "type": "integer",
+                        "description": "The end row (exclusive) of the range, or not set if unbounded"
+                      },
+                      "startRowIndex": {
+                        "type": "integer",
+                        "description": "The start row (inclusive) of the range, or not set if unbounded"
+                      },
+                      "endColumnIndex": {
+                        "type": "integer",
+                        "description": "The end column (exclusive) of the range, or not set if unbounded"
+                      },
+                      "startColumnIndex": {
+                        "type": "integer",
+                        "description": "The start column (inclusive) of the range, or not set if unbounded"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "namedRangeId": {
+                    "type": "string",
+                    "description": "The ID of the named range"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "Named ranges in the spreadsheet"
+            },
+            "spreadsheetUrl": {
+              "type": "string",
+              "description": "The URL of the spreadsheet"
+            },
+            "developerMetadata": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["metadataId", "metadataKey", "metadataValue", "visibility", "location"],
+                "required": ["metadataKey", "metadataValue", "visibility", "location"],
+                "properties": {
+                  "location": {
+                    "type": "object",
+                    "visible": ["sheetId", "dimensionRange"],
+                    "required": ["sheetId"],
+                    "properties": {
+                      "sheetId": {
+                        "type": "integer",
+                        "description": "The sheet ID"
+                      },
+                      "dimensionRange": {
+                        "type": "object",
+                        "visible": ["sheetId", "dimension", "startIndex", "endIndex"],
+                        "required": ["sheetId", "dimension", "startIndex", "endIndex"],
+                        "properties": {
+                          "sheetId": {
+                            "type": "integer",
+                            "description": "The sheet ID"
+                          },
+                          "endIndex": {
+                            "type": "integer",
+                            "description": "The end index"
+                          },
+                          "dimension": {
+                            "enum": ["ROWS", "COLUMNS"],
+                            "type": "string",
+                            "description": "The dimension"
+                          },
+                          "startIndex": {
+                            "type": "integer",
+                            "description": "The start index"
+                          }
+                        },
+                        "description": "The dimension range",
+                        "additionalProperties": false
+                      }
+                    },
+                    "description": "The location of the developer metadata",
+                    "additionalProperties": false
+                  },
+                  "metadataId": {
+                    "type": "integer",
+                    "description": "The ID of the developer metadata"
+                  },
+                  "visibility": {
+                    "enum": ["DEVELOPER_STRING", "DOCUMENT", "PROJECT"],
+                    "type": "string",
+                    "description": "The visibility of the developer metadata"
+                  },
+                  "metadataKey": {
+                    "type": "string",
+                    "description": "The key of the developer metadata"
+                  },
+                  "metadataValue": {
+                    "type": "string",
+                    "description": "The value of the developer metadata"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "Developer metadata associated with the spreadsheet"
+            },
+            "dataSourceSchedules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["dataSourceId", "refreshSchedule"],
+                "required": ["dataSourceId", "refreshSchedule"],
+                "properties": {
+                  "dataSourceId": {
+                    "type": "string",
+                    "description": "The ID of the data source"
+                  },
+                  "refreshSchedule": {
+                    "type": "object",
+                    "visible": ["dailySchedule", "weeklySchedule", "monthlySchedule"],
+                    "required": [],
+                    "properties": {
+                      "dailySchedule": {
+                        "type": "object",
+                        "visible": ["startTime"],
+                        "required": ["startTime"],
+                        "properties": {
+                          "startTime": {
+                            "type": "object",
+                            "visible": ["hours", "minutes", "seconds", "nanos"],
+                            "required": [],
+                            "properties": {
+                              "hours": {
+                                "type": "integer",
+                                "description": "Hours of day in 24 hour format"
+                              },
+                              "nanos": {
+                                "type": "integer",
+                                "description": "Fractions of seconds in nanoseconds"
+                              },
+                              "minutes": {
+                                "type": "integer",
+                                "description": "Minutes of hour"
+                              },
+                              "seconds": {
+                                "type": "integer",
+                                "description": "Seconds of minute"
+                              }
+                            },
+                            "description": "The start time",
+                            "additionalProperties": false
+                          }
+                        },
+                        "description": "Daily refresh schedule",
+                        "additionalProperties": false
+                      },
+                      "weeklySchedule": {
+                        "type": "object",
+                        "visible": ["startTime", "daysOfWeek"],
+                        "required": ["startTime", "daysOfWeek"],
+                        "properties": {
+                          "startTime": {
+                            "type": "object",
+                            "visible": ["hours", "minutes", "seconds", "nanos"],
+                            "required": [],
+                            "properties": {
+                              "hours": {
+                                "type": "integer",
+                                "description": "Hours of day in 24 hour format"
+                              },
+                              "nanos": {
+                                "type": "integer",
+                                "description": "Fractions of seconds in nanoseconds"
+                              },
+                              "minutes": {
+                                "type": "integer",
+                                "description": "Minutes of hour"
+                              },
+                              "seconds": {
+                                "type": "integer",
+                                "description": "Seconds of minute"
+                              }
+                            },
+                            "description": "The start time",
+                            "additionalProperties": false
+                          },
+                          "daysOfWeek": {
+                            "type": "array",
+                            "items": {
+                              "enum": [
+                                "DAY_OF_WEEK_UNSPECIFIED",
+                                "MONDAY",
+                                "TUESDAY",
+                                "WEDNESDAY",
+                                "THURSDAY",
+                                "FRIDAY",
+                                "SATURDAY",
+                                "SUNDAY"
+                              ],
+                              "type": "string"
+                            },
+                            "description": "Days of the week to refresh"
+                          }
+                        },
+                        "description": "Weekly refresh schedule",
+                        "additionalProperties": false
+                      },
+                      "monthlySchedule": {
+                        "type": "object",
+                        "visible": ["startTime", "daysOfMonth"],
+                        "required": ["startTime", "daysOfMonth"],
+                        "properties": {
+                          "startTime": {
+                            "type": "object",
+                            "visible": ["hours", "minutes", "seconds", "nanos"],
+                            "required": [],
+                            "properties": {
+                              "hours": {
+                                "type": "integer",
+                                "description": "Hours of day in 24 hour format"
+                              },
+                              "nanos": {
+                                "type": "integer",
+                                "description": "Fractions of seconds in nanoseconds"
+                              },
+                              "minutes": {
+                                "type": "integer",
+                                "description": "Minutes of hour"
+                              },
+                              "seconds": {
+                                "type": "integer",
+                                "description": "Seconds of minute"
+                              }
+                            },
+                            "description": "The start time",
+                            "additionalProperties": false
+                          },
+                          "daysOfMonth": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            },
+                            "description": "Days of the month to refresh"
+                          }
+                        },
+                        "description": "Monthly refresh schedule",
+                        "additionalProperties": false
+                      }
+                    },
+                    "description": "The refresh schedule",
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "Data source refresh schedules"
+            }
+          },
+          "description": "Request body parameters for creating a spreadsheet",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_SHEETS__VALUES_GET",
+    "description": "Retrieves data from specified range in a spreadsheet",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "VALUES_GET",
+      "canonical_tool_description_hash": "2994ebe9dbde95a3ef0b795f5b179c96497fd46f1c5bfaf8980bff6107d61fef",
+      "canonical_tool_input_schema_hash": "114e08139dffd8d0ae9b874e9ffaa722343b6197cd131d4c90f159dde66ecdaf"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["spreadsheetId", "range"],
+          "properties": {
+            "range": {
+              "type": "string",
+              "description": "The A1 notation or R1C1 notation of the range to retrieve values from"
+            },
+            "spreadsheetId": {
+              "type": "string",
+              "description": "The ID of the spreadsheet to retrieve data from"
+            }
+          },
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "majorDimension": {
+              "enum": ["ROWS", "COLUMNS"],
+              "type": "string",
+              "description": "The major dimension that results should use"
+            },
+            "valueRenderOption": {
+              "enum": ["FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA"],
+              "type": "string",
+              "default": "FORMATTED_VALUE",
+              "description": "How values should be rendered in the output"
+            },
+            "dateTimeRenderOption": {
+              "enum": ["SERIAL_NUMBER", "FORMATTED_STRING"],
+              "type": "string",
+              "default": "SERIAL_NUMBER",
+              "description": "How dates, times, and durations should be represented in the output"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_SHEETS__VALUES_UPDATE",
+    "description": "Sets values in a range of a spreadsheet. The caller must specify the spreadsheet ID, range, and a valueInputOption.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "VALUES_UPDATE",
+      "canonical_tool_description_hash": "c9f6a855d4e8d6736947f8cc7a01f6f21ff5596b1f134f2fd2250a8e80bf9d80",
+      "canonical_tool_input_schema_hash": "337fbe6521174946ed27099584fe12f58b515c0b888a470e82aa33870681218b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["values"],
+          "properties": {
+            "range": {
+              "type": "string",
+              "description": "The range the values cover, in A1 notation. For output, this range indicates the entire requested range, even though the values will exclude trailing rows and columns. When appending values, this field represents the range to search for a table, after which values will be appended."
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Boolean value"
+                    },
+                    {
+                      "type": "string",
+                      "description": "String value. To set a cell to an empty value, use an empty string."
+                    },
+                    {
+                      "type": "number",
+                      "description": "Numeric value (double)"
+                    }
+                  ]
+                }
+              },
+              "description": "The data that was read or to be written. This is an array of arrays, the outer array representing all the data and each inner array representing a major dimension. Each item in the inner array corresponds with one cell. For output, empty trailing rows and columns will not be included. For input, supported value types are: bool, string, and double. Null values will be skipped."
+            },
+            "majorDimension": {
+              "enum": ["DIMENSION_UNSPECIFIED", "ROWS", "COLUMNS"],
+              "type": "string",
+              "description": "Indicates which dimension an operation should apply to. ROWS: Operates on the rows of a sheet. COLUMNS: Operates on the columns of a sheet. DIMENSION_UNSPECIFIED: The default value, do not use."
+            }
+          },
+          "description": "The request body contains an instance of ValueRange",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["spreadsheetId", "range"],
+          "properties": {
+            "range": {
+              "type": "string",
+              "description": "The A1 notation of the values to update"
+            },
+            "spreadsheetId": {
+              "type": "string",
+              "description": "The ID of the spreadsheet to update"
+            }
+          },
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["valueInputOption"],
+          "properties": {
+            "valueInputOption": {
+              "enum": ["INPUT_VALUE_OPTION_UNSPECIFIED", "RAW", "USER_ENTERED"],
+              "type": "string",
+              "description": "How the input data should be interpreted"
+            },
+            "includeValuesInResponse": {
+              "type": "boolean",
+              "description": "Determines if the update response should include the values of the cells that were updated. By default, responses do not include the updated values. If the range to write was larger than the range actually written, the response includes all values in the requested range (excluding trailing empty rows and columns)."
+            },
+            "responseValueRenderOption": {
+              "enum": ["FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA"],
+              "type": "string",
+              "default": "FORMATTED_VALUE",
+              "description": "Determines how values in the response should be rendered. The default render option is FORMATTED_VALUE."
+            },
+            "responseDateTimeRenderOption": {
+              "enum": ["SERIAL_NUMBER", "FORMATTED_STRING"],
+              "type": "string",
+              "default": "SERIAL_NUMBER",
+              "description": "Determines how dates, times, and durations in the response should be rendered. This is ignored if responseValueRenderOption is FORMATTED_VALUE. The default dateTime render option is SERIAL_NUMBER."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_SHEETS__VALUES_BATCH_UPDATE",
+    "description": "Sets values in one or more ranges of a spreadsheet. The caller must specify the spreadsheet ID, a valueInputOption, and one or more ValueRanges.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "VALUES_BATCH_UPDATE",
+      "canonical_tool_description_hash": "81f55858d0d5cd2d7ccf003a2c14b6d2b2fb2fa023bf76d78fcc83ed908333d5",
+      "canonical_tool_input_schema_hash": "879d8849ad405ec62324c91d9d476e11a541b89bad7c299533b23d9f20e6bd58"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["valueInputOption"],
+          "properties": {
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["range", "values", "majorDimension"],
+                "required": ["range", "values"],
+                "properties": {
+                  "range": {
+                    "type": "string",
+                    "description": "The range the values cover, in A1 notation. For output, this range indicates the entire requested range, even though the values will exclude trailing rows and columns."
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "oneOf": [
+                          {
+                            "type": "boolean",
+                            "description": "Boolean value"
+                          },
+                          {
+                            "type": "string",
+                            "description": "String value. To set a cell to an empty value, use an empty string."
+                          },
+                          {
+                            "type": "number",
+                            "description": "Numeric value (double)"
+                          }
+                        ]
+                      }
+                    },
+                    "description": "The data that was read or to be written. This is an array of arrays, the outer array representing all the data and each inner array representing a major dimension. Each item in the inner array corresponds with one cell. For output, empty trailing rows and columns will not be included. For input, supported value types are: bool, string, and double. Null values will be skipped."
+                  },
+                  "majorDimension": {
+                    "enum": ["DIMENSION_UNSPECIFIED", "ROWS", "COLUMNS"],
+                    "type": "string",
+                    "description": "Indicates which dimension an operation should apply to. ROWS: Operates on the rows of a sheet. COLUMNS: Operates on the columns of a sheet. DIMENSION_UNSPECIFIED: The default value, do not use."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The new values to apply to the spreadsheet"
+            },
+            "valueInputOption": {
+              "enum": ["INPUT_VALUE_OPTION_UNSPECIFIED", "RAW", "USER_ENTERED"],
+              "type": "string",
+              "description": "How the input data should be interpreted"
+            },
+            "includeValuesInResponse": {
+              "type": "boolean",
+              "description": "Determines if the update response should include the values of the cells that were updated. By default, responses do not include the updated values. The updatedData field within each of the BatchUpdateValuesResponse.responses contains the updated values. If the range to write was larger than the range actually written, the response includes all values in the requested range (excluding trailing empty rows and columns)."
+            },
+            "responseValueRenderOption": {
+              "enum": ["FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA"],
+              "type": "string",
+              "default": "FORMATTED_VALUE",
+              "description": "Determines how values in the response should be rendered. The default render option is FORMATTED_VALUE."
+            },
+            "responseDateTimeRenderOption": {
+              "enum": ["SERIAL_NUMBER", "FORMATTED_STRING"],
+              "type": "string",
+              "default": "SERIAL_NUMBER",
+              "description": "Determines how dates, times, and durations in the response should be rendered. This is ignored if responseValueRenderOption is FORMATTED_VALUE. The default dateTime render option is SERIAL_NUMBER."
+            }
+          },
+          "description": "The request body contains data with the following structure",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["spreadsheetId"],
+          "properties": {
+            "spreadsheetId": {
+              "type": "string",
+              "description": "The ID of the spreadsheet to update"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_SHEETS__VALUES_APPEND",
+    "description": "Appends values to a spreadsheet. The input range is used to search for existing data and find a 'table' within that range. Values will be appended to the next row of the table, starting from the first column of the table. The caller must specify the spreadsheet ID, range, and a valueInputOption. The valueInputOption only controls how the input data will be added to the sheet (column-wise or row-wise), it does not influence what cell the data starts being written to.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "VALUES_APPEND",
+      "canonical_tool_description_hash": "fe270cd043bec1754e6aff43f958adb0b189c12ab475c382ae3a8321ea99fb98",
+      "canonical_tool_input_schema_hash": "394021cbaced1c3b062fbdf62c635347570f99efaabf92189d89daa3a7f7ac3a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["range", "values"],
+          "properties": {
+            "range": {
+              "type": "string",
+              "description": "The range the values cover, in A1 notation. For output, this range indicates the entire requested range, even though the values will exclude trailing rows and columns. When appending values, this field represents the range to search for a table, after which values will be appended."
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Boolean value"
+                    },
+                    {
+                      "type": "string",
+                      "description": "String value. To set a cell to an empty value, use an empty string."
+                    },
+                    {
+                      "type": "number",
+                      "description": "Numeric value (double)"
+                    }
+                  ]
+                }
+              },
+              "description": "The data that was read or to be written. This is an array of arrays, the outer array representing all the data and each inner array representing a major dimension. Each item in the inner array corresponds with one cell. For output, empty trailing rows and columns will not be included. For input, supported value types are: bool, string, and double. Null values will be skipped."
+            },
+            "majorDimension": {
+              "enum": ["DIMENSION_UNSPECIFIED", "ROWS", "COLUMNS"],
+              "type": "string",
+              "description": "Indicates which dimension an operation should apply to. ROWS: Operates on the rows of a sheet. COLUMNS: Operates on the columns of a sheet. DIMENSION_UNSPECIFIED: The default value, do not use."
+            }
+          },
+          "description": "The request body contains an instance of ValueRange",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["spreadsheetId", "range"],
+          "properties": {
+            "range": {
+              "type": "string",
+              "description": "The A1 notation of a range to search for a logical table of data. Values are appended after the last row of the table."
+            },
+            "spreadsheetId": {
+              "type": "string",
+              "description": "The ID of the spreadsheet to update"
+            }
+          },
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["valueInputOption"],
+          "properties": {
+            "insertDataOption": {
+              "enum": ["OVERWRITE", "INSERT_ROWS"],
+              "type": "string",
+              "default": "OVERWRITE",
+              "description": "How the input data should be inserted"
+            },
+            "valueInputOption": {
+              "enum": ["INPUT_VALUE_OPTION_UNSPECIFIED", "RAW", "USER_ENTERED"],
+              "type": "string",
+              "description": "How the input data should be interpreted. This only controls how the input data will be added to the sheet (column-wise or row-wise), it does not influence what cell the data starts being written to."
+            },
+            "includeValuesInResponse": {
+              "type": "boolean",
+              "description": "Determines if the update response should include the values of the cells that were appended. By default, responses do not include the updated values."
+            },
+            "responseValueRenderOption": {
+              "enum": ["FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA"],
+              "type": "string",
+              "default": "FORMATTED_VALUE",
+              "description": "Determines how values in the response should be rendered. The default render option is FORMATTED_VALUE."
+            },
+            "responseDateTimeRenderOption": {
+              "enum": ["SERIAL_NUMBER", "FORMATTED_STRING"],
+              "type": "string",
+              "default": "SERIAL_NUMBER",
+              "description": "Determines how dates, times, and durations in the response should be rendered. This is ignored if responseValueRenderOption is FORMATTED_VALUE. The default dateTime render option is SERIAL_NUMBER."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/google_tasks/tools.json
+++ b/backend/mcp_servers/google_tasks/tools.json
@@ -1,0 +1,277 @@
+[
+  {
+    "name": "GOOGLE_TASKS__TASKLIST_GET",
+    "description": "Returns a specific task list by ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TASKLIST_GET",
+      "canonical_tool_description_hash": "d2590fae9db4d4ce207c98bf3c355c099fa2aab03bd4ddaa90687551f352e98e",
+      "canonical_tool_input_schema_hash": "d7180b63e441272108fa25403348071a5bd7ab8e475bebc6f7127f8d6a231919"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["tasklist"],
+          "properties": {
+            "tasklist": {
+              "type": "string",
+              "description": "ID of the task list to retrieve."
+            }
+          },
+          "description": "Path parameters.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_TASKS__TASKLIST_LIST",
+    "description": "Returns all task lists for the authenticated user. A user can have up to 2000 lists at a time.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TASKLIST_LIST",
+      "canonical_tool_description_hash": "e49efcfeec6de91cce2a9b99365751eaf9b5b6e45abc4632629625f59c6cc714",
+      "canonical_tool_input_schema_hash": "c3468bc73a6c55068b19da8e6d0cc51e8b6215f4fc90d22c608ee1ffb908d8c3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "pageToken": {
+              "type": "string",
+              "description": "Token specifying the result page to return. Optional."
+            },
+            "maxResults": {
+              "type": "integer",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Maximum number of task lists returned on one page. Optional. The default is 1000 (max allowed: 1000)."
+            }
+          },
+          "description": "Query parameters for pagination and filtering.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_TASKS__TASKS_LIST",
+    "description": "Returns all tasks in the specified task list. Doesn't return assigned tasks by default (from Docs, Chat Spaces). A user can have up to 20,000 non-hidden tasks per list and up to 100,000 tasks in total at a time.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TASKS_LIST",
+      "canonical_tool_description_hash": "932e5d44b801f7ba88bf7cdad68481b0d5b68116ab21f76432abcc887a86891c",
+      "canonical_tool_input_schema_hash": "2439e55727d82b97d4f1302d80fb28d1a9c0e5266b813136e6b87c078a9a7f8b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["tasklist"],
+          "properties": {
+            "tasklist": {
+              "type": "string",
+              "description": "Task list identifier."
+            }
+          },
+          "description": "Path parameters.",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "dueMax": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Upper bound for a task's due date (as a RFC 3339 timestamp) to filter by. Optional. The default is not to filter by due date."
+            },
+            "dueMin": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Lower bound for a task's due date (as a RFC 3339 timestamp) to filter by. Optional. The default is not to filter by due date."
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Token specifying the result page to return. Optional."
+            },
+            "maxResults": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Maximum number of tasks returned on one page. Optional. The default is 20 (max allowed: 100)."
+            },
+            "showHidden": {
+              "type": "boolean",
+              "default": false,
+              "description": "Flag indicating whether hidden tasks are returned in the result. Optional. The default is False."
+            },
+            "updatedMin": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Lower bound for a task's last modification time (as a RFC 3339 timestamp) to filter by. Optional. The default is not to filter by last modification time."
+            },
+            "showDeleted": {
+              "type": "boolean",
+              "default": false,
+              "description": "Flag indicating whether deleted tasks are returned in the result. Optional. The default is False."
+            },
+            "completedMax": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Upper bound for a task's completion date (as a RFC 3339 timestamp) to filter by. Optional. The default is not to filter by completion date."
+            },
+            "completedMin": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Lower bound for a task's completion date (as a RFC 3339 timestamp) to filter by. Optional. The default is not to filter by completion date."
+            },
+            "showAssigned": {
+              "type": "boolean",
+              "default": false,
+              "description": "Flag indicating whether tasks assigned to the current user are returned in the result. Optional. The default is False."
+            },
+            "showCompleted": {
+              "type": "boolean",
+              "default": true,
+              "description": "Flag indicating whether completed tasks are returned in the result. Note that showHidden must also be True to show tasks completed in first party clients, such as the web UI and Google's mobile apps. Optional. The default is True."
+            }
+          },
+          "description": "Query parameters for filtering tasks.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_TASKS__TASKS_INSERT",
+    "description": "Creates a new task in the specified task list. Tasks assigned through Google Docs or Chat Spaces cannot be inserted through the Tasks public API; they can only be created through Google Docs or Chat Spaces assignments. A user can have up to 20,000 non-hidden tasks per list and up to 100,000 tasks in total at a time.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TASKS_INSERT",
+      "canonical_tool_description_hash": "570895753b6c95064a59151fe86f48c96297efc78de0f0fc637b55ff072ccc2a",
+      "canonical_tool_input_schema_hash": "5c6739b8e4216b13e589c5774c2dc176e5978213061d0662f90f5a5c882b4557"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "due": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Due date of the task (as a RFC 3339 timestamp). Optional. The due date only records date information; the time portion of the timestamp is discarded when setting the due date. It isn't possible to read or write the time that a task is due via the API."
+            },
+            "notes": {
+              "type": "string",
+              "description": "Notes describing the task. Tasks assigned from Google Docs cannot have notes. Optional. Maximum length allowed: 8192 characters."
+            },
+            "title": {
+              "type": "string",
+              "description": "Title of the task. Maximum length allowed: 1024 characters."
+            },
+            "hidden": {
+              "type": "boolean",
+              "description": "Flag indicating whether the task is hidden. This is the case if the task had been marked completed when the task list was last cleared. The default is False. This field is read-only."
+            },
+            "status": {
+              "enum": ["needsAction", "completed"],
+              "type": "string",
+              "description": "Status of the task. This is either \"needsAction\" or \"completed\"."
+            },
+            "deleted": {
+              "type": "boolean",
+              "description": "Flag indicating whether the task has been deleted. For assigned tasks this field is read-only. They can only be deleted by calling tasks.delete, in which case both the assigned task and the original task (in Docs or Chat Spaces) are deleted. To delete the assigned task only, navigate to the assignment surface and unassign the task from there. The default is False."
+            },
+            "completed": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Completion date of the task (as a RFC 3339 timestamp). This field is omitted if the task has not been completed."
+            }
+          },
+          "description": "Task properties to create.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["tasklist"],
+          "properties": {
+            "tasklist": {
+              "type": "string",
+              "description": "Task list identifier."
+            }
+          },
+          "description": "Path parameters.",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "parent": {
+              "type": "string",
+              "description": "Parent task identifier. If the task is created at the top level, omit this parameter. Assigned tasks cannot be parent tasks or have parent tasks. Setting the parent to an assigned task will cause the request to fail. Optional."
+            },
+            "previous": {
+              "type": "string",
+              "description": "Previous sibling task identifier. If the task is created at the first position among its siblings, omit this parameter. Optional."
+            }
+          },
+          "description": "Query parameters for task insertion.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "GOOGLE_TASKS__TASKS_DELETE",
+    "description": "Deletes a task from the specified task list.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TASKS_DELETE",
+      "canonical_tool_description_hash": "91f303627d21a5cb0eea4696592dace5ec801e8e389e0a9325b961ade60271ca",
+      "canonical_tool_input_schema_hash": "7a74e461b68ea74e92f9c611077ee6a1cff2280df035f13cbc88ba861576557d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["tasklist", "task"],
+          "properties": {
+            "task": {
+              "type": "string",
+              "description": "ID of the task to delete."
+            },
+            "tasklist": {
+              "type": "string",
+              "description": "ID of the task list containing the task."
+            }
+          },
+          "description": "Path parameters.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/hackernews/tools.json
+++ b/backend/mcp_servers/hackernews/tools.json
@@ -1,0 +1,134 @@
+[
+  {
+    "name": "HACKERNEWS__TOP_STORIES_GET",
+    "description": "Fetch the top stories from HackerNews.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TOP_STORIES_GET",
+      "canonical_tool_description_hash": "fe13345cc511945fc53f0549b4022b8f68e278ee753ea16f42413a9084e8645c",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "HACKERNEWS__ITEM_GET",
+    "description": "Fetch a specific item (story or comment) by ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ITEM_GET",
+      "canonical_tool_description_hash": "9accc60cf7712370d44c12bcc10c13a024618d7cb75c3d1e3794027fd50d8695",
+      "canonical_tool_input_schema_hash": "d2ba47ec26431b3eeefdb78f79033955bcb3d29b06811575d1ceba8f63581e46"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the item (story or comment) to retrieve."
+            }
+          },
+          "description": "Path parameters for the request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "HACKERNEWS__USER_GET",
+    "description": "Fetch user information by user ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "USER_GET",
+      "canonical_tool_description_hash": "0a05a8dd22bb946b816f6b637bd5c62682f73b7c4c6e805996612bce57ff60de",
+      "canonical_tool_input_schema_hash": "9db32d56e85af2b64835c8f5eddf77dc88cc02e7adf50460bd24138807d8fefe"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the user to retrieve."
+            }
+          },
+          "description": "Path parameters for the request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "HACKERNEWS__USER_STORIES_GET",
+    "description": "Fetch stories submitted by a user.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "USER_STORIES_GET",
+      "canonical_tool_description_hash": "a022da0d4fea36b4691d081d93de10e9c0bd5aebd7b60cfcdb72d79ad31dbf13",
+      "canonical_tool_input_schema_hash": "05d6ccc696fcc85c774b2b3b64bbc6238571106e2b8e04739921209105dd4fa2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the user whose submitted stories to retrieve."
+            }
+          },
+          "description": "Path parameters for the request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "HACKERNEWS__USER_RECEIVED_GET",
+    "description": "Fetch stories received (comments) by a user.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "USER_RECEIVED_GET",
+      "canonical_tool_description_hash": "93511629044e5e01aac80b4f4fba0fc1cd3315bc26964ad0c646c9b302332c59",
+      "canonical_tool_input_schema_hash": "7bb6140810b52ead803d26626b9c073b0d089781e1b1427e8fa0a115e4085eb9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the user whose received stories/comments to retrieve."
+            }
+          },
+          "description": "Path parameters for the request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/holded/tools.json
+++ b/backend/mcp_servers/holded/tools.json
@@ -1,0 +1,359 @@
+[
+  {
+    "name": "HOLDED__LIST_EMPLOYEES",
+    "description": "List all employees with pagination",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_EMPLOYEES",
+      "canonical_tool_description_hash": "4517c80703c5499708731f7a25f41d2261e66051761943953ef7da4c30ff9652",
+      "canonical_tool_input_schema_hash": "f54de584ab439d2076e7ce35952b49c4d5a01c73fce92565df03fcf5535c999c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "page": {
+              "type": "integer",
+              "default": 1,
+              "description": "Page number for pagination"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "HOLDED__CREATE_EMPLOYEE",
+    "description": "Create a new employee",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_EMPLOYEE",
+      "canonical_tool_description_hash": "56ab1613f484d0dcca05b80997d08c1fa49af6ad9f43afd91065f4da0ec200fb",
+      "canonical_tool_input_schema_hash": "ace336ff8575916ce1aad584264607ca537686e0e0314fb483223e3d4be6014b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name", "lastName", "email"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "First name of the employee"
+            },
+            "email": {
+              "type": "string",
+              "description": "Email address of the employee"
+            },
+            "lastName": {
+              "type": "string",
+              "description": "Last name of the employee"
+            },
+            "sendInvite": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether to send an invite email to the employee"
+            }
+          },
+          "description": "Employee creation parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "HOLDED__GET_EMPLOYEE",
+    "description": "Get details of a specific employee",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_EMPLOYEE",
+      "canonical_tool_description_hash": "8ee10898c426e6875bf6fb72c7217c0caba77e49787d4202f00de8353c9ae3e6",
+      "canonical_tool_input_schema_hash": "f4e4773e769113f7b02819fa2000b58d481e5718ca0c478f0444499190a9076a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["employeeId"],
+          "properties": {
+            "employeeId": {
+              "type": "string",
+              "description": "ID of the employee to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "HOLDED__UPDATE_EMPLOYEE",
+    "description": "Update an existing employee's information",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_EMPLOYEE",
+      "canonical_tool_description_hash": "60a680e75f0483e9c962f2cae707ddf3303bb618370add6ca4643784dc60c0f1",
+      "canonical_tool_input_schema_hash": "38c4a7bad6be09291d40c8aa29bc6b87b2636cfe78eefa7463b539cf5d562ab0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Employee code or NIF"
+            },
+            "iban": {
+              "type": "string",
+              "description": "International Bank Account Number"
+            },
+            "name": {
+              "type": "string",
+              "description": "First name of the employee"
+            },
+            "email": {
+              "type": "string",
+              "description": "Email address of the employee"
+            },
+            "phone": {
+              "type": "string",
+              "description": "Phone number of the employee"
+            },
+            "teams": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of team IDs the employee belongs to"
+            },
+            "gender": {
+              "enum": ["male", "female"],
+              "type": "string",
+              "description": "Gender of the employee"
+            },
+            "mobile": {
+              "type": "string",
+              "description": "Mobile phone number of the employee"
+            },
+            "address": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "City"
+                },
+                "address": {
+                  "type": "string",
+                  "description": "Street address"
+                },
+                "country": {
+                  "type": "string",
+                  "description": "Country"
+                },
+                "province": {
+                  "type": "string",
+                  "description": "Province or state"
+                },
+                "postalCode": {
+                  "type": "string",
+                  "description": "Postal or ZIP code"
+                }
+              },
+              "description": "Employee's address information",
+              "additionalProperties": false
+            },
+            "lastName": {
+              "type": "string",
+              "description": "Last name of the employee"
+            },
+            "mainEmail": {
+              "type": "string",
+              "description": "Main email address of the employee"
+            },
+            "workplace": {
+              "type": "string",
+              "description": "ID of the workplace"
+            },
+            "dateOfBirth": {
+              "type": "string",
+              "description": "Date of birth in format dd/mm/yyyy"
+            },
+            "nationality": {
+              "type": "string",
+              "description": "Nationality of the employee"
+            },
+            "reportingTo": {
+              "type": "string",
+              "description": "ID of the employee this employee reports to"
+            },
+            "holdedUserId": {
+              "type": "string",
+              "description": "Holded user ID"
+            },
+            "mainLanguage": {
+              "enum": [
+                "English",
+                "English(UK)",
+                "English(US)",
+                "English(Canada)",
+                "Spanish",
+                "Spanish(Spain)",
+                "Spanish(Mexico)",
+                "Spanish(Argentina)",
+                "Spanish(Colombia)",
+                "Portuguese",
+                "Portuguese(Portugal)",
+                "Portuguese(Brazil)",
+                "Catalan",
+                "Galician",
+                "Euskera",
+                "French",
+                "German(Deutsch)",
+                "Italian",
+                "Greek",
+                "Swedish",
+                "Dutch",
+                "Finnish",
+                "Irish",
+                "Norwegian",
+                "Danish",
+                "Czech",
+                "Croatian",
+                "Russian",
+                "Polish"
+              ],
+              "type": "string",
+              "description": "Main language of the employee"
+            },
+            "fiscalAddress": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "City"
+                },
+                "idNum": {
+                  "type": "string",
+                  "description": "Identification number"
+                },
+                "address": {
+                  "type": "string",
+                  "description": "Street address"
+                },
+                "country": {
+                  "type": "string",
+                  "description": "Country"
+                },
+                "province": {
+                  "type": "string",
+                  "description": "Province or state"
+                },
+                "postalCode": {
+                  "type": "string",
+                  "description": "Postal or ZIP code"
+                },
+                "cityOfBirth": {
+                  "type": "string",
+                  "description": "City of birth"
+                },
+                "countryOfBirth": {
+                  "type": "string",
+                  "description": "Country of birth"
+                },
+                "endSituationDate": {
+                  "type": "string",
+                  "description": "End date of the situation"
+                }
+              },
+              "description": "Fiscal address information. This object is only used when fiscalResidence is set to false.",
+              "additionalProperties": false
+            },
+            "fiscalResidence": {
+              "type": "boolean",
+              "description": "Whether the fiscal residence is the same as the regular address"
+            },
+            "timeOffPolicyId": {
+              "type": "string",
+              "description": "ID of the time off policy for the employee"
+            },
+            "socialSecurityNum": {
+              "type": "string",
+              "description": "Social security number"
+            },
+            "timeOffSupervisors": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of employee IDs who are supervisors for time off"
+            }
+          },
+          "description": "Employee update parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["employeeId"],
+          "properties": {
+            "employeeId": {
+              "type": "string",
+              "description": "ID of the employee to update"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "HOLDED__DELETE_EMPLOYEE",
+    "description": "Delete an employee",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_EMPLOYEE",
+      "canonical_tool_description_hash": "565b5278bcdee8b968010eaacfe2ec280429baac1bff3e8f6955151c91c44ea8",
+      "canonical_tool_input_schema_hash": "6082a3d422545090960716c5683eb5e706e31c5da02c52a10920e918e4433582"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["employeeId"],
+          "properties": {
+            "employeeId": {
+              "type": "string",
+              "description": "ID of the employee to delete"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/linear/tools.json
+++ b/backend/mcp_servers/linear/tools.json
@@ -16,9 +16,7 @@
           "description": "The issue ID"
         }
       },
-      "required": [
-        "issueId"
-      ],
+      "required": ["issueId"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -48,10 +46,7 @@
           "description": "The content of the comment as Markdown"
         }
       },
-      "required": [
-        "issueId",
-        "body"
-      ],
+      "required": ["issueId", "body"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -74,17 +69,11 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "current",
-            "previous",
-            "next"
-          ],
+          "enum": ["current", "previous", "next"],
           "description": "Retrieve the current, previous, next, or all cycles. If no type is provided all cycles in the team will be returned"
         }
       },
-      "required": [
-        "teamId"
-      ],
+      "required": ["teamId"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -106,9 +95,7 @@
           "description": "The document ID or slug"
         }
       },
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -141,10 +128,7 @@
         },
         "orderBy": {
           "type": "string",
-          "enum": [
-            "createdAt",
-            "updatedAt"
-          ],
+          "enum": ["createdAt", "updatedAt"],
           "default": "updatedAt",
           "description": "The order in which to return results"
         },
@@ -199,9 +183,7 @@
           "description": "The issue ID"
         }
       },
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -234,10 +216,7 @@
         },
         "orderBy": {
           "type": "string",
-          "enum": [
-            "createdAt",
-            "updatedAt"
-          ],
+          "enum": ["createdAt", "updatedAt"],
           "default": "updatedAt",
           "description": "The order in which to return results"
         },
@@ -372,19 +351,13 @@
                 "minLength": 1
               }
             },
-            "required": [
-              "url",
-              "title"
-            ],
+            "required": ["url", "title"],
             "additionalProperties": false
           },
           "description": "Array of link objects to attach to the issue. Each object must contain a valid `url` and a non-empty `title`."
         }
       },
-      "required": [
-        "title",
-        "team"
-      ],
+      "required": ["title", "team"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -470,18 +443,13 @@
                 "minLength": 1
               }
             },
-            "required": [
-              "url",
-              "title"
-            ],
+            "required": ["url", "title"],
             "additionalProperties": false
           },
           "description": "Array of link objects to attach to the issue. Each object must contain a valid `url` and a non-empty `title`."
         }
       },
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -503,9 +471,7 @@
           "description": "The team name or ID"
         }
       },
-      "required": [
-        "team"
-      ],
+      "required": ["team"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -535,11 +501,7 @@
           "description": "The team name or ID"
         }
       },
-      "required": [
-        "id",
-        "name",
-        "team"
-      ],
+      "required": ["id", "name", "team"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -572,10 +534,7 @@
         },
         "orderBy": {
           "type": "string",
-          "enum": [
-            "createdAt",
-            "updatedAt"
-          ],
+          "enum": ["createdAt", "updatedAt"],
           "default": "updatedAt",
           "description": "The order in which to return results"
         }
@@ -612,10 +571,7 @@
         },
         "orderBy": {
           "type": "string",
-          "enum": [
-            "createdAt",
-            "updatedAt"
-          ],
+          "enum": ["createdAt", "updatedAt"],
           "default": "updatedAt",
           "description": "The order in which to return results"
         },
@@ -670,9 +626,7 @@
           "description": "Whether this is label group (cannot be applied to issues directly)"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -705,10 +659,7 @@
         },
         "orderBy": {
           "type": "string",
-          "enum": [
-            "createdAt",
-            "updatedAt"
-          ],
+          "enum": ["createdAt", "updatedAt"],
           "default": "updatedAt",
           "description": "The order in which to return results"
         },
@@ -751,9 +702,7 @@
           "description": "The ID or name of the project to retrieve"
         }
       },
-      "required": [
-        "query"
-      ],
+      "required": ["query"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -806,10 +755,7 @@
           "description": "The UUID of the user to set as project lead"
         }
       },
-      "required": [
-        "name",
-        "teamId"
-      ],
+      "required": ["name", "teamId"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -862,9 +808,7 @@
           "description": "The UUID of the user to set as project lead"
         }
       },
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -913,10 +857,7 @@
         },
         "orderBy": {
           "type": "string",
-          "enum": [
-            "createdAt",
-            "updatedAt"
-          ],
+          "enum": ["createdAt", "updatedAt"],
           "default": "updatedAt",
           "description": "The order in which to return results"
         },
@@ -959,9 +900,7 @@
           "description": "The UUID, key, or name of the team to retrieve"
         }
       },
-      "required": [
-        "query"
-      ],
+      "required": ["query"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -1004,9 +943,7 @@
           "description": "The UUID or name of the user to retrieve"
         }
       },
-      "required": [
-        "query"
-      ],
+      "required": ["query"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -1033,9 +970,7 @@
           "description": "The page number"
         }
       },
-      "required": [
-        "query"
-      ],
+      "required": ["query"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }

--- a/backend/mcp_servers/lmnt/tools.json
+++ b/backend/mcp_servers/lmnt/tools.json
@@ -1,0 +1,364 @@
+[
+  {
+    "name": "LMNT__VOICE_INFO",
+    "description": "Returns details of a specific voice.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "VOICE_INFO",
+      "canonical_tool_description_hash": "f798ac93cf8f2c7f28e050878e69cb9b90847dabb3b744f99b4872ef29fadd37",
+      "canonical_tool_input_schema_hash": "cd4f551cf9573038ce6803545c10a465bbe42c5df44fb242bb33c418580188c3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The id of the voice to update, which can be retrieved by a call to List voices."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "LMNT__SPEECH_BYTES",
+    "description": "Synthesizes speech from a text string and returns the audio data as a binary stream.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SPEECH_BYTES",
+      "canonical_tool_description_hash": "989bd6a983634ba9fa24f875d2f2e775ad7d89ef42ec56a9173d9fcbc96beb1b",
+      "canonical_tool_input_schema_hash": "eaeae314f7ac475c2e914e4da0dc0cc59c34bf455a35800868ca837666ce14aa"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["voice", "text"],
+          "properties": {
+            "text": {
+              "type": "string",
+              "example": "hello world.",
+              "description": "The text to synthesize; max 5000 characters per request (including spaces)"
+            },
+            "model": {
+              "enum": ["aurora", "blizzard"],
+              "type": "string",
+              "default": "aurora",
+              "description": "The model to use for synthesis. One of aurora (default) or blizzard."
+            },
+            "speed": {
+              "type": "number",
+              "default": 1,
+              "maximum": 2,
+              "minimum": 0.25,
+              "description": "The talking speed of the generated speech, a floating point value between 0.25 (slow) and 2.0 (fast)."
+            },
+            "top_p": {
+              "type": "number",
+              "default": 1,
+              "maximum": 1,
+              "minimum": 0,
+              "description": "Controls the stability of the generated speech."
+            },
+            "voice": {
+              "type": "string",
+              "example": "ava",
+              "description": "The voice id of the voice to use; voice ids can be retrieved by calls to List voices or Voice info."
+            },
+            "format": {
+              "enum": ["aac", "mp3", "mulaw", "raw", "wav"],
+              "type": "string",
+              "default": "mp3",
+              "description": "The file format of the audio output"
+            },
+            "length": {
+              "type": "number",
+              "maximum": 300,
+              "description": "Produce speech of this length in seconds; maximum 300.0 (5 minutes)."
+            },
+            "language": {
+              "enum": [
+                "auto",
+                "en",
+                "es",
+                "pt",
+                "fr",
+                "de",
+                "zh",
+                "ko",
+                "hi",
+                "ja",
+                "ru",
+                "it",
+                "tr"
+              ],
+              "type": "string",
+              "default": "auto",
+              "description": "The desired language. Two letter ISO 639-1 code."
+            },
+            "sample_rate": {
+              "enum": [8000, 16000, 24000],
+              "type": "integer",
+              "default": 24000,
+              "description": "The desired output sample rate in Hz"
+            },
+            "temperature": {
+              "type": "number",
+              "default": 1,
+              "minimum": 0,
+              "description": "Influences how expressive and emotionally varied the speech becomes."
+            },
+            "conversational": {
+              "type": "boolean",
+              "default": false,
+              "description": "Set this to true to generate conversational-style speech rather than reading-style speech."
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "LMNT__SPEECH_ADVANCED",
+    "description": "Synthesizes speech from a text string and provides advanced information about the synthesis.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SPEECH_ADVANCED",
+      "canonical_tool_description_hash": "7f16053b7dc961d0075619931252f158a965a7859a045e51962fdff87fecf137",
+      "canonical_tool_input_schema_hash": "1974e37b217635a62f607a53a3974e5fb74eb855f15afa55f6efd8738fd67b05"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["voice", "text"],
+          "properties": {
+            "text": {
+              "type": "string",
+              "example": "hello world.",
+              "description": "The text to synthesize; max 5000 characters per request (including spaces)"
+            },
+            "model": {
+              "enum": ["aurora", "blizzard"],
+              "type": "string",
+              "default": "aurora",
+              "description": "The model to use for synthesis. One of aurora (default) or blizzard."
+            },
+            "speed": {
+              "type": "number",
+              "default": 1,
+              "maximum": 2,
+              "minimum": 0.25,
+              "description": "The talking speed of the generated speech, a floating point value between 0.25 (slow) and 2.0 (fast)."
+            },
+            "top_p": {
+              "type": "number",
+              "default": 1,
+              "maximum": 1,
+              "minimum": 0,
+              "description": "Controls the stability of the generated speech."
+            },
+            "voice": {
+              "type": "string",
+              "example": "ava",
+              "description": "The voice id of the voice to use; voice ids can be retrieved by calls to List voices or Voice info."
+            },
+            "format": {
+              "enum": ["aac", "mp3", "mulaw", "raw", "wav"],
+              "type": "string",
+              "default": "mp3",
+              "description": "The file format of the audio output"
+            },
+            "length": {
+              "type": "number",
+              "maximum": 300,
+              "description": "Produce speech of this length in seconds; maximum 300.0 (5 minutes)."
+            },
+            "language": {
+              "enum": [
+                "auto",
+                "en",
+                "es",
+                "pt",
+                "fr",
+                "de",
+                "zh",
+                "ko",
+                "hi",
+                "ja",
+                "ru",
+                "it",
+                "tr"
+              ],
+              "type": "string",
+              "default": "auto",
+              "description": "The desired language. Two letter ISO 639-1 code."
+            },
+            "sample_rate": {
+              "enum": [8000, 16000, 24000],
+              "type": "integer",
+              "default": 24000,
+              "description": "The desired output sample rate in Hz"
+            },
+            "temperature": {
+              "type": "number",
+              "default": 1,
+              "minimum": 0,
+              "description": "Influences how expressive and emotionally varied the speech becomes."
+            },
+            "conversational": {
+              "type": "boolean",
+              "default": false,
+              "description": "Set this to true to generate conversational-style speech rather than reading-style speech."
+            },
+            "return_durations": {
+              "type": "boolean",
+              "default": false,
+              "description": "If set as true, response will contain a durations object."
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "LMNT__LIST_VOICES",
+    "description": "Returns a list of voices available to you.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_VOICES",
+      "canonical_tool_description_hash": "c5a68bc1593b58e3f319497b805904e6af4f8c9e9e2717ff84fd85f639242339",
+      "canonical_tool_input_schema_hash": "4cc38e063fe2f9994f9ee946c9fb3a831474bb5424904f44b41bd9b21a95a7ca"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "owner": {
+              "enum": ["system", "me", "all"],
+              "type": "string",
+              "default": "all",
+              "description": "Which owner's voices to return. Choose from system, me, or all."
+            },
+            "starred": {
+              "type": "string",
+              "default": "false",
+              "description": "If true, only returns voices that you have starred."
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "LMNT__UPDATE_VOICE",
+    "description": "Updates metadata for a specific voice. Only provided fields will be changed.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_VOICE",
+      "canonical_tool_description_hash": "a7d9f22011b7b43c68ce280c8200a9eaee8f08958104fe8dee8776a33f763602",
+      "canonical_tool_input_schema_hash": "df54de068e5e73f58e16ab406cad3c39b37bb1594c5f601a45614de5ee4ca8a7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The display name for this voice."
+            },
+            "gender": {
+              "type": "string",
+              "description": "A tag describing the gender of this voice, e.g. male, female, nonbinary."
+            },
+            "starred": {
+              "type": "boolean",
+              "description": "If true, adds this voice to your starred list."
+            },
+            "unfreeze": {
+              "type": "boolean",
+              "description": "If true, unfreezes this voice and upgrades it to the latest model."
+            },
+            "description": {
+              "type": "string",
+              "description": "A description of this voice."
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The id of the voice to update, which can be retrieved by a call to List voices."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "LMNT__DELETE_VOICE",
+    "description": "Deletes a voice and cancels any pending operations on it. Cannot be undone.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_VOICE",
+      "canonical_tool_description_hash": "d96517500732f96aa3dad7d7ce9e30dcd21e75ea21d77b8a591ab3aabc183efa",
+      "canonical_tool_input_schema_hash": "582726332f90fbcbb5cff37b01dd3ac5066076d02591ef6ca9682906db39e011"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The id of the voice to delete, which can be retrieved by a call to List voices."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/microsoft_calendar/tools.json
+++ b/backend/mcp_servers/microsoft_calendar/tools.json
@@ -1,0 +1,1994 @@
+[
+  {
+    "name": "MICROSOFT_CALENDAR__CREATE_EVENT_DEFAULT",
+    "description": "Create an event in the user's default calendar with simplified parameters. Perfect for quick event creation without specifying a calendar ID. Supports all event features including attendees, locations, recurrence patterns, and online meeting details.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_EVENT_DEFAULT",
+      "canonical_tool_description_hash": "d1cd56765c0eacddd1be5c1a51f2e218aa8f3d60f4a9799162c004f828ffe747",
+      "canonical_tool_input_schema_hash": "f4e0ed465f4c278c91de4a5236885207c5545aa4bf145337d9943f281c681e94"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["subject", "start", "end"],
+          "properties": {
+            "end": {
+              "type": "object",
+              "required": ["dateTime"],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "description": "End date and time in ISO 8601 format (e.g., '2024-04-04T15:00:00')"
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Time zone (e.g., 'UTC', 'America/New_York', 'Europe/London')"
+                }
+              },
+              "description": "Event end date and time",
+              "additionalProperties": false
+            },
+            "body": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The content of the event description"
+                },
+                "contentType": {
+                  "enum": ["text", "html"],
+                  "type": "string",
+                  "description": "The content type (text or html)"
+                }
+              },
+              "description": "The event description/body",
+              "additionalProperties": false
+            },
+            "start": {
+              "type": "object",
+              "required": ["dateTime"],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "description": "Start date and time in ISO 8601 format (e.g., '2024-04-04T14:00:00')"
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Time zone (e.g., 'UTC', 'America/New_York', 'Europe/London')"
+                }
+              },
+              "description": "Event start date and time",
+              "additionalProperties": false
+            },
+            "showAs": {
+              "enum": ["free", "tentative", "busy", "oof", "workingElsewhere"],
+              "type": "string",
+              "description": "Show availability as (free, tentative, busy, oof, workingElsewhere)"
+            },
+            "subject": {
+              "type": "string",
+              "description": "The event title/subject"
+            },
+            "isAllDay": {
+              "type": "boolean",
+              "description": "Whether this is an all-day event"
+            },
+            "location": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "address": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "city": {
+                      "type": "string",
+                      "description": "City name"
+                    },
+                    "state": {
+                      "type": "string",
+                      "description": "State or province"
+                    },
+                    "street": {
+                      "type": "string",
+                      "description": "Street address"
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "description": "Postal or ZIP code"
+                    },
+                    "countryOrRegion": {
+                      "type": "string",
+                      "description": "Country or region"
+                    }
+                  },
+                  "description": "Physical address details",
+                  "additionalProperties": false
+                },
+                "displayName": {
+                  "type": "string",
+                  "description": "Location display name (e.g., 'Conference Room A', 'Microsoft Teams', '123 Main St')"
+                },
+                "locationEmailAddress": {
+                  "type": "string",
+                  "description": "Email address for room or resource (if the location has an email address)"
+                }
+              },
+              "description": "Event location details",
+              "additionalProperties": false
+            },
+            "attendees": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["emailAddress", "type"],
+                "required": ["emailAddress"],
+                "properties": {
+                  "type": {
+                    "enum": ["required", "optional", "resource"],
+                    "type": "string",
+                    "description": "Type: 'required' for essential attendees, 'optional' for non-essential, 'resource' for rooms/equipment"
+                  },
+                  "emailAddress": {
+                    "type": "object",
+                    "visible": ["address", "name"],
+                    "required": ["address"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Display name of the attendee or resource"
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "Email address of the attendee or resource"
+                      }
+                    },
+                    "description": "Attendee email details",
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "List of event attendees (including resources like meeting rooms or equipment)"
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of category names for the event"
+            },
+            "importance": {
+              "enum": ["low", "normal", "high"],
+              "type": "string",
+              "description": "Event importance level"
+            },
+            "recurrence": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "range": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "type": {
+                      "enum": ["endDate", "noEnd", "numbered"],
+                      "type": "string",
+                      "description": "The recurrence range type"
+                    },
+                    "endDate": {
+                      "type": "string",
+                      "description": "The date to stop applying the recurrence pattern"
+                    },
+                    "startDate": {
+                      "type": "string",
+                      "description": "The date to start applying the recurrence pattern"
+                    },
+                    "numberOfOccurrences": {
+                      "type": "integer",
+                      "description": "The number of times to repeat the event"
+                    }
+                  },
+                  "description": "The range of the recurrence",
+                  "additionalProperties": false
+                },
+                "pattern": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "daily",
+                        "weekly",
+                        "absoluteMonthly",
+                        "relativeMonthly",
+                        "absoluteYearly",
+                        "relativeYearly"
+                      ],
+                      "type": "string",
+                      "description": "The recurrence pattern type"
+                    },
+                    "index": {
+                      "enum": ["first", "second", "third", "fourth", "last"],
+                      "type": "string",
+                      "description": "Specifies on which instance of the allowed days specified in daysOfWeek the event occurs"
+                    },
+                    "month": {
+                      "type": "integer",
+                      "description": "The month in which the event occurs"
+                    },
+                    "interval": {
+                      "type": "integer",
+                      "description": "The number of units between occurrences"
+                    },
+                    "dayOfMonth": {
+                      "type": "integer",
+                      "description": "The day of the month on which the event occurs"
+                    },
+                    "daysOfWeek": {
+                      "type": "array",
+                      "items": {
+                        "enum": [
+                          "sunday",
+                          "monday",
+                          "tuesday",
+                          "wednesday",
+                          "thursday",
+                          "friday",
+                          "saturday"
+                        ],
+                        "type": "string"
+                      },
+                      "description": "Days of the week on which the event occurs"
+                    },
+                    "firstDayOfWeek": {
+                      "enum": [
+                        "sunday",
+                        "monday",
+                        "tuesday",
+                        "wednesday",
+                        "thursday",
+                        "friday",
+                        "saturday"
+                      ],
+                      "type": "string",
+                      "description": "The first day of the week"
+                    }
+                  },
+                  "description": "The frequency of the recurrence",
+                  "additionalProperties": false
+                }
+              },
+              "description": "The recurrence pattern for the event",
+              "additionalProperties": false
+            },
+            "sensitivity": {
+              "enum": ["normal", "personal", "private", "confidential"],
+              "type": "string",
+              "description": "Event sensitivity level"
+            },
+            "isReminderOn": {
+              "type": "boolean",
+              "description": "Whether to show a reminder for this event"
+            },
+            "isOnlineMeeting": {
+              "type": "boolean",
+              "description": "Whether this is an online meeting"
+            },
+            "responseRequested": {
+              "type": "boolean",
+              "description": "Whether to request responses from attendees"
+            },
+            "allowNewTimeProposals": {
+              "type": "boolean",
+              "description": "Whether attendees can propose new times (default: true)"
+            },
+            "onlineMeetingProvider": {
+              "enum": ["unknown", "skypeForBusiness", "skypeForConsumer", "teamsForBusiness"],
+              "type": "string",
+              "description": "Online meeting provider"
+            },
+            "reminderMinutesBeforeStart": {
+              "type": "integer",
+              "description": "Minutes before start to show reminder (e.g., 15, 30, 60)"
+            }
+          },
+          "description": "Event details to create in the default calendar",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__LIST_CALENDARS",
+    "description": "Get all the user's calendars. This retrieves calendars from the default calendar group and allows filtering, sorting, and selecting specific properties using OData query parameters.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_CALENDARS",
+      "canonical_tool_description_hash": "c870c201b067ec1f05f78e6de3396cdae7249cd6a249c1a03fec1ce037ef1c2e",
+      "canonical_tool_input_schema_hash": "6c454f7adee382df647ec4d9fa2367d9bcd32d19934eaebb2335928d8974dea7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of calendars to return"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of calendars to skip for pagination"
+            },
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities (e.g., 'events', 'singleValueExtendedProperties')"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "Filter expression to limit calendars returned (e.g., 'canEdit eq true', 'owner/name eq \"John Doe\"')"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response (e.g., 'id,name,color,owner')"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort calendars by with direction (e.g., 'name asc', 'createdDateTime desc')"
+            }
+          },
+          "description": "Query parameters for customizing the calendar list",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__CREATE_CALENDAR",
+    "description": "Create a new calendar for the user. This creates a calendar in the user's default calendar group with the specified name and optional properties like color.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_CALENDAR",
+      "canonical_tool_description_hash": "0c4e6b48d4bcd1bc5613aa32a9e084edb85027d2e9ef2702903598f7d922dc0d",
+      "canonical_tool_input_schema_hash": "587979f10069abedec490514c94ad69e8fff9758bc5f9eaa72e4af94207c9336"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the new calendar. This will be displayed in the calendar list."
+            },
+            "color": {
+              "enum": [
+                "lightBlue",
+                "lightGreen",
+                "lightOrange",
+                "lightGray",
+                "lightYellow",
+                "lightTeal",
+                "lightPink",
+                "lightBrown",
+                "lightRed",
+                "maxColor"
+              ],
+              "type": "string",
+              "description": "The color theme for the calendar. Valid values include: lightBlue, lightGreen, lightOrange, lightGray, lightYellow, lightTeal, lightPink, lightBrown, lightRed, maxColor"
+            },
+            "hexColor": {
+              "type": "string",
+              "description": "The hex color code for the calendar (e.g., '#FF5733'). If provided, this takes precedence over the color property."
+            }
+          },
+          "description": "The calendar properties for creating a new calendar",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__GET_CALENDAR",
+    "description": "Get the properties and relationships of a specific calendar object by its ID. This retrieves detailed information about a calendar including permissions, settings, and metadata.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CALENDAR",
+      "canonical_tool_description_hash": "78d409c5e563787550417dfc7eae4ed404f29b9be8f6525cd6d3726bbca8482a",
+      "canonical_tool_input_schema_hash": "5bcebb1d9cf7bcc65d64a2348dca716d9a4b9a1c5e14d55a718f8b29280c3af4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["calendar_id"],
+          "properties": {
+            "calendar_id": {
+              "type": "string",
+              "description": "The unique identifier of the calendar to retrieve"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities (e.g., 'events', 'calendarPermissions', 'singleValueExtendedProperties')"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response (e.g., 'id,name,color,owner,canEdit')"
+            }
+          },
+          "description": "Query parameters for customizing the calendar details",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__LIST_ALL_EVENTS",
+    "description": "Get a comprehensive list of all event objects across all calendars in the user's mailbox. This provides a unified view of all events from every calendar, supporting timezone preferences and OData query parameters for filtering, sorting, and pagination. Complements the specific calendar LIST_EVENTS function.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_ALL_EVENTS",
+      "canonical_tool_description_hash": "4a7db035bb5cb8aef3490332a6f56f885645ec9b8d97c22a68552ffc2deb2a32",
+      "canonical_tool_input_schema_hash": "e2483eb2f35dcde2d5efdcb0ef39ed761b5b46478a6c27969962948f4ff7f591"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of events to return"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of events to skip for pagination"
+            },
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities (e.g., 'attachments', 'calendar', 'instances')"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "Filter expression to limit events (e.g., 'startsWith(subject,\"Meeting\")', 'sensitivity eq normal', 'showAs eq busy'). Note: Cannot filter on recurrence property."
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'subject,start,end,organizer,attendees,location,body,bodyPreview')"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort events by (e.g., 'start/dateTime asc', 'subject desc', 'createdDateTime desc')"
+            }
+          },
+          "description": "Query parameters for customizing the event list",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "Prefer": {
+              "type": "string",
+              "description": "Use 'outlook.timezone=\"{timezone}\"' to specify the timezone for start and end times in the response (e.g., 'outlook.timezone=\"Pacific Standard Time\"' or 'outlook.timezone=\"America/New_York\"'). If not specified, times are returned in UTC."
+            }
+          },
+          "description": "Optional request headers for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__UPDATE_CALENDAR",
+    "description": "Update the properties of an existing calendar object. You can modify the calendar name, color theme, or default calendar status. Only include properties you want to update.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_CALENDAR",
+      "canonical_tool_description_hash": "246be53e35dd101153783f83426be182e76ad85b50f350974d0dcc771e2e752f",
+      "canonical_tool_input_schema_hash": "e7c045d5cfbb420dd20dca4e1e89edb0a64d1b69492d82aae30788ef92c68699"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The new name for the calendar. This will be displayed in the calendar list."
+            },
+            "color": {
+              "enum": [
+                "lightBlue",
+                "lightGreen",
+                "lightOrange",
+                "lightGray",
+                "lightYellow",
+                "lightTeal",
+                "lightPink",
+                "lightBrown",
+                "lightRed",
+                "maxColor",
+                "auto"
+              ],
+              "type": "string",
+              "description": "The color theme for the calendar. Valid values: lightBlue, lightGreen, lightOrange, lightGray, lightYellow, lightTeal, lightPink, lightBrown, lightRed, maxColor, auto"
+            },
+            "hexColor": {
+              "type": "string",
+              "description": "The hex color code for the calendar (e.g., '#FF5733'). If provided, this takes precedence over the color property."
+            },
+            "isDefaultCalendar": {
+              "type": "boolean",
+              "description": "True if this calendar should be the user's default calendar, false otherwise. Note: Only one calendar can be the default."
+            }
+          },
+          "description": "The calendar properties to update. Only include fields you want to change.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["calendar_id"],
+          "properties": {
+            "calendar_id": {
+              "type": "string",
+              "description": "The unique identifier of the calendar to update"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__DELETE_CALENDAR",
+    "description": "Delete a calendar other than the default calendar. This permanently removes the calendar and all its events. The default calendar cannot be deleted.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_CALENDAR",
+      "canonical_tool_description_hash": "1fa14430f420ed65beb78d4993a07b8406032774530bdcc79acbd4bb707a173e",
+      "canonical_tool_input_schema_hash": "c1460303e670bde356c3489acd4a236a43d42a29f5044bec387462a452ccb5cf"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["calendar_id"],
+          "properties": {
+            "calendar_id": {
+              "type": "string",
+              "description": "The unique identifier of the calendar to delete. Note: Cannot delete the default calendar (isDefaultCalendar=true)."
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__LIST_CALENDAR_VIEW",
+    "description": "Get events, occurrences, exceptions and single instances from a calendar within a specified time range. This returns actual calendar events/appointments between the start and end dates.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_CALENDAR_VIEW",
+      "canonical_tool_description_hash": "9ec7d31bf4b3155050489b09e4855cd6e369c5e606c155ff789624e815e1fdb9",
+      "canonical_tool_input_schema_hash": "a67a50bee7acd94f5b5df75a096c14a5eb0a593a5ad88d3bf09cbdfe713478a9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["calendar_id"],
+          "properties": {
+            "calendar_id": {
+              "type": "string",
+              "description": "The unique identifier of the calendar to get events from"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["startDateTime", "endDateTime"],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of events to return (minimum 1, maximum 1000)"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of events to skip for pagination"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "Filter expression to limit events (e.g., 'sensitivity eq normal', 'showAs eq busy')"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,subject,start,end,organizer'). Note: createdDateTime and lastModifiedDateTime don't support $select."
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort events by (e.g., 'start/dateTime asc', 'subject desc')"
+            },
+            "endDateTime": {
+              "type": "string",
+              "description": "The end date and time of the time range in ISO 8601 format (e.g., '2024-01-15T17:00:00-08:00' or '2024-01-16T01:00:00Z')"
+            },
+            "startDateTime": {
+              "type": "string",
+              "description": "The start date and time of the time range in ISO 8601 format (e.g., '2024-01-15T09:00:00-08:00' or '2024-01-15T17:00:00Z')"
+            }
+          },
+          "description": "Query parameters for the calendar view. startDateTime and endDateTime are required.",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "Prefer": {
+              "type": "string",
+              "description": "Use 'outlook.timezone=\"{timezone}\"' to specify the timezone for start and end times in the response (e.g., 'outlook.timezone=\"Pacific Standard Time\"' or 'outlook.timezone=\"America/New_York\"'). If not specified, times are returned in UTC."
+            }
+          },
+          "description": "Optional request headers for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__LIST_EVENTS",
+    "description": "Retrieve a list of all events in a calendar without date restrictions. This returns single instance meetings, series masters, and recurring events. Use this to get all events in a calendar regardless of time range.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_EVENTS",
+      "canonical_tool_description_hash": "ee56f076fecb8efd4cbceb0119ebf76f00fa44191e7cbcc18d5e492652687808",
+      "canonical_tool_input_schema_hash": "b4134f08e0da5c47055089d72d83f67413e799a52dfd3cbfeaf68026b3ed2d71"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["calendar_id"],
+          "properties": {
+            "calendar_id": {
+              "type": "string",
+              "description": "The unique identifier of the calendar to get events from"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of events to return"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of events to skip for pagination"
+            },
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities (e.g., 'attachments', 'calendar', 'instances')"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "Filter expression to limit events (e.g., 'startsWith(subject,\"Meeting\")', 'sensitivity eq normal', 'showAs eq busy')"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,subject,start,end,organizer,location')"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort events by (e.g., 'start/dateTime asc', 'subject desc', 'createdDateTime desc')"
+            }
+          },
+          "description": "Query parameters for customizing the event list",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "Prefer": {
+              "type": "string",
+              "description": "Use 'outlook.timezone=\"{timezone}\"' to specify the timezone for start and end times in the response (e.g., 'outlook.timezone=\"Pacific Standard Time\"' or 'outlook.timezone=\"America/New_York\"'). If not specified, times are returned in UTC."
+            }
+          },
+          "description": "Optional request headers for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__CREATE_EVENT",
+    "description": "Create a new event in a calendar. This allows creating meetings, appointments, and events with attendees, locations, recurrence patterns, and online meeting details.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_EVENT",
+      "canonical_tool_description_hash": "0527daf8ea95c525dcdcb4098f67c4e1538b8e249cc2a88db2c4d5ee6d303bcb",
+      "canonical_tool_input_schema_hash": "0b683aec92a5115e39b3e62bb00528fece4eab7d564b2d6bfaf52ee0d00e456d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["subject", "start", "end"],
+          "properties": {
+            "end": {
+              "type": "object",
+              "required": ["dateTime"],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "description": "End date and time in ISO 8601 format (e.g., '2024-04-04T15:00:00')"
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Time zone (e.g., 'UTC', 'America/New_York', 'Europe/London')"
+                }
+              },
+              "description": "Event end date and time",
+              "additionalProperties": false
+            },
+            "body": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The content of the event description"
+                },
+                "contentType": {
+                  "enum": ["text", "html"],
+                  "type": "string",
+                  "description": "The content type (text or html)"
+                }
+              },
+              "description": "The event description/body",
+              "additionalProperties": false
+            },
+            "start": {
+              "type": "object",
+              "required": ["dateTime"],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "description": "Start date and time in ISO 8601 format (e.g., '2024-04-04T14:00:00')"
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Time zone (e.g., 'UTC', 'America/New_York', 'Europe/London')"
+                }
+              },
+              "description": "Event start date and time",
+              "additionalProperties": false
+            },
+            "showAs": {
+              "enum": ["free", "tentative", "busy", "oof", "workingElsewhere"],
+              "type": "string",
+              "description": "Show availability as (free, tentative, busy, oof, workingElsewhere)"
+            },
+            "subject": {
+              "type": "string",
+              "description": "The event title/subject"
+            },
+            "isAllDay": {
+              "type": "boolean",
+              "description": "Whether this is an all-day event"
+            },
+            "location": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "address": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "city": {
+                      "type": "string",
+                      "description": "City name"
+                    },
+                    "state": {
+                      "type": "string",
+                      "description": "State or province"
+                    },
+                    "street": {
+                      "type": "string",
+                      "description": "Street address"
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "description": "Postal or ZIP code"
+                    },
+                    "countryOrRegion": {
+                      "type": "string",
+                      "description": "Country or region"
+                    }
+                  },
+                  "description": "Physical address details",
+                  "additionalProperties": false
+                },
+                "displayName": {
+                  "type": "string",
+                  "description": "Location display name (e.g., 'Conference Room A', 'Microsoft Teams', '123 Main St')"
+                }
+              },
+              "description": "Event location details",
+              "additionalProperties": false
+            },
+            "attendees": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["emailAddress"],
+                "required": ["emailAddress"],
+                "properties": {
+                  "type": {
+                    "enum": ["required", "optional", "resource"],
+                    "type": "string",
+                    "description": "Type of attendee (required, optional, or resource)"
+                  },
+                  "emailAddress": {
+                    "type": "object",
+                    "visible": ["address", "name"],
+                    "required": ["address"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Display name of the attendee"
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "Email address of the attendee"
+                      }
+                    },
+                    "description": "Attendee email details",
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "List of event attendees"
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of category names for the event"
+            },
+            "importance": {
+              "enum": ["low", "normal", "high"],
+              "type": "string",
+              "description": "Event importance level"
+            },
+            "recurrence": {
+              "type": "object",
+              "required": ["pattern", "range"],
+              "properties": {
+                "range": {
+                  "type": "object",
+                  "required": ["type", "startDate"],
+                  "properties": {
+                    "type": {
+                      "enum": ["endDate", "noEnd", "numbered"],
+                      "type": "string",
+                      "description": "Range type"
+                    },
+                    "endDate": {
+                      "type": "string",
+                      "description": "End date in YYYY-MM-DD format (for endDate type)"
+                    },
+                    "startDate": {
+                      "type": "string",
+                      "description": "Start date in YYYY-MM-DD format"
+                    },
+                    "numberOfOccurrences": {
+                      "type": "integer",
+                      "description": "Number of occurrences (for numbered type)"
+                    }
+                  },
+                  "description": "Recurrence range",
+                  "additionalProperties": false
+                },
+                "pattern": {
+                  "type": "object",
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "daily",
+                        "weekly",
+                        "absoluteMonthly",
+                        "relativeMonthly",
+                        "absoluteYearly",
+                        "relativeYearly"
+                      ],
+                      "type": "string",
+                      "description": "Recurrence pattern type"
+                    },
+                    "interval": {
+                      "type": "integer",
+                      "description": "Interval between occurrences"
+                    },
+                    "daysOfWeek": {
+                      "type": "array",
+                      "items": {
+                        "enum": [
+                          "sunday",
+                          "monday",
+                          "tuesday",
+                          "wednesday",
+                          "thursday",
+                          "friday",
+                          "saturday"
+                        ],
+                        "type": "string"
+                      },
+                      "description": "Days of the week for weekly patterns"
+                    }
+                  },
+                  "description": "Recurrence pattern details",
+                  "additionalProperties": false
+                }
+              },
+              "description": "Recurrence pattern for recurring events",
+              "additionalProperties": false
+            },
+            "sensitivity": {
+              "enum": ["normal", "personal", "private", "confidential"],
+              "type": "string",
+              "description": "Event sensitivity level"
+            },
+            "isReminderOn": {
+              "type": "boolean",
+              "description": "Whether to show a reminder for this event"
+            },
+            "isOnlineMeeting": {
+              "type": "boolean",
+              "description": "Whether this is an online meeting"
+            },
+            "responseRequested": {
+              "type": "boolean",
+              "description": "Whether to request responses from attendees"
+            },
+            "allowNewTimeProposals": {
+              "type": "boolean",
+              "description": "Whether attendees can propose new times"
+            },
+            "onlineMeetingProvider": {
+              "enum": ["unknown", "skypeForBusiness", "skypeForConsumer", "teamsForBusiness"],
+              "type": "string",
+              "description": "Online meeting provider"
+            },
+            "reminderMinutesBeforeStart": {
+              "type": "integer",
+              "description": "Minutes before start to show reminder (e.g., 15, 30, 60)"
+            }
+          },
+          "description": "Event details to create",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["calendar_id"],
+          "properties": {
+            "calendar_id": {
+              "type": "string",
+              "description": "The unique identifier of the calendar to create the event in"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__GET_SCHEDULE",
+    "description": "Get the free/busy availability information for a collection of users, distribution lists, or resources (rooms or equipment) for a specified time period. Perfect for finding available meeting times and checking when people are free.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SCHEDULE",
+      "canonical_tool_description_hash": "c2c34c0cdeb09609c1ced0a38d752425371e7f3ff81c0607432a0413d6c4cd60",
+      "canonical_tool_input_schema_hash": "8291e71cb6ad0e6a250ec0505757e3623d3239d61c8a1b477dab694566f9aa9e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["schedules", "startTime", "endTime"],
+          "properties": {
+            "endTime": {
+              "type": "object",
+              "required": ["dateTime"],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "description": "End date and time in ISO 8601 format (e.g., '2024-06-21T17:00:00')"
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Time zone (e.g., 'UTC', 'America/New_York', 'Europe/London')"
+                }
+              },
+              "description": "The date, time, and time zone that the period ends",
+              "additionalProperties": false
+            },
+            "schedules": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Email address (e.g., 'user@company.com', 'room@company.com')"
+              },
+              "minItems": 1,
+              "description": "Collection of SMTP email addresses of users, distribution lists, or resources to get availability information for"
+            },
+            "startTime": {
+              "type": "object",
+              "required": ["dateTime"],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "description": "Start date and time in ISO 8601 format (e.g., '2024-06-21T09:00:00')"
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Time zone (e.g., 'UTC', 'America/New_York', 'Europe/London')"
+                }
+              },
+              "description": "The date, time, and time zone that the period starts",
+              "additionalProperties": false
+            },
+            "availabilityViewInterval": {
+              "type": "integer",
+              "maximum": 1440,
+              "minimum": 5,
+              "description": "Duration of a time slot in minutes for the availability view. Default is 30 minutes, minimum is 5, maximum is 1440 (24 hours)"
+            }
+          },
+          "description": "Schedule request parameters",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "Prefer": {
+              "type": "string",
+              "description": "Use 'outlook.timezone=\"{timezone}\"' to specify the timezone for free/busy times in the response (e.g., 'outlook.timezone=\"Pacific Standard Time\"' or 'outlook.timezone=\"America/New_York\"'). If not specified, times are returned in UTC."
+            }
+          },
+          "description": "Optional request headers for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__GET_EVENT",
+    "description": "Get the properties and relationships of a specific event. Returns event details including subject, body, attendees, location, start/end times, and all other event properties. Supports timezone preferences and custom property selection.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_EVENT",
+      "canonical_tool_description_hash": "d09acd5fe443668b475918dec779a16e05c152941cf363a2f8ecede86d434eb7",
+      "canonical_tool_input_schema_hash": "72995522422eff727bcd99c02783664b529a7c1d2a4282891a7e5fdd994b55b2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "The unique identifier of the event to retrieve"
+            }
+          },
+          "description": "Path parameters for the event request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities (e.g., 'attachments', 'extensions', 'singleValueExtendedProperties', 'multiValueExtendedProperties')"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response (e.g., 'subject,body,start,end,attendees,location,organizer')"
+            }
+          },
+          "description": "Query parameters for customizing the event response",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "Prefer": {
+              "type": "string",
+              "description": "Use 'outlook.timezone=\"{timezone}\"' to specify the timezone for start and end times in the response (e.g., 'outlook.timezone=\"Pacific Standard Time\"' or 'outlook.timezone=\"America/New_York\"'). If not specified, times are returned in UTC."
+            }
+          },
+          "description": "Optional request headers for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__UPDATE_EVENT",
+    "description": "Update the properties of an existing event. Can modify subject, attendees, times, location, body, importance, reminders, online meeting settings, and other event properties. Use PATCH to update only specified fields while preserving others.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_EVENT",
+      "canonical_tool_description_hash": "1e2bff6d459fa5d0f110dc06b81027d4b1131c9e77129d32ad3ce754ff5f1b40",
+      "canonical_tool_input_schema_hash": "5b77bed725439885a14e927e280d2e5561f0264aea400ae0b667414d7bff2e4f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "end": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "description": "A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000)"
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Represents a time zone, for example, 'Pacific Standard Time'"
+                }
+              },
+              "description": "The date, time, and time zone that the event ends",
+              "additionalProperties": false
+            },
+            "body": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The content of the body"
+                },
+                "contentType": {
+                  "enum": ["text", "html"],
+                  "type": "string",
+                  "description": "The format of the content (text or html)"
+                }
+              },
+              "description": "The body of the message associated with the event",
+              "additionalProperties": false
+            },
+            "start": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "description": "A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000)"
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "Represents a time zone, for example, 'Pacific Standard Time'"
+                }
+              },
+              "description": "The start date, time, and time zone of the event",
+              "additionalProperties": false
+            },
+            "showAs": {
+              "enum": ["free", "tentative", "busy", "oof", "workingElsewhere", "unknown"],
+              "type": "string",
+              "description": "The status to show during the event time"
+            },
+            "subject": {
+              "type": "string",
+              "description": "The text of the event's subject line"
+            },
+            "isAllDay": {
+              "type": "boolean",
+              "description": "Set to true if the event lasts all day"
+            },
+            "location": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "address": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "city": {
+                      "type": "string",
+                      "description": "City name"
+                    },
+                    "state": {
+                      "type": "string",
+                      "description": "State or province"
+                    },
+                    "street": {
+                      "type": "string",
+                      "description": "Street address"
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "description": "Postal or ZIP code"
+                    },
+                    "countryOrRegion": {
+                      "type": "string",
+                      "description": "Country or region name"
+                    }
+                  },
+                  "description": "Physical address of the location",
+                  "additionalProperties": false
+                },
+                "uniqueId": {
+                  "type": "string",
+                  "description": "For internal use only"
+                },
+                "coordinates": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "latitude": {
+                      "type": "number",
+                      "description": "Latitude coordinate"
+                    },
+                    "longitude": {
+                      "type": "number",
+                      "description": "Longitude coordinate"
+                    }
+                  },
+                  "description": "Geographic coordinates of the location",
+                  "additionalProperties": false
+                },
+                "displayName": {
+                  "type": "string",
+                  "description": "The name of the location"
+                },
+                "locationType": {
+                  "enum": [
+                    "default",
+                    "conferenceRoom",
+                    "homeAddress",
+                    "businessAddress",
+                    "geoCoordinates",
+                    "streetAddress",
+                    "hotel",
+                    "restaurant",
+                    "localBusiness",
+                    "postalAddress"
+                  ],
+                  "type": "string",
+                  "description": "The type of location"
+                },
+                "uniqueIdType": {
+                  "enum": ["unknown", "locationStore", "directory", "private", "bing"],
+                  "type": "string",
+                  "description": "For internal use only"
+                }
+              },
+              "description": "The location of the event",
+              "additionalProperties": false
+            },
+            "attendees": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["type", "emailAddress"],
+                "required": [],
+                "properties": {
+                  "type": {
+                    "enum": ["required", "optional", "resource"],
+                    "type": "string",
+                    "description": "The type of attendee"
+                  },
+                  "emailAddress": {
+                    "type": "object",
+                    "visible": ["address", "name"],
+                    "required": [],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The display name"
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "The email address"
+                      }
+                    },
+                    "description": "Email address information",
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The collection of attendees for the event"
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The categories associated with the event"
+            },
+            "importance": {
+              "enum": ["low", "normal", "high"],
+              "type": "string",
+              "description": "The importance of the event"
+            },
+            "recurrence": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "range": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "type": {
+                      "enum": ["endDate", "noEnd", "numbered"],
+                      "type": "string",
+                      "description": "The recurrence range type"
+                    },
+                    "endDate": {
+                      "type": "string",
+                      "description": "The date to stop applying the recurrence pattern"
+                    },
+                    "startDate": {
+                      "type": "string",
+                      "description": "The date to start applying the recurrence pattern"
+                    },
+                    "numberOfOccurrences": {
+                      "type": "integer",
+                      "description": "The number of times to repeat the event"
+                    }
+                  },
+                  "description": "The range of the recurrence",
+                  "additionalProperties": false
+                },
+                "pattern": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "daily",
+                        "weekly",
+                        "absoluteMonthly",
+                        "relativeMonthly",
+                        "absoluteYearly",
+                        "relativeYearly"
+                      ],
+                      "type": "string",
+                      "description": "The recurrence pattern type"
+                    },
+                    "index": {
+                      "enum": ["first", "second", "third", "fourth", "last"],
+                      "type": "string",
+                      "description": "Specifies on which instance of the allowed days specified in daysOfWeek the event occurs"
+                    },
+                    "month": {
+                      "type": "integer",
+                      "description": "The month in which the event occurs"
+                    },
+                    "interval": {
+                      "type": "integer",
+                      "description": "The number of units between occurrences"
+                    },
+                    "dayOfMonth": {
+                      "type": "integer",
+                      "description": "The day of the month on which the event occurs"
+                    },
+                    "daysOfWeek": {
+                      "type": "array",
+                      "items": {
+                        "enum": [
+                          "sunday",
+                          "monday",
+                          "tuesday",
+                          "wednesday",
+                          "thursday",
+                          "friday",
+                          "saturday"
+                        ],
+                        "type": "string"
+                      },
+                      "description": "Days of the week on which the event occurs"
+                    },
+                    "firstDayOfWeek": {
+                      "enum": [
+                        "sunday",
+                        "monday",
+                        "tuesday",
+                        "wednesday",
+                        "thursday",
+                        "friday",
+                        "saturday"
+                      ],
+                      "type": "string",
+                      "description": "The first day of the week"
+                    }
+                  },
+                  "description": "The frequency of the recurrence",
+                  "additionalProperties": false
+                }
+              },
+              "description": "The recurrence pattern for the event",
+              "additionalProperties": false
+            },
+            "sensitivity": {
+              "enum": ["normal", "personal", "private", "confidential"],
+              "type": "string",
+              "description": "The sensitivity level of the event"
+            },
+            "isReminderOn": {
+              "type": "boolean",
+              "description": "Set to true if an alert is set to remind the user of the event"
+            },
+            "hideAttendees": {
+              "type": "boolean",
+              "description": "When set to true, each attendee only sees themselves in the meeting request and meeting tracking list"
+            },
+            "isOnlineMeeting": {
+              "type": "boolean",
+              "description": "True if this event has online meeting information, false otherwise"
+            },
+            "responseRequested": {
+              "type": "boolean",
+              "description": "Set to true if the sender would like a response when the event is accepted or declined"
+            },
+            "onlineMeetingProvider": {
+              "enum": ["teamsForBusiness", "skypeForBusiness", "skypeForConsumer"],
+              "type": "string",
+              "description": "Represents the online meeting service provider"
+            },
+            "reminderMinutesBeforeStart": {
+              "type": "integer",
+              "description": "The number of minutes before the event start time that the reminder alert occurs"
+            }
+          },
+          "description": "Event properties to update. Only include fields you want to change.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "The unique identifier of the event to update"
+            }
+          },
+          "description": "Path parameters for the event to update",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__DELETE_EVENT",
+    "description": "Delete a specific event from the calendar. If the event is a meeting, deleting it on the organizer's calendar sends a cancellation message to all attendees. This action cannot be undone.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_EVENT",
+      "canonical_tool_description_hash": "1ddc9a0b5fe89ccc1f24d57626e39dc5b5bf52fdd24694e13a02b60c95fbb15c",
+      "canonical_tool_input_schema_hash": "e3df6144da4c6d248a638225d4d4e5879f2e5b88822883de4961baa507029b64"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "The unique identifier of the event to delete"
+            }
+          },
+          "description": "Path parameters for the event to delete",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__PERMANENT_DELETE_EVENT",
+    "description": "Permanently delete an event and place it in the purges folder in the dumpster. Unlike regular delete, this action moves the event to a deeper deletion state that cannot be recovered by standard means. Email clients cannot access permanently deleted items.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PERMANENT_DELETE_EVENT",
+      "canonical_tool_description_hash": "74371b6fa881f124e88c33a762457b45fb92a9fcb5d1a1b97a1d38956bdd657e",
+      "canonical_tool_input_schema_hash": "eb28cd1f855ec52fec4cb74fcd552e168eaf22aa5e90e800acf9bdac6097c649"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "The unique identifier of the event to permanently delete"
+            }
+          },
+          "description": "Path parameters for the event to permanently delete",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__DELTA_EVENTS",
+    "description": "Get a set of event resources that have been added, deleted, or updated in a calendarView (a range of events defined by start and end dates) of the user's primary calendar. Supports delta query for incremental sync.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELTA_EVENTS",
+      "canonical_tool_description_hash": "d3508c2ee651862ca08ce8b3e7796c592df3a9cc912f80d8ad3fdce3733abc0e",
+      "canonical_tool_input_schema_hash": "1987fc253a51a7d6d13e74e4451d63b939d7578a2370495141e8139a596c405b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$skiptoken": {
+              "type": "string",
+              "description": "A state token returned in the @odata.nextLink URL of the previous delta function call. Use for pagination."
+            },
+            "$deltatoken": {
+              "type": "string",
+              "description": "A state token returned in the @odata.deltaLink URL of the previous delta function call. Use for incremental sync."
+            },
+            "endDateTime": {
+              "type": "string",
+              "description": "The end date and time of the time range in ISO 8601 format (e.g., '2025-07-22T00:00:00Z')"
+            },
+            "startDateTime": {
+              "type": "string",
+              "description": "The start date and time of the time range in ISO 8601 format (e.g., '2025-07-20T00:00:00Z')"
+            }
+          },
+          "description": "Query parameters for delta sync. Specify startDateTime and endDateTime for the initial call. Use $deltatoken or $skiptoken for subsequent calls.",
+          "additionalProperties": false
+        },
+        "header": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "Prefer": {
+              "type": "string",
+              "description": "Use 'outlook.timezone=\"{timezone}\"' to specify the timezone for start and end times in the response (e.g., 'outlook.timezone=\"Pacific Standard Time\"' or 'outlook.timezone=\"America/New_York\"'). If not specified, times are returned in UTC."
+            }
+          },
+          "description": "Optional request headers for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__FORWARD_EVENT",
+    "description": "Forward a meeting event to new recipients. Allows the organizer or attendee to forward the meeting request, optionally including a comment. The new recipients will be added to the event and notified.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "FORWARD_EVENT",
+      "canonical_tool_description_hash": "bda38b4d57745dcd5ff231bf7433f4c773f9577e588de3e2b74bb9f87b7a1924",
+      "canonical_tool_input_schema_hash": "270c7d4f4a5182c4456ebc40a38a6e52cd4194d0ab2b4c7f90b3407b47db0cc4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["ToRecipients"],
+          "properties": {
+            "Comment": {
+              "type": "string",
+              "description": "A comment to include in the forward notification. Can be empty."
+            },
+            "ToRecipients": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["EmailAddress"],
+                "required": ["EmailAddress"],
+                "properties": {
+                  "EmailAddress": {
+                    "type": "object",
+                    "visible": ["Address", "Name"],
+                    "required": ["Address"],
+                    "properties": {
+                      "Name": {
+                        "type": "string",
+                        "description": "The display name of the recipient."
+                      },
+                      "Address": {
+                        "type": "string",
+                        "description": "The email address of the recipient."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The list of recipients to forward the event to."
+            }
+          },
+          "description": "Request body for forwarding the event.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "The unique identifier of the event to forward"
+            }
+          },
+          "description": "Path parameters for the event to forward",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__ACCEPT_EVENT",
+    "description": "Accept the specified event in a user calendar. Optionally include a comment and choose whether to send a response to the organizer.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ACCEPT_EVENT",
+      "canonical_tool_description_hash": "b936da39dc3451d98195f860af32b572a34cc9d91029a33b22d8bc50d4166bc0",
+      "canonical_tool_input_schema_hash": "80a4eb0a091243be45345e6f162a6dcb59e1aa336ab9808fbd222b68c77e7f47"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "comment": {
+              "type": "string",
+              "description": "Text included in the response. Optional."
+            },
+            "sendResponse": {
+              "type": "boolean",
+              "description": "true if a response is to be sent to the organizer; otherwise, false. Optional. Default is true."
+            }
+          },
+          "description": "Request body for accepting the event.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "The unique identifier of the event to accept"
+            }
+          },
+          "description": "Path parameters for the event to accept",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__TENTATIVELY_ACCEPT_EVENT",
+    "description": "Tentatively accept the specified event in a user calendar. Optionally include a comment, propose a new time, and choose whether to send a response to the organizer.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TENTATIVELY_ACCEPT_EVENT",
+      "canonical_tool_description_hash": "66f17bc59353de1aaac6ec154b867fbdca12757fd448c18a6746acae71f297d6",
+      "canonical_tool_input_schema_hash": "63e73e3c22a5dee982995803dcccfe2c370fb43b936c9ab34c3a9eb1d72cae85"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "comment": {
+              "type": "string",
+              "description": "Text included in the response. Optional."
+            },
+            "sendResponse": {
+              "type": "boolean",
+              "description": "true if a response is to be sent to the organizer; otherwise, false. Optional. Default is true."
+            },
+            "proposedNewTime": {
+              "type": "object",
+              "required": ["start", "end"],
+              "properties": {
+                "end": {
+                  "type": "object",
+                  "required": ["dateTime", "timeZone"],
+                  "properties": {
+                    "dateTime": {
+                      "type": "string",
+                      "description": "End date and time in ISO 8601 format (e.g., '2025-07-22T11:00:00')"
+                    },
+                    "timeZone": {
+                      "type": "string",
+                      "description": "Time zone for the end time (e.g., 'UTC', 'Pacific Standard Time')"
+                    }
+                  },
+                  "description": "Proposed new end time.",
+                  "additionalProperties": false
+                },
+                "start": {
+                  "type": "object",
+                  "required": ["dateTime", "timeZone"],
+                  "properties": {
+                    "dateTime": {
+                      "type": "string",
+                      "description": "Start date and time in ISO 8601 format (e.g., '2025-07-22T10:00:00')"
+                    },
+                    "timeZone": {
+                      "type": "string",
+                      "description": "Time zone for the start time (e.g., 'UTC', 'Pacific Standard Time')"
+                    }
+                  },
+                  "description": "Proposed new start time.",
+                  "additionalProperties": false
+                }
+              },
+              "description": "An alternate date/time proposed by an invitee for a meeting request to start and end. Valid only for events that allow new time proposals. Optional.",
+              "additionalProperties": false
+            }
+          },
+          "description": "Request body for tentatively accepting the event.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "The unique identifier of the event to tentatively accept"
+            }
+          },
+          "description": "Path parameters for the event to tentatively accept",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__DISMISS_REMINDER",
+    "description": "Dismiss a reminder that has been triggered for an event in a user calendar.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DISMISS_REMINDER",
+      "canonical_tool_description_hash": "14f9f3a0d9ea9cd9bd7f14e55126636a342992594e1e8f853fa0d342995251a5",
+      "canonical_tool_input_schema_hash": "ab9a9553c230e48b7f7c9369a87c38fc89c47eb0938be546f3f12ee4d9e38ca7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "The unique identifier of the event to dismiss the reminder for"
+            }
+          },
+          "description": "Path parameters for the event to dismiss the reminder for",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__SNOOZE_REMINDER",
+    "description": "Postpone a reminder for an event in a user calendar until a new time.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SNOOZE_REMINDER",
+      "canonical_tool_description_hash": "4ca5ebd9b7d59e9db8c1c111bb72bfc5eba4e1aefc968a19fceb54b2cbe1cb8d",
+      "canonical_tool_input_schema_hash": "0fa00a03e918639a26f6dfd79acaac64395e3b1d3f5005dfa51e1005e16be73e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["newReminderTime"],
+          "properties": {
+            "newReminderTime": {
+              "type": "object",
+              "required": ["dateTime", "timeZone"],
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "description": "The new reminder time in ISO 8601 format (e.g., '2025-07-21T09:00:00')"
+                },
+                "timeZone": {
+                  "type": "string",
+                  "description": "The time zone for the new reminder time (e.g., 'UTC', 'Pacific Standard Time')"
+                }
+              },
+              "description": "The new date and time to trigger the reminder.",
+              "additionalProperties": false
+            }
+          },
+          "description": "Request body for snoozing the reminder.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "The unique identifier of the event to snooze the reminder for"
+            }
+          },
+          "description": "Path parameters for the event to snooze the reminder for",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_CALENDAR__LIST_INSTANCES",
+    "description": "Get the instances (occurrences) of an event for a specified time range. If the event is a seriesMaster, returns the occurrences and exceptions in the range.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_INSTANCES",
+      "canonical_tool_description_hash": "9a95630bd4d115b564414d7e9b3d51818e1c6a3d54ad682be98ab69566da9447",
+      "canonical_tool_input_schema_hash": "4a80aaefd50f820450577dd54c49c0452dd69b812572b666a98ee7cb3c0892a9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["eventId"],
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "description": "The unique identifier of the event (series master or single event)"
+            }
+          },
+          "description": "Path parameters for the event to get instances for",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["startDateTime", "endDateTime"],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of instances to return"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of instances to skip for pagination"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response (e.g., 'subject,start,end,recurrence,type')"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort instances by (e.g., 'start/dateTime asc')"
+            },
+            "endDateTime": {
+              "type": "string",
+              "description": "The end date and time of the time range in ISO 8601 format (e.g., '2025-07-22T00:00:00Z')"
+            },
+            "startDateTime": {
+              "type": "string",
+              "description": "The start date and time of the time range in ISO 8601 format (e.g., '2025-07-20T00:00:00Z')"
+            }
+          },
+          "description": "Query parameters for the time range and OData options.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/microsoft_onedrive/tools.json
+++ b/backend/mcp_servers/microsoft_onedrive/tools.json
@@ -1,0 +1,966 @@
+[
+  {
+    "name": "MICROSOFT_ONEDRIVE__PERMANENT_DELETE_DRIVE_ITEM",
+    "description": "Permanently delete a driveItem by using its ID. WARNING: Items deleted with this method are permanently removed and are NOT sent to the recycle bin. They cannot be restored afterward. Use with extreme caution. Returns 204 No Content on successful deletion.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PERMANENT_DELETE_DRIVE_ITEM",
+      "canonical_tool_description_hash": "6784cd694f17333c6c3d14e553decef4d5c2120adfea63414e619bb481e78003",
+      "canonical_tool_input_schema_hash": "8814ea4a0a320463b7ba3ff932c4056639bb8b6206638c00760efea07661360f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["itemId"],
+          "properties": {
+            "itemId": {
+              "type": "string",
+              "description": "The ID of the driveItem to permanently delete. WARNING: This action is irreversible and the item cannot be recovered."
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__LIST_DRIVES",
+    "description": "List all drives available to the current user (personal, shared, or group drives).",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_DRIVES",
+      "canonical_tool_description_hash": "d5a48048a0b42a100eb6f704263472cbba19a45e78ea870ded97552ee14be655",
+      "canonical_tool_input_schema_hash": "a598fee0c3eb2b26f80a9f1945521383dbb0fe1aca900a3fc67eb798aa3e3e55"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of drives to return."
+            },
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities."
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response."
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort drives by."
+            },
+            "$skipToken": {
+              "type": "string",
+              "description": "Skip token for pagination."
+            }
+          },
+          "description": "OData query parameters to customize the response.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__GET_DRIVE",
+    "description": "Retrieve the properties and relationships of a specific Drive resource by its ID. A Drive is the top-level container for a file system, such as OneDrive or SharePoint document libraries.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DRIVE",
+      "canonical_tool_description_hash": "fca26db53d06aa078adbc523474eb04f7c6bb45fe230e26c044d500eadc4cd6a",
+      "canonical_tool_input_schema_hash": "3ba8c816613ef8d0d671a39445269020b13f51248a1851ddfbedbd9b2096c506"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["driveId"],
+          "properties": {
+            "driveId": {
+              "type": "string",
+              "description": "The identifier for the drive requested."
+            }
+          },
+          "description": "Path parameters for the drive request.",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response."
+            }
+          },
+          "description": "OData query parameters to customize the response.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__GET_MY_DRIVE",
+    "description": "Get the current user's OneDrive. The signed-in user's drive is accessed automatically and will be provisioned if it doesn't exist but the user has a license to use OneDrive.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_MY_DRIVE",
+      "canonical_tool_description_hash": "f4b48193ed9d518f1917a42c114b0fdee685dc968a253f09fa5dedae844ec6e4",
+      "canonical_tool_input_schema_hash": "5c7f109514fcf51ed9298d6085bf71238636dac8ad98606bab4427e4e455c0db"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response."
+            }
+          },
+          "description": "OData query parameters to customize the response.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__GET_DRIVE_ITEM_BY_ID",
+    "description": "Retrieve the metadata for a driveItem in a drive by its unique ID. Returns file/folder details including name, size, created/modified dates, parent references, and other properties.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DRIVE_ITEM_BY_ID",
+      "canonical_tool_description_hash": "0ea4db6c09308aa0a978d8e7149865307636b0862bab37e7224d0c28a1dec56f",
+      "canonical_tool_input_schema_hash": "8b5df69496a31e84f8524b8fa2d4ad208f750f539fec93d7002dd82c6f2be0f0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["itemId"],
+          "properties": {
+            "itemId": {
+              "type": "string",
+              "description": "The identifier for the drive item (file or folder). Note: Use %21 to escape the ! character in item IDs (e.g., '7006ADAF2D3C1355%211014')."
+            }
+          },
+          "description": "Path parameters for the drive item request.",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities (e.g., 'children' to include child items)."
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response."
+            },
+            "includeDeletedItems": {
+              "type": "boolean",
+              "description": "Include deleted items in the response (OneDrive Personal only)."
+            }
+          },
+          "description": "OData query parameters to customize the response.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__LIST_DRIVE_ITEM_CHILDREN",
+    "description": "Return a collection of DriveItems in the children relationship of a DriveItem. DriveItems with a non-null folder or package facet can have one or more child DriveItems.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_DRIVE_ITEM_CHILDREN",
+      "canonical_tool_description_hash": "1174963632c4d7c7d8103e92568c36ce6b08198016e84f6424ccf75606bf953c",
+      "canonical_tool_input_schema_hash": "3f597ad2ea7dd5b92c854e23c78eed4cd3c0a3f08ad6d5ef2d61e4fdf06b906e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["itemId"],
+          "properties": {
+            "itemId": {
+              "type": "string",
+              "description": "The identifier for the drive item (folder) whose children to list. Note: Use %21 to escape the ! character in item IDs (e.g., '7006ADAF2D3C1355%211014')."
+            }
+          },
+          "description": "Path parameters for the drive item children request.",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of items to return."
+            },
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities."
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response."
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort items by."
+            },
+            "$skipToken": {
+              "type": "string",
+              "description": "Skip token for pagination."
+            }
+          },
+          "description": "OData query parameters to customize the response.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__DELTA_DRIVE_ITEMS",
+    "description": "Track changes in a driveItem and its children over time. Use for incremental synchronization to detect added, modified, or deleted items. Returns @odata.nextLink for pagination or @odata.deltaLink for future change tracking.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELTA_DRIVE_ITEMS",
+      "canonical_tool_description_hash": "b73cef932d82d1873d9a36a62abec3923affa42b22941395e88593703a8b41bb",
+      "canonical_tool_input_schema_hash": "6a2ecf52eced8655ab068554700ef2c33ec82bfe8e640301538c09ea9c5b2548"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of items to return per page."
+            },
+            "token": {
+              "type": "string",
+              "description": "Delta token. Use 'latest' to get current deltaLink, or provide previous deltaLink token to get changes since last sync. If unspecified, starts full enumeration."
+            },
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities."
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response."
+            }
+          },
+          "description": "Query parameters for delta synchronization.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__CREATE_FOLDER",
+    "description": "Create a new folder in a drive at the specified parent location. Returns the newly created folder with its metadata including ID, name, creation time, and parent reference. Supports conflict resolution when a folder with the same name already exists.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_FOLDER",
+      "canonical_tool_description_hash": "72517a5019527d76c8a551abdac84e5c42cad81c2f8180e45da9a283c2c21175",
+      "canonical_tool_input_schema_hash": "2369d25fd4f4e3b69b0ec226a4e05b3568bcafa7602697d9d2f2b25395159ee2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the new folder to create."
+            },
+            "@microsoft.graph.conflictBehavior": {
+              "enum": ["rename", "replace", "fail"],
+              "type": "string",
+              "description": "Behavior when a folder with the same name already exists. Options: 'rename' (automatically choose a new name), 'replace' (overwrite existing), 'fail' (return error). Default is 'fail'."
+            }
+          },
+          "description": "Request body containing the folder details to create.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["parentItemId"],
+          "properties": {
+            "parentItemId": {
+              "type": "string",
+              "description": "The identifier of the parent folder where the new folder will be created. Use 'root' for the root directory or a specific item ID. Note: Use %21 to escape the ! character in item IDs (e.g., '7006ADAF2D3C1355%211014')."
+            }
+          },
+          "description": "Path parameters for the folder creation request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__SEARCH_DRIVE_ITEMS",
+    "description": "Search the hierarchy of items within a drive for items matching a query. Searches across filename, metadata, and file content within the user's drive only.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_DRIVE_ITEMS",
+      "canonical_tool_description_hash": "fddbe13082381be75c11e6dd7c4d156c82815876e3dcb41fffeb6aaf795f4721",
+      "canonical_tool_input_schema_hash": "483b57b24197be5c7f40da4d2b5086562007d7e49e5ae6afe5ab686d42ffa7aa"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "The query text used to search for items. Values may be matched across several fields including filename, metadata, and file content."
+            }
+          },
+          "description": "Path parameters for the search request.",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of items to return."
+            },
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities."
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response."
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort items by."
+            },
+            "$skipToken": {
+              "type": "string",
+              "description": "Skip token for pagination."
+            }
+          },
+          "description": "OData query parameters to customize the response.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__SEARCH_ALL_ACCESSIBLE_ITEMS",
+    "description": "Search more broadly to include items shared with the current user, in addition to items within the user's drive. Returns items from the user's drive and items shared with them from other drives.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_ALL_ACCESSIBLE_ITEMS",
+      "canonical_tool_description_hash": "c9349aa64f0085b1b8b0efe77bc2d4a0c6492cf7c699136015ae269fe8d8f93f",
+      "canonical_tool_input_schema_hash": "73dbc0871a08ccefd393a661905ba88484d7dc22db8689516da644c71590395c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "The query text used to search for items. Values may be matched across several fields including filename, metadata, and file content."
+            }
+          },
+          "description": "Path parameters for the broader search request.",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number items to return."
+            },
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities."
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response."
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort items by."
+            },
+            "$skipToken": {
+              "type": "string",
+              "description": "Skip token for pagination."
+            }
+          },
+          "description": "OData query parameters to customize the response.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__GET_DRIVE_ITEM_BY_PATH",
+    "description": "Retrieve the metadata for a driveItem in a drive by its file system path relative to the root. Returns file/folder details including name, size, created/modified dates, and other properties. Use this when you know the path but not the item ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DRIVE_ITEM_BY_PATH",
+      "canonical_tool_description_hash": "8519671a982d0ff6d0ce79bd05f73a7a8e88971099e5b8d199284461c6787895",
+      "canonical_tool_input_schema_hash": "e63a2f391933f025020e0590620667169771b42e6b62ad05bdf6ae9b6c047254"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["itemPath"],
+          "properties": {
+            "itemPath": {
+              "type": "string",
+              "description": "The file system path to the drive item (file or folder) relative to the root. Example: 'Documents/MyFile.txt' or 'Pictures' for a folder."
+            }
+          },
+          "description": "Path parameters for the drive item request.",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities (e.g., 'children' to include child items)."
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response."
+            },
+            "includeDeletedItems": {
+              "type": "boolean",
+              "description": "Include deleted items in the response (OneDrive Personal only)."
+            }
+          },
+          "description": "OData query parameters to customize the response.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__GET_ROOT_FOLDER",
+    "description": "Get the root folder of the user's OneDrive. This is a shortcut to access the top-level folder without needing to know its ID. Supports expanding children and other OData query parameters.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ROOT_FOLDER",
+      "canonical_tool_description_hash": "d79863b23483b19bc6b17b3cfcb83d25d97de81ff63d8a1e6cbc2bc1cd33d9a2",
+      "canonical_tool_input_schema_hash": "e3e0158a598debe9e606a765bc1f9c8bab92781cdf4f3dbed2e807cd56418589"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities (e.g., 'children' to include child items)."
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response."
+            },
+            "includeDeletedItems": {
+              "type": "boolean",
+              "description": "Include deleted items in the response (OneDrive Personal only)."
+            }
+          },
+          "description": "OData query parameters to customize the response.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__LIST_DRIVE_ITEM_VERSIONS",
+    "description": "Retrieve the version history of a driveItem. OneDrive and SharePoint retain file history depending on configuration. Returns DriveItemVersion objects with version ID, lastModifiedBy, lastModifiedDateTime, and size. Versions are returned in descending order (newest to oldest).",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_DRIVE_ITEM_VERSIONS",
+      "canonical_tool_description_hash": "351774a2f9d295267780c251ae8f9ae6383e10e4ef782928d9b782fd0ed3ea05",
+      "canonical_tool_input_schema_hash": "46d1ddb1bb0691d1bf781e317f1f92e6008e9785c8ec537a50f0aec48199bfe7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["itemId"],
+          "properties": {
+            "itemId": {
+              "type": "string",
+              "description": "The identifier for the drive item (file) whose version history to retrieve. Note: Use %21 to escape the ! character in item IDs (e.g., '7006ADAF2D3C1355%211014')."
+            }
+          },
+          "description": "Path parameters for the drive item versions request.",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of versions to return."
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response."
+            },
+            "$skipToken": {
+              "type": "string",
+              "description": "Skip token for pagination."
+            }
+          },
+          "description": "Query parameters to customize the response. Note: $orderby is not supported as versions are always returned newest to oldest.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__UPDATE_DRIVE_ITEM",
+    "description": "Update the metadata for a driveItem by ID. Allows updating properties such as name (to rename files/folders), parentReference (to move items), and other metadata. Returns the updated DriveItem resource with modified properties.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_DRIVE_ITEM",
+      "canonical_tool_description_hash": "d6919a7aa84225d9a97f221e17901b1c9adc8d587afef1b8358264b0f918fc8f",
+      "canonical_tool_input_schema_hash": "35a6f222517b8a818420a5119420ba8bfc7deded4f1e78178f56453719822414"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "New name for the drive item (file or folder). Use this to rename items."
+            },
+            "description": {
+              "type": "string",
+              "description": "Description or comment for the drive item."
+            },
+            "parentReference": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The ID of the new parent folder. Note: Use %21 to escape the ! character in item IDs."
+                },
+                "driveId": {
+                  "type": "string",
+                  "description": "The ID of the drive containing the new parent folder."
+                }
+              },
+              "description": "Parent reference to move the item to a different folder. Specify the new parent's driveId and id.",
+              "additionalProperties": false
+            }
+          },
+          "description": "Request body containing the properties to update. Only include properties that should be changed.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["itemId"],
+          "properties": {
+            "itemId": {
+              "type": "string",
+              "description": "The identifier for the drive item (file or folder) to update. Note: Use %21 to escape the ! character in item IDs (e.g., '7006ADAF2D3C1355%211014')."
+            }
+          },
+          "description": "Path parameters for the drive item update request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__COPY_DRIVE_ITEM",
+    "description": "Create a copy of a driveItem asynchronously including child items. You can specify a new parent folder, provide a new name, copy only children, or include version history. The operation is queued and processed asynchronously - use the monitor URL to track progress until completion.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "COPY_DRIVE_ITEM",
+      "canonical_tool_description_hash": "37204488b82129017dfa7f94e85b5a142db6c3feeeca556d02d743a92b56f2f1",
+      "canonical_tool_input_schema_hash": "05eb78fc4ef2c4cf871fd7dbd9f58a455167e762f92fe69dca86732df3f0c58b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Optional. The new name for the copy. If not provided, the same name as the original is used. Cannot be used with childrenOnly=true."
+            },
+            "childrenOnly": {
+              "type": "boolean",
+              "description": "Optional. If true, copy the children of the driveItem but not the driveItem itself. Default is false. Valid only for folder items. Cannot be used with 'name' parameter."
+            },
+            "parentReference": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The ID of the destination parent folder. Note: Use %21 to escape the ! character in item IDs."
+                },
+                "driveId": {
+                  "type": "string",
+                  "description": "The ID of the drive containing the destination folder."
+                }
+              },
+              "description": "Reference to the parent item where the copy will be created. Required for copying to a different location.",
+              "additionalProperties": false
+            },
+            "includeAllVersionHistory": {
+              "type": "boolean",
+              "description": "Optional. If true, copy all version history (major and minor versions) to the destination within version limit. If false, only the latest major version is copied. Default is false."
+            }
+          },
+          "description": "Request body containing copy operation parameters.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["itemId"],
+          "properties": {
+            "itemId": {
+              "type": "string",
+              "description": "The identifier for the drive item (file or folder) to copy. Use 'root' for the root folder (only with childrenOnly=true). Note: Use %21 to escape the ! character in item IDs (e.g., '7006ADAF2D3C1355%211014')."
+            }
+          },
+          "description": "Path parameters for the copy operation.",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "@microsoft.graph.conflictBehavior": {
+              "enum": ["fail", "replace", "rename"],
+              "type": "string",
+              "description": "Behavior when a conflict occurs. 'fail' (default): entire operation fails; 'replace': overwrite existing (files only); 'rename': append integer for uniqueness. Note: Not supported for OneDrive Consumer."
+            }
+          },
+          "description": "Query parameters for conflict resolution.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__MOVE_DRIVE_ITEM",
+    "description": "Move a driveItem to a new parent folder by updating its parentReference. You can also rename the item during the move operation. This is a special case of the update method that moves items within the same drive. Items cannot be moved between different drives.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "MOVE_DRIVE_ITEM",
+      "canonical_tool_description_hash": "8d9c49c7b772a223fbdbadea926f74963d40e650fb87b95af4484d751a4894f7",
+      "canonical_tool_input_schema_hash": "57012c91aa39c885733f96618caca6d04a0565b03d15096fa5730ea8167fc6cc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["parentReference"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Optional. New name for the item. Use this to rename the item during the move operation."
+            },
+            "description": {
+              "type": "string",
+              "description": "Optional. New description for the item."
+            },
+            "parentReference": {
+              "type": "object",
+              "required": ["id"],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The ID of the new parent folder. For root folder, provide the actual root folder ID (not 'root'). Note: Use %21 to escape the ! character in item IDs."
+                },
+                "driveId": {
+                  "type": "string",
+                  "description": "Optional. The ID of the drive containing the new parent folder. If not specified, uses the same drive as the source item."
+                }
+              },
+              "description": "Reference to the new parent folder where the item will be moved. Required to move the item.",
+              "additionalProperties": false
+            }
+          },
+          "description": "Request body containing the new parent reference and optional properties to update.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["itemId"],
+          "properties": {
+            "itemId": {
+              "type": "string",
+              "description": "The identifier for the drive item (file or folder) to move. Note: Use %21 to escape the ! character in item IDs (e.g., '7006ADAF2D3C1355%211014')."
+            }
+          },
+          "description": "Path parameters for the move operation.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__READ_TEXT_FILE_CONTENT",
+    "description": "Read the content of a text-based file from OneDrive by its item ID. This function downloads the actual file content for text-based files such as .txt, .csv, .md, .log, .json, and other text formats.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "READ_TEXT_FILE_CONTENT",
+      "canonical_tool_description_hash": "1b1dd966fc450fba019cf680871026a93130256a09c658175b826bf9f467b112",
+      "canonical_tool_input_schema_hash": "dc245525771cf3b103b852f68a60c3f5f385fbe36d19a10bd6c86aca6ae7bf58"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["item_id"],
+      "properties": {
+        "item_id": {
+          "type": "string",
+          "description": "The identifier of the driveItem file to read. Only files (not folders) can be read. Use the full item ID as returned by other OneDrive functions (e.g., '7006ADAF2D3C1355!s5625f3cefe4c4fe28f99a4b6f05cb944')."
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__GET_DOWNLOAD_LINK",
+    "description": "Get the download URL for a driveItem file. Returns the @microsoft.graph.downloadUrl property which provides a preauthenticated download URL that's valid for a short period. This URL can be used directly for downloading without additional authentication.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DOWNLOAD_LINK",
+      "canonical_tool_description_hash": "c4c260c4b3c097bc49c5be4c37472a66e9882cd395c68be1680e7c9df0a57d85",
+      "canonical_tool_input_schema_hash": "63fa7e536986a0a92b691640b943db4bd5a87a089f959d89a9caa59898fa3151"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["itemId"],
+          "properties": {
+            "itemId": {
+              "type": "string",
+              "description": "The ID of the driveItem to download. Only driveItem objects with the file property can be downloaded."
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__DELETE_DRIVE_ITEM",
+    "description": "Delete a DriveItem by using its ID. Deleting items using this method moves the items to the recycle bin instead of permanently deleting the item. Returns 204 No Content on successful deletion.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_DRIVE_ITEM",
+      "canonical_tool_description_hash": "f78ceeb27b9f6e50e208a8572005c83ec9de67d843054cd09f23bc2f73ee0312",
+      "canonical_tool_input_schema_hash": "8d83e78e1d0b20bfc6031bb1c19e08906a6b5ec9ce7b7fdae48ce33782a82771"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["itemId"],
+          "properties": {
+            "itemId": {
+              "type": "string",
+              "description": "The ID of the driveItem to delete. The item will be moved to the recycle bin."
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__CREATE_TEXT_FILE",
+    "description": "Upload or create a new text-based file to OneDrive. This method only supports text-based files like .txt, .md, .csv, .json, .log, .xml, .html, .css, .js, .py, .yaml, etc. Files up to 250 MB in size are supported. The file will be created at the specified parent location with the given filename.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_TEXT_FILE",
+      "canonical_tool_description_hash": "3d4d9b98912bd77f58c3c1c9c54a0159669c2c4adcbf9accefa262b6c40e672d",
+      "canonical_tool_input_schema_hash": "26b2707474d7317a7173439ec47a5d1f7db8b84027bf31aeaa2d6786896384c2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "string",
+          "description": "The text content of the file to upload. Provide the text content directly as a string."
+        },
+        "path": {
+          "type": "object",
+          "required": ["parentId", "filename"],
+          "properties": {
+            "filename": {
+              "type": "string",
+              "description": "The name of the new file to create, including the file extension (e.g., 'document.txt', 'image.jpg')."
+            },
+            "parentId": {
+              "type": "string",
+              "description": "The identifier of the parent folder where the new file will be created. Use 'root' for the root directory or a specific item ID. Note: Use %21 to escape the ! character in item IDs (e.g., '7006ADAF2D3C1355%211014')."
+            }
+          },
+          "description": "Path parameters for file creation",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__UPDATE_TEXT_FILE_CONTENT",
+    "description": "Update or replace the contents of an existing text-based file in OneDrive. This method only supports text-based files like .txt, .md, .csv, .json, .log, .xml, .html, .css, .js, .py, .yaml, etc. Files up to 250 MB in size are supported. The file content will be completely replaced with the new content provided.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_TEXT_FILE_CONTENT",
+      "canonical_tool_description_hash": "cd021d92efd1427969a290753dc35f633b99a74886eea8b5cc71d05d56ee09a0",
+      "canonical_tool_input_schema_hash": "f8a9121afd045d183fb52419f34e0af830c73441515c010dab70d7dacbe6a756"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "string",
+          "description": "The text content to replace the existing file content with. Provide the text content directly as a string."
+        },
+        "path": {
+          "type": "object",
+          "required": ["itemId"],
+          "properties": {
+            "itemId": {
+              "type": "string",
+              "description": "The identifier of the existing file to update. Note: Use %21 to escape the ! character in item IDs (e.g., '7006ADAF2D3C1355%211014')."
+            }
+          },
+          "description": "Path parameters for file update",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_ONEDRIVE__CREATE_EXCEL_FROM_CSV",
+    "description": "Convert CSV data to a formatted text file and save it to OneDrive. Takes CSV data as a string and creates a properly formatted CSV file in the specified parent folder on OneDrive. While named 'excel', this creates a CSV file that can be opened in Excel.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_EXCEL_FROM_CSV",
+      "canonical_tool_description_hash": "c0664e84c5645761a7782d7c817f5c6d4bc9ecb436d813fec853b8ce616f6536",
+      "canonical_tool_input_schema_hash": "d72377de0fe775b0b2a79e0582f045c5e15b2f68bfd60e39458985abe733e1fb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["csv_data", "parent_folder_id"],
+      "properties": {
+        "csv_data": {
+          "type": "string",
+          "description": "The CSV data as a string to save as a file. Should be properly formatted CSV with headers and data rows."
+        },
+        "filename": {
+          "type": "string",
+          "description": "The name for the CSV file (without .csv extension). If not provided, defaults to 'converted_data'."
+        },
+        "parent_folder_id": {
+          "type": "string",
+          "description": "The identifier of the parent folder where the new CSV file will be created. Use 'root' for the root directory or a specific folder item ID."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/microsoft_outlook/tools.json
+++ b/backend/mcp_servers/microsoft_outlook/tools.json
@@ -1,0 +1,1381 @@
+[
+  {
+    "name": "MICROSOFT_OUTLOOK__LIST_MESSAGES",
+    "description": "List email messages from the user's inbox.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_MESSAGES",
+      "canonical_tool_description_hash": "3b8bafbb7905fbf23b39adcd7492c30f0a093a20b14a1ef70099da6e04df75e3",
+      "canonical_tool_input_schema_hash": "d49a24d52e58602505e311ad6add14c7d4e7b08abeb85b46c92aa6ce60093a3c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Limits the number of items returned from a collection"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Skips items in a result set. Also used by some APIs to implement paging and can be used with $top to manually page results"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "OData filter expression"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Order by expression like 'receivedDateTime desc'"
+            }
+          },
+          "description": "Query parameters for filtering messages",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__LIST_MESSAGES_IN_FOLDER",
+    "description": "Get all messages in a specified mail folder. Supports filtering, pagination, and sorting using OData query parameters. This allows you to retrieve messages from any specific folder in the mailbox.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_MESSAGES_IN_FOLDER",
+      "canonical_tool_description_hash": "76abc767a598e05f13472e72bc254a3b6328a5ae9fb940ded9e6bd22fabb1f76",
+      "canonical_tool_input_schema_hash": "65cac7339403484459964bd3fd84fe80e563153de0f0c39b2a449daacacc5341"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["folder_id"],
+          "properties": {
+            "folder_id": {
+              "type": "string",
+              "description": "The unique identifier of the mail folder, or a well-known folder name (e.g., 'inbox', 'drafts', 'sentitems')"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of messages to return (default 10, max 1000)"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of messages to skip for pagination"
+            },
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities (e.g., 'attachments', 'extensions')"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "Filter expression to limit messages (e.g., 'hasAttachments eq true', 'from/emailAddress/address eq \"example@domain.com\"')"
+            },
+            "$search": {
+              "type": "string",
+              "description": "Search query string to find messages containing specific text"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,subject,sender,receivedDateTime')"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort by with direction (e.g., 'receivedDateTime desc', 'subject asc')"
+            }
+          },
+          "description": "Query parameters for filtering and customizing the message list",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__SEND",
+    "description": "Send an existing draft message. The draft can be a new message draft, reply draft, reply-all draft, or forward draft. This saves the message in the Sent Items folder.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND",
+      "canonical_tool_description_hash": "6b2a3ba2194f03c18d144372798fc2d5bff4101891a0a107f9344b4e54298a36",
+      "canonical_tool_input_schema_hash": "b5a972f39e2720e691694d87055e125c479bed47419be51c5d88e139c8f32210"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the draft message to send"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__LIST_MAIL_FOLDERS",
+    "description": "Get the mail folder collection directly under the root folder of the signed-in user. Includes mail search folders and can optionally include hidden folders.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_MAIL_FOLDERS",
+      "canonical_tool_description_hash": "4ffcd00d8c55345cf6f6f13d0730515448d1a4dbfdf39ce27353f5807dafdd54",
+      "canonical_tool_input_schema_hash": "13484e7ae6d1ee9ebb1c778c972450e99395eed64621829797681a663151edc0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Limits the number of folders returned from a collection"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Skips folders in a result set"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "OData filter expression to filter folders"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Select specific properties like 'id,displayName,parentFolderId'"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Order by expression like 'displayName asc'"
+            },
+            "includeHiddenFolders": {
+              "type": "boolean",
+              "description": "Include hidden folders in the response (folders where isHidden property is true)"
+            }
+          },
+          "description": "Query parameters for customizing the folder list",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__GET_MAIL_FOLDER",
+    "description": "Retrieve the properties and relationships of a specific mail folder object by its ID. Returns detailed folder information including permissions and relationships.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_MAIL_FOLDER",
+      "canonical_tool_description_hash": "60c963892478c968ad25cc633e0261ca34649ae7d6224f5f04e76aabaf591299",
+      "canonical_tool_input_schema_hash": "9c45740ddb02092ef452c1ca6a16eb69f06bda0d2cab6a5ad603c57361deac32"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["folder_id"],
+          "properties": {
+            "folder_id": {
+              "type": "string",
+              "description": "The unique identifier of the mail folder to retrieve"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities like 'childFolders' or 'messages'"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Select specific properties like 'id,displayName,parentFolderId,childFolderCount'"
+            }
+          },
+          "description": "Query parameters for customizing the folder details",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__UPDATE_MAIL_FOLDER",
+    "description": "Update the properties of a mail folder object. Currently supports updating the display name of the folder. This allows you to rename folders for better organization.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_MAIL_FOLDER",
+      "canonical_tool_description_hash": "e207a555a9bf543d7d6b64f056e78663566a6021f1ec48041677d4000a796c88",
+      "canonical_tool_input_schema_hash": "7904ddbda5a59a1bf8462646013b02be0b4fe8d83d4926ec73d7ee0a319972bb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["displayName"],
+          "properties": {
+            "displayName": {
+              "type": "string",
+              "description": "The new display name for the mail folder. This will be the name shown in the user's mailbox."
+            }
+          },
+          "description": "The mail folder properties to update",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["folder_id"],
+          "properties": {
+            "folder_id": {
+              "type": "string",
+              "description": "The unique identifier of the mail folder to update"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__LIST_CHILD_FOLDERS",
+    "description": "Get the collection of child folders under a specified mail folder. By default, hidden folders are excluded unless explicitly requested. Supports OData query parameters for filtering and customization.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_CHILD_FOLDERS",
+      "canonical_tool_description_hash": "82dfc362c3afa9212201cfbde0281415368ac33ce92b860fcff3df1e8c0c369e",
+      "canonical_tool_input_schema_hash": "53ca12cb76b18de05a4b23afc59bd10a92e4f658e378ce289aece4ebd4c88329"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["folder_id"],
+          "properties": {
+            "folder_id": {
+              "type": "string",
+              "description": "The unique identifier of the parent mail folder whose child folders to retrieve"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of child folders to return"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of child folders to skip (for pagination)"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "Filter expression to limit the child folders returned (e.g., 'totalItemCount gt 0')"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response (e.g., 'id,displayName,totalItemCount')"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort the child folders by, optionally with 'asc' or 'desc' (e.g., 'displayName asc')"
+            },
+            "includeHiddenFolders": {
+              "type": "boolean",
+              "description": "Whether to include hidden child folders in the response. Default is false."
+            }
+          },
+          "description": "Query parameters for customizing the child folder list",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__CREATE_MESSAGE_IN_FOLDER",
+    "description": "Create a new message directly in a specific mail folder. This creates an actual message in the folder, not a draft. The message will appear in the specified folder immediately.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_MESSAGE_IN_FOLDER",
+      "canonical_tool_description_hash": "c7234bf010e5d8bf491c7214a8ebc5334de390724d45018b2382c78841ee7e5a",
+      "canonical_tool_input_schema_hash": "6e1a961e8f70f27b86442bacdafb4450199a3e7370e64cf027fc00a228c7d2a6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["subject", "body"],
+          "properties": {
+            "body": {
+              "type": "object",
+              "required": ["contentType", "content"],
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The content of the message body"
+                },
+                "contentType": {
+                  "type": "string",
+                  "description": "The content type of the body. Either 'text' or 'html'"
+                }
+              },
+              "description": "The body of the message",
+              "additionalProperties": false
+            },
+            "isRead": {
+              "type": "boolean",
+              "description": "Indicates whether the message has been read"
+            },
+            "subject": {
+              "type": "string",
+              "description": "The subject line of the message"
+            },
+            "importance": {
+              "enum": ["low", "normal", "high"],
+              "type": "string",
+              "description": "The importance of the message. Values: low, normal, high"
+            },
+            "ccRecipients": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["emailAddress"],
+                "required": ["emailAddress"],
+                "properties": {
+                  "emailAddress": {
+                    "type": "object",
+                    "visible": ["address", "name"],
+                    "required": ["address"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The display name of the recipient"
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "The email address"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The recipients in the CC field"
+            },
+            "toRecipients": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["emailAddress"],
+                "required": ["emailAddress"],
+                "properties": {
+                  "emailAddress": {
+                    "type": "object",
+                    "visible": ["address", "name"],
+                    "required": ["address"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The display name of the recipient"
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "The email address"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The recipients in the To field"
+            },
+            "bccRecipients": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["emailAddress"],
+                "required": ["emailAddress"],
+                "properties": {
+                  "emailAddress": {
+                    "type": "object",
+                    "visible": ["address", "name"],
+                    "required": ["address"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The display name of the recipient"
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "The email address"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The recipients in the BCC field"
+            }
+          },
+          "description": "The message properties to create",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["folder_id"],
+          "properties": {
+            "folder_id": {
+              "type": "string",
+              "description": "The unique identifier of the mail folder where the message will be created"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__CREATE_MAIL_FOLDER",
+    "description": "Create a new mail folder in the root folder of the user's mailbox. You can set the folder name and whether it should be hidden. Hidden folders cannot be unhidden later.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_MAIL_FOLDER",
+      "canonical_tool_description_hash": "42235827766992b023434974185d0f512ca8ed8cf0708fc548771f33e7fd2f34",
+      "canonical_tool_input_schema_hash": "34a3edc6e452c9c98a167b075f4d25d94b040ddf8032709fe931b204fb20b731"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["displayName"],
+          "properties": {
+            "isHidden": {
+              "type": "boolean",
+              "description": "Indicates whether the new folder should be hidden. Default is false. Once set to true, this property cannot be changed later."
+            },
+            "displayName": {
+              "type": "string",
+              "description": "The display name of the new folder. This is the name that will appear in the user's mailbox."
+            }
+          },
+          "description": "The mail folder properties to create",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__CREATE_CHILD_FOLDER",
+    "description": "Create a new child mail folder under a specific parent folder. You can set the folder name and whether it should be hidden. Hidden folders cannot be unhidden later. This is useful for organizing emails in a hierarchical structure.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_CHILD_FOLDER",
+      "canonical_tool_description_hash": "0d839a0830fa75669efa2f58d0340304cc7bc95e49bc8284033bcb5a5e8cd8ed",
+      "canonical_tool_input_schema_hash": "34c69a7d1cfa4b5b8fa1164f6aa9dfbf81887c3ddd5007b446ce94bf0018f2cb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["displayName"],
+          "properties": {
+            "isHidden": {
+              "type": "boolean",
+              "description": "Indicates whether the new child folder should be hidden. Default is false. Once set to true, this property cannot be changed later."
+            },
+            "displayName": {
+              "type": "string",
+              "description": "The display name of the new child folder. This is the name that will appear in the user's mailbox under the parent folder."
+            }
+          },
+          "description": "The child folder properties to create",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["folder_id"],
+          "properties": {
+            "folder_id": {
+              "type": "string",
+              "description": "The unique identifier of the parent mail folder under which to create the child folder"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__GET_MESSAGE",
+    "description": "Get a specific email message by its ID with detailed information including sender, recipients, subject, body, and attachments.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_MESSAGE",
+      "canonical_tool_description_hash": "744ca2b68ea046a19e5fc77ec4352d4ab8dd960a1910d82879e2ba6d858113fc",
+      "canonical_tool_input_schema_hash": "b921b82296283e2e35438d131f924007b9133ad72bc62c3c23094f6c395a09df"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to retrieve"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$expand": {
+              "type": "string",
+              "description": "Comma-separated list of relationships to expand (e.g., 'attachments')"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response (e.g., 'subject,sender,receivedDateTime')"
+            }
+          },
+          "description": "Query parameters for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__DELETE_MESSAGE",
+    "description": "Delete a specific email message by its ID. This operation moves the message to the Deleted Items folder.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_MESSAGE",
+      "canonical_tool_description_hash": "539eacaee56c5bfae5d6aa79c3dc32dbc42075823001e6601c1fb30235a24ef8",
+      "canonical_tool_input_schema_hash": "c39ee6a73e0dea5dccdf9d06d229dbe10d4e2da436aa7fd2a2cc7d72b87ddd1b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to delete"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__PERMANENT_DELETE",
+    "description": "Permanently delete a message and place it in the purges folder in the dumpster. Unlike regular delete, this cannot be recovered by email clients and items are permanently deleted after a set period.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PERMANENT_DELETE",
+      "canonical_tool_description_hash": "7d30ec59ada6e794d1ae22b1e828d3ec7aa3e47a8b0a21143f90562f643d23b1",
+      "canonical_tool_input_schema_hash": "1f7d9af647a5b3ea65280f0506f6391cfd9a2a77f4497965bac4049c183784c1"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to permanently delete"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__COPY_MESSAGE",
+    "description": "Copy a message to a folder within the user's mailbox. You can specify a destination folder ID or use well-known folder names like 'inbox', 'drafts', 'sentitems', 'deleteditems'.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "COPY_MESSAGE",
+      "canonical_tool_description_hash": "081187bea61a0ee5e38a0a1b390bd4cf48e92eb7a48869931065dd2f98b28754",
+      "canonical_tool_input_schema_hash": "d05911ca23b751e3e6c5cb997571a48a392b8c38b174cd491e4fffe6c85c01fc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["destinationId"],
+          "properties": {
+            "destinationId": {
+              "type": "string",
+              "description": "The destination folder ID, or a well-known folder name (e.g., 'inbox', 'drafts', 'sentitems', 'deleteditems', 'archive', 'junkfolder')"
+            }
+          },
+          "description": "The copy operation parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to copy"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__CREATE_FORWARD",
+    "description": "Create a draft to forward an existing message. You can optionally add a comment and specify recipients. The draft can be updated later or sent in a subsequent operation.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_FORWARD",
+      "canonical_tool_description_hash": "a223acc0cb1b4c81c32d48c8fc7283a8e5ddf1eecf2af9773b5970ce268a3ef6",
+      "canonical_tool_input_schema_hash": "32e0700a04c921a55e39eeaeacb665508a27ba7ea3a2ec7afd9663f50fc2be7a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "comment": {
+              "type": "string",
+              "description": "A comment to include with the forward (alternative to message body)"
+            },
+            "message": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "body": {
+                  "type": "object",
+                  "required": ["contentType", "content"],
+                  "properties": {
+                    "content": {
+                      "type": "string",
+                      "description": "The actual content of the message body"
+                    },
+                    "contentType": {
+                      "enum": ["text", "html"],
+                      "type": "string",
+                      "description": "The content type of the message body"
+                    }
+                  },
+                  "description": "The body content of the forward message",
+                  "additionalProperties": false
+                },
+                "toRecipients": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "visible": ["emailAddress"],
+                    "required": ["emailAddress"],
+                    "properties": {
+                      "emailAddress": {
+                        "type": "object",
+                        "visible": ["address", "name"],
+                        "required": ["address"],
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The display name of the recipient"
+                          },
+                          "address": {
+                            "type": "string",
+                            "description": "The email address of the recipient"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "description": "The list of recipients (alternative to top-level toRecipients)"
+                }
+              },
+              "description": "Message properties for the forward draft",
+              "additionalProperties": false
+            },
+            "toRecipients": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["emailAddress"],
+                "required": ["emailAddress"],
+                "properties": {
+                  "emailAddress": {
+                    "type": "object",
+                    "visible": ["address", "name"],
+                    "required": ["address"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The display name of the recipient"
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "The email address of the recipient"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The list of recipients to forward the message to"
+            }
+          },
+          "description": "Optional parameters for the forward draft",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to forward"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__CREATE_REPLY",
+    "description": "Create a draft reply to an existing message. The reply will automatically include the original sender as the recipient and reference the original message.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_REPLY",
+      "canonical_tool_description_hash": "f92b8b4c30a7b7a8d05509dbaff85eee1955769bf900a5fb41a6d6686f318c0b",
+      "canonical_tool_input_schema_hash": "bfb6d32ae4610aea8b8b9fb03f68e5189e9b847a76d5e1b428b0b2f0c0000638"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to reply to"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__CREATE_REPLY_ALL",
+    "description": "Create a draft to reply to the sender and all recipients of a message. The reply will automatically include all original recipients (To, CC) and follow proper reply-to logic.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_REPLY_ALL",
+      "canonical_tool_description_hash": "f82ea1e04ff14b2b7372642b183c41acc243e135410311d518469d66832c349b",
+      "canonical_tool_input_schema_hash": "ea493652da0303a99b7a145e86a8d01864d8aaff106a4a006ba28f7d4aeffb09"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to reply to all recipients"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__FORWARD",
+    "description": "Forward a message immediately (not as draft). The message will be sent right away and saved in the Sent Items folder. You can add a comment and specify recipients.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "FORWARD",
+      "canonical_tool_description_hash": "13c3365999ae6e2330c98b7933540d2dc9719edc375a6c61a6b6100aec70c6dc",
+      "canonical_tool_input_schema_hash": "e3e2d2fcf01c78c2be9ddce7bdeec3096fe3100bad7b9b3a6c37b7c7adabd14a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "comment": {
+              "type": "string",
+              "description": "A comment to include with the forwarded message. Cannot be used together with message.body property."
+            },
+            "message": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "body": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "content": {
+                      "type": "string",
+                      "description": "The content of the body"
+                    },
+                    "contentType": {
+                      "enum": ["text", "html"],
+                      "type": "string",
+                      "description": "The content type of the body"
+                    }
+                  },
+                  "description": "The body of the forwarded message. Cannot be used together with comment parameter.",
+                  "additionalProperties": false
+                },
+                "toRecipients": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "visible": ["emailAddress"],
+                    "required": ["emailAddress"],
+                    "properties": {
+                      "emailAddress": {
+                        "type": "object",
+                        "visible": ["address", "name"],
+                        "required": ["address"],
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The display name"
+                          },
+                          "address": {
+                            "type": "string",
+                            "description": "The email address"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "description": "Recipients in message format. Cannot be used together with toRecipients parameter."
+                }
+              },
+              "description": "Alternative way to specify message properties",
+              "additionalProperties": false
+            },
+            "toRecipients": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["emailAddress"],
+                "required": ["emailAddress"],
+                "properties": {
+                  "emailAddress": {
+                    "type": "object",
+                    "visible": ["address", "name"],
+                    "required": ["address"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The display name for the email address"
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "The email address"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The recipients for the forwarded message. Cannot be used together with message.toRecipients property."
+            }
+          },
+          "description": "The request body for forwarding the message",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to forward"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__REPLY",
+    "description": "Reply to the sender of a message immediately (not as draft). The reply will be sent right away and saved in the Sent Items folder. You can add a comment or custom body.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REPLY",
+      "canonical_tool_description_hash": "e4b72e3a6a1d526c08d367eadc334b055f63fe9b4d27b27928470a00d8f9dd7b",
+      "canonical_tool_input_schema_hash": "e82627eca5d843a8d55822f30fe482f69cb59166b5d3cc1d04fe6965de368422"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "comment": {
+              "type": "string",
+              "description": "A comment to include with the reply. Cannot be used together with message.body property."
+            },
+            "message": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "body": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "content": {
+                      "type": "string",
+                      "description": "The content of the body"
+                    },
+                    "contentType": {
+                      "enum": ["text", "html"],
+                      "type": "string",
+                      "description": "The content type of the body"
+                    }
+                  },
+                  "description": "The body of the reply message. Cannot be used together with comment parameter.",
+                  "additionalProperties": false
+                }
+              },
+              "description": "Alternative way to specify message properties",
+              "additionalProperties": false
+            }
+          },
+          "description": "The request body for the reply",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to reply to"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__REPLY_ALL",
+    "description": "Reply to all recipients of a message immediately (not as draft). The reply will be sent right away to all original recipients and saved in the Sent Items folder. You can add a comment or custom body.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REPLY_ALL",
+      "canonical_tool_description_hash": "072009d0bafdcb7ef00eb84623ccef9ea4d11612833fb77ac54aee3e266dc11e",
+      "canonical_tool_input_schema_hash": "0dfeebd4ec7679d49f4b2dc405f2e38e4d7c7fb6e1425dc0f5c7b0c5f6d90b4c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "comment": {
+              "type": "string",
+              "description": "A comment to include with the reply all. Cannot be used together with message.body property."
+            },
+            "message": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "body": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "content": {
+                      "type": "string",
+                      "description": "The content of the body"
+                    },
+                    "contentType": {
+                      "enum": ["text", "html"],
+                      "type": "string",
+                      "description": "The content type of the body"
+                    }
+                  },
+                  "description": "The body of the reply all message. Cannot be used together with comment parameter.",
+                  "additionalProperties": false
+                }
+              },
+              "description": "Alternative way to specify message properties",
+              "additionalProperties": false
+            }
+          },
+          "description": "The request body for the reply all",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["message_id"],
+          "properties": {
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to reply all to"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__CREATE_DRAFT_MESSAGE",
+    "description": "Create a draft of a new message in JSON format. By default, this operation saves the draft in the Drafts folder. You can update the draft later to add content or change properties, or send it in a subsequent operation.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_DRAFT_MESSAGE",
+      "canonical_tool_description_hash": "1b61d37f316eeeafdd99bc162807ee062d46196e2a700d138d90f8b583fcaa1d",
+      "canonical_tool_input_schema_hash": "e35960bf2fc49dcee900f3ed295da944653cc16a65815a819b2b72a9dda9459f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "body": {
+              "type": "object",
+              "required": ["contentType", "content"],
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The actual content of the message body"
+                },
+                "contentType": {
+                  "enum": ["text", "html"],
+                  "type": "string",
+                  "description": "The content type of the message body"
+                }
+              },
+              "description": "The body content of the message",
+              "additionalProperties": false
+            },
+            "subject": {
+              "type": "string",
+              "description": "The subject of the message"
+            },
+            "importance": {
+              "enum": ["low", "normal", "high"],
+              "type": "string",
+              "description": "The importance level of the message"
+            },
+            "ccRecipients": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["emailAddress"],
+                "required": ["emailAddress"],
+                "properties": {
+                  "emailAddress": {
+                    "type": "object",
+                    "visible": ["address", "name"],
+                    "required": ["address"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The display name of the CC recipient"
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "The email address of the CC recipient"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The list of CC recipients"
+            },
+            "toRecipients": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["emailAddress"],
+                "required": ["emailAddress"],
+                "properties": {
+                  "emailAddress": {
+                    "type": "object",
+                    "visible": ["address", "name"],
+                    "required": ["address"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The display name of the recipient"
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "The email address of the recipient"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The list of recipients to send the message to"
+            },
+            "bccRecipients": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["emailAddress"],
+                "required": ["emailAddress"],
+                "properties": {
+                  "emailAddress": {
+                    "type": "object",
+                    "visible": ["address", "name"],
+                    "required": ["address"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The display name of the BCC recipient"
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "The email address of the BCC recipient"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "The list of BCC recipients"
+            }
+          },
+          "description": "The message properties for creating a draft email",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__DELTA_MAIL_FOLDERS",
+    "description": "Get incremental changes (added, deleted, or updated) in mail folders since the last delta query. This allows efficient synchronization by tracking only changes rather than fetching all folders every time. Use deltatoken for completed rounds and skiptoken for pagination.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELTA_MAIL_FOLDERS",
+      "canonical_tool_description_hash": "4477bccaa12efe2c8ce9b3a34bc4b3209af34d3749204f30ccbab408e02072c1",
+      "canonical_tool_input_schema_hash": "fb7b7333a3158e2acabfe458de5a35db7fee81927f1ceec2744d4025d8e3a771"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include in the response for performance optimization (e.g., 'id,displayName,parentFolderId'). The 'id' property is always returned."
+            },
+            "$skiptoken": {
+              "type": "string",
+              "description": "State token from the @odata.nextLink URL of the previous delta call, indicating there are more changes to be tracked in the same round."
+            },
+            "$deltatoken": {
+              "type": "string",
+              "description": "State token from the @odata.deltaLink URL of the previous delta call, indicating completion of a change tracking round. Use this to start the next round of change tracking."
+            }
+          },
+          "description": "Query parameters for delta tracking and customization",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__COPY_MAIL_FOLDER",
+    "description": "Copy a mail folder and its contents to another mail folder. You can specify a destination folder ID or use well-known folder names like 'inbox', 'drafts', 'sentitems', 'deleteditems'. The entire folder structure and contents will be duplicated.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "COPY_MAIL_FOLDER",
+      "canonical_tool_description_hash": "691416b381daaa2eb038da3b6b3e879a01a3824c2c957dfd641b0425698ae7d9",
+      "canonical_tool_input_schema_hash": "6cfd1cd6a215ee36ccdf4d90a5f9acdc0c7a3010b5a587e089e40d3248eb3c8d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["destinationId"],
+          "properties": {
+            "destinationId": {
+              "type": "string",
+              "description": "The destination folder ID, or a well-known folder name (e.g., 'inbox', 'drafts', 'sentitems', 'deleteditems', 'archive', 'junkfolder')"
+            }
+          },
+          "description": "The copy operation parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["folder_id"],
+          "properties": {
+            "folder_id": {
+              "type": "string",
+              "description": "The unique identifier of the mail folder to copy"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_OUTLOOK__DELETE_MAIL_FOLDER",
+    "description": "Delete a mail folder by its ID. The folder can be a mailSearchFolder. You can specify a mail folder by its folder ID, or by its well-known folder name. Note: You may not be able to delete items in the recoverable items deletions folder.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_MAIL_FOLDER",
+      "canonical_tool_description_hash": "8c0cd940aeefcefc94ce8075be1165454535a485e29835033666379dd20e191d",
+      "canonical_tool_input_schema_hash": "97c5c8365f883624375a6d44b47e23508190fc3e8a607e5860e148254cf15a75"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["folder_id"],
+          "properties": {
+            "folder_id": {
+              "type": "string",
+              "description": "The unique identifier of the mail folder to delete, or a well-known folder name"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/microsoft_teams/tools.json
+++ b/backend/mcp_servers/microsoft_teams/tools.json
@@ -1,0 +1,1889 @@
+[
+  {
+    "name": "MICROSOFT_TEAMS__ARCHIVE_TEAM",
+    "description": "Archive a team. Archived teams are read-only and members cannot add new content, but existing content remains accessible.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ARCHIVE_TEAM",
+      "canonical_tool_description_hash": "c6a42b2339d04ac8072ffb32eac9662e7ba386f9a44c536100f33749b8c4d9b3",
+      "canonical_tool_input_schema_hash": "e620e4ce19c1ae5626bee4459ea25d091dc40a3c7d6f74bfef56e09fc55ee249"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "shouldSetSpoSiteReadOnlyForMembers": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to make the SharePoint site read-only for members"
+            }
+          },
+          "description": "Archive options",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team to archive"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__LIST_JOINED_TEAMS",
+    "description": "Get the teams in Microsoft Teams that the user is a direct member of. This API doesn't return the host team of the shared channel that the user is a direct member of.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_JOINED_TEAMS",
+      "canonical_tool_description_hash": "a994cfd9ed0871b1555f15bf53257184296b3b1c693bf15a1538f91132fdb257",
+      "canonical_tool_input_schema_hash": "45a3a326b8413807a06278beb025e7c3f485540a955963a978b103dc573c7770"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of teams to return (default 20, max 999)"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of teams to skip for pagination"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "Filter expression to limit teams (e.g., \"displayName eq 'Project Team'\")"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,displayName,description')"
+            }
+          },
+          "description": "Query parameters for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__GET_TEAM",
+    "description": "Get the properties and relationships of the specified team. This returns more detailed information about a team than the basic joined teams list.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_TEAM",
+      "canonical_tool_description_hash": "dff7fd51419a0d2b4b6418fe712ee6b0d5902a053e42471b87aff246234809c3",
+      "canonical_tool_input_schema_hash": "cbb71cf3c7295ecff25b94b062269d96de1c6d26cd7c6d2681c370be268cdf16"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities like 'channels' or 'members'"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Select specific properties like 'id,displayName,description,settings'"
+            }
+          },
+          "description": "Query parameters for customizing the team details",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__LIST_TEAM_CHANNELS",
+    "description": "Get the list of channels in a team. This allows you to see all channels within a specific team.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_TEAM_CHANNELS",
+      "canonical_tool_description_hash": "2b6703165669434a9744a19eb4e8e9a510431aecd2d0943bb3d415adbdeb303c",
+      "canonical_tool_input_schema_hash": "b36b3fb4fe93be6510d7b4307ae4d2819fe24613d37fa46ec4a0b9ccbce607e7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of channels to return"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of channels to skip for pagination"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "Filter expression to limit channels (e.g., \"membershipType eq 'standard'\")"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,displayName,description,membershipType')"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort by with direction (e.g., 'displayName asc')"
+            }
+          },
+          "description": "Query parameters for filtering and customizing the channel list",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__LIST_TEAM_MEMBERS",
+    "description": "Get the members of a team. This returns all users who are part of the specified team.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_TEAM_MEMBERS",
+      "canonical_tool_description_hash": "289dea79a3eb07277f70326bb79654c622196debb7cd715dba7a7148ac7fdf1a",
+      "canonical_tool_input_schema_hash": "c1dfa50289cb0357dd45f9edd44ba52e572dc5065aa50dd1168438e9c6ab4086"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of members to return"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of members to skip for pagination"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "Filter expression to limit members (e.g., \"roles/any(r:r eq 'owner')\")"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,displayName,email,roles')"
+            }
+          },
+          "description": "Query parameters for filtering and customizing the member list",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__LIST_CHANNEL_MESSAGES",
+    "description": "Get the list of messages in a channel. This allows you to retrieve conversation messages from a specific team channel.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_CHANNEL_MESSAGES",
+      "canonical_tool_description_hash": "a351266b7c04d9c2fc376b651883b4c264cc45d452f0407c940207bf15ab7d0c",
+      "canonical_tool_input_schema_hash": "270ab788347082fe81530edfe62f5bebce4a3197d6aa941e51d9c734c228178c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of messages to return (default 20, max 50)"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of messages to skip for pagination"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "Filter expression to limit messages (e.g., \"from/user/displayName eq 'John Doe'\")"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,body,from,createdDateTime')"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort by with direction (e.g., 'createdDateTime desc')"
+            }
+          },
+          "description": "Query parameters for filtering and customizing the message list",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__SEND_CHANNEL_MESSAGE",
+    "description": "Send a new message to a channel in a team. This allows posting messages to team channels.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND_CHANNEL_MESSAGE",
+      "canonical_tool_description_hash": "f8012c21723cba03b44ab48ab38e817ac45223e9c9ded108b1f33becf8ad4afd",
+      "canonical_tool_input_schema_hash": "6063a5705d0ee00fcbdc323b25cd74070ce2a36971730b72753f47d706bae9e0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["body"],
+          "properties": {
+            "body": {
+              "type": "object",
+              "required": ["content"],
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The actual content of the message"
+                },
+                "contentType": {
+                  "enum": ["text", "html"],
+                  "type": "string",
+                  "default": "text",
+                  "description": "The content type of the message body"
+                }
+              },
+              "description": "The message body",
+              "additionalProperties": false
+            },
+            "subject": {
+              "type": "string",
+              "description": "The subject of the message (optional)"
+            }
+          },
+          "description": "The message content to send",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__GET_CHANNEL",
+    "description": "Get the properties and relationships of a channel in a team. This provides detailed information about a specific channel.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CHANNEL",
+      "canonical_tool_description_hash": "45b6ba86676bae0a3eb6b72dd095169eeff41ce9a5ff90635169b52869d63dee",
+      "canonical_tool_input_schema_hash": "27ee8c24ca702459b9ffaa7441a7d05cab7873a196f7428acd2efd4a437ca4d3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities like 'members' or 'tabs'"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Select specific properties like 'id,displayName,description,membershipType'"
+            }
+          },
+          "description": "Query parameters for customizing the channel details",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__CREATE_TEAM",
+    "description": "Create a new team in Microsoft Teams. This allows creating a team with specified settings including name, description, visibility, and member permissions.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_TEAM",
+      "canonical_tool_description_hash": "a1d4f1ea7ab062ff13bd45a72c56acce87e43eeb23ac9392dd7565ef953598ac",
+      "canonical_tool_input_schema_hash": "affc7dbc9b31df291f095e4eaf9acc30d1db374b92285e24398a87faead25ccc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["template@odata.bind", "displayName"],
+          "properties": {
+            "visibility": {
+              "enum": ["private", "public"],
+              "type": "string",
+              "default": "private",
+              "description": "Team visibility - private or public"
+            },
+            "description": {
+              "type": "string",
+              "description": "The description of the team (optional)"
+            },
+            "displayName": {
+              "type": "string",
+              "description": "The name of the team"
+            },
+            "template@odata.bind": {
+              "type": "string",
+              "default": "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
+              "description": "The team template to use"
+            }
+          },
+          "description": "The team configuration",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__ADD_TEAM_MEMBER",
+    "description": "Add a member to a team. This allows adding users to an existing team with specified roles.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ADD_TEAM_MEMBER",
+      "canonical_tool_description_hash": "c87eeb416597f4706976715af73e739aa7475ccb5fedd8ecb8852fa993034724",
+      "canonical_tool_input_schema_hash": "7a500f1c1c9e75488623f5a2ebee0bd434c591a6426f78c460c6752af9e39f1f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["user@odata.bind"],
+          "properties": {
+            "roles": {
+              "type": "array",
+              "items": {
+                "enum": ["owner", "guest"],
+                "type": "string"
+              },
+              "default": [],
+              "description": "The roles for the member. Use [] for basic members, ['owner'] for owners, ['guest'] for in-tenant guests. Out-of-tenant external members are assigned ['owner']."
+            },
+            "user@odata.bind": {
+              "type": "string",
+              "description": "The user to add (format: https://graph.microsoft.com/v1.0/users/user-id or https://graph.microsoft.com/v1.0/users/user-email)"
+            }
+          },
+          "description": "The member to add",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__CREATE_CHANNEL",
+    "description": "Create a new channel in a team. This allows creating standard or private channels within an existing team.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_CHANNEL",
+      "canonical_tool_description_hash": "ee886a705ee7a394252c0f6cd8be51b94f738db655454593b7a5892041688173",
+      "canonical_tool_input_schema_hash": "94f68781fbfb25e9deeec13a7dc61eec17692347e9d0e7556bb83eb9e507b4bb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["displayName"],
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "The description of the channel (optional)"
+            },
+            "displayName": {
+              "type": "string",
+              "description": "The name of the channel"
+            },
+            "membershipType": {
+              "enum": ["standard", "private"],
+              "type": "string",
+              "default": "standard",
+              "description": "The type of channel - standard or private"
+            }
+          },
+          "description": "The channel to create",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__SEND_MESSAGE_REPLY",
+    "description": "Send a reply to a message in a channel. This allows responding to existing messages in team channels.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND_MESSAGE_REPLY",
+      "canonical_tool_description_hash": "e217c2bedb88eb14f7eb944c4dd76f4079662af53161c697c504d44fc8dbaa8a",
+      "canonical_tool_input_schema_hash": "77ae13c6c1cd9689a964f39106e6ed629c40da032db7d0693496e2475732428e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["body"],
+          "properties": {
+            "body": {
+              "type": "object",
+              "required": ["content"],
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The actual content of the reply"
+                },
+                "contentType": {
+                  "enum": ["text", "html"],
+                  "type": "string",
+                  "default": "text",
+                  "description": "The content type of the message body"
+                }
+              },
+              "description": "The message body",
+              "additionalProperties": false
+            }
+          },
+          "description": "The reply message content",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id", "message_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to reply to"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__SEND_CHAT_MESSAGE",
+    "description": "Send a direct message to a team member or in a chat. This allows sending private messages between team members.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND_CHAT_MESSAGE",
+      "canonical_tool_description_hash": "c5956f5b6ef61988a91d120bb5441851a8d72c105bdadc7705301d531ca4d3a0",
+      "canonical_tool_input_schema_hash": "38dfea64cb3d15a168409afaa982d67f4871469a06519b0c4d95bd0c40563aea"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["body"],
+          "properties": {
+            "body": {
+              "type": "object",
+              "required": ["content"],
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The actual content of the message"
+                },
+                "contentType": {
+                  "enum": ["text", "html"],
+                  "type": "string",
+                  "default": "text",
+                  "description": "The content type of the message body"
+                }
+              },
+              "description": "The message body",
+              "additionalProperties": false
+            }
+          },
+          "description": "The message content to send",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["chat_id"],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "description": "The unique identifier of the chat"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__UNARCHIVE_TEAM",
+    "description": "Unarchive a team. This restores the team to an active state where members can add new content.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UNARCHIVE_TEAM",
+      "canonical_tool_description_hash": "c40742c41e13b8545b6307e66e487ed0613bcb27ae3299f133e828a2ff4a1e02",
+      "canonical_tool_input_schema_hash": "bba1aabd574b76b425ff748322668e17f8b2ab36e97db2c81eabcdbc94f2d89c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team to unarchive"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__LIST_MESSAGE_REPLIES",
+    "description": "List all replies to a specific message in a channel. This allows viewing conversation threads and discussions.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_MESSAGE_REPLIES",
+      "canonical_tool_description_hash": "d175ac5a2da146deb04f6ea437979b0ee7312066d4c1a015ad721bb71d28d2d5",
+      "canonical_tool_input_schema_hash": "75798b07c70e4a31d02626e5c2d8b4849b8a5be09cafabfd252dc08190ce8b10"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id", "message_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of replies to return"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of replies to skip for pagination"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,body,from,createdDateTime')"
+            }
+          },
+          "description": "Query parameters for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__LIST_USER_CHATS",
+    "description": "Get all chats that the user is part of. This includes one-on-one chats, group chats, and meeting chats.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_USER_CHATS",
+      "canonical_tool_description_hash": "e9759c644490d54d4887014f7f08e58e72899001019335aece0e0f9514ce5e4f",
+      "canonical_tool_input_schema_hash": "499f0d6e6d5162c6c908c6e91d69e10de2a4d7d46086cd5182e22c6d24c7cacc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of chats to return"
+            },
+            "$skip": {
+              "type": "integer",
+              "description": "Number of chats to skip for pagination"
+            },
+            "$filter": {
+              "type": "string",
+              "description": "Filter expression to limit chats (e.g., \"chatType eq 'oneOnOne'\" or \"chatType eq 'group'\")"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,topic,chatType,createdDateTime')"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort by with direction (e.g., 'createdDateTime desc')"
+            }
+          },
+          "description": "Query parameters for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__LIST_CHAT_MESSAGES",
+    "description": "Get all messages in a specific chat. This allows viewing the conversation history in direct messages or group chats.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_CHAT_MESSAGES",
+      "canonical_tool_description_hash": "e7c7eacd099698d82e499babb369c15a8c084f618927857742a04ab254e496c7",
+      "canonical_tool_input_schema_hash": "f74b503d67cc5701843a3359c5e4e08e75d36e6a223ef948d4b9817aeaee2b16"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["chat_id"],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "description": "The unique identifier of the chat"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of messages to return"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,body,from,createdDateTime')"
+            },
+            "$orderby": {
+              "type": "string",
+              "description": "Property to sort by with direction (e.g., 'createdDateTime desc')"
+            }
+          },
+          "description": "Query parameters for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__GET_CHAT_MESSAGE",
+    "description": "Get a specific message from a chat. This allows retrieving detailed information about a particular chat message.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CHAT_MESSAGE",
+      "canonical_tool_description_hash": "a43ebeae851118d310ea4e12c4c5061d484d8c8e3d1769592f5a717901c6735c",
+      "canonical_tool_input_schema_hash": "7658fe449bfc1632d5bce99acc7de1942e952ef11a7ed32d4f6c78b1385dbd7c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["chat_id", "message_id"],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "description": "The unique identifier of the chat"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$expand": {
+              "type": "string",
+              "description": "Expand related entities like 'replies'"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,body,from,createdDateTime,attachments')"
+            }
+          },
+          "description": "Query parameters for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__DELETE_TEAM",
+    "description": "Delete a team and its underlying Microsoft 365 group. This permanently removes the team and all its data.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_TEAM",
+      "canonical_tool_description_hash": "4f9ff41fd9ed22f22fb2070700b062b01b048a7900ec785b2fd2f6c63e33408b",
+      "canonical_tool_input_schema_hash": "4f92fd1ddef58615f4c6b74de85e767de66f853ba014a695a748034ebcdc6f86"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team to delete"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__UPDATE_TEAM",
+    "description": "Update the properties of a team such as display name, description, and visibility settings.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_TEAM",
+      "canonical_tool_description_hash": "5f54c44d2adc43141f797a317b5e73dbd9060d737357b21a1129e2e4653e79a5",
+      "canonical_tool_input_schema_hash": "fbe3e89e5ea216bb62e1c71eea112fb762f221a70219638491f6f024aaa82394"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "visibility": {
+              "enum": ["private", "public"],
+              "type": "string",
+              "description": "The visibility of the team (private or public)"
+            },
+            "description": {
+              "type": "string",
+              "description": "The updated description of the team"
+            },
+            "displayName": {
+              "type": "string",
+              "description": "The updated name of the team"
+            }
+          },
+          "description": "The team properties to update",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["team_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team to update"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__UPDATE_CHANNEL_MESSAGE",
+    "description": "Update an existing message in a team channel. This allows editing the content of previously sent channel messages.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_CHANNEL_MESSAGE",
+      "canonical_tool_description_hash": "eda69c90232802496289ca67cb3befef11c8f86dc6582832c49da085b0abd99b",
+      "canonical_tool_input_schema_hash": "651a5b592307082bd7bae4fbded1bbbd7c6b177eed63b1ff6328f80640e0c9ea"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["body"],
+          "properties": {
+            "body": {
+              "type": "object",
+              "required": ["content"],
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The updated content of the message"
+                },
+                "contentType": {
+                  "enum": ["text", "html"],
+                  "type": "string",
+                  "default": "text",
+                  "description": "The content type of the message body"
+                }
+              },
+              "description": "The message body",
+              "additionalProperties": false
+            }
+          },
+          "description": "The updated message content",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id", "message_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to update"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__UPDATE_CHAT_MESSAGE",
+    "description": "Update an existing message in a chat. This allows editing the content of previously sent chat messages.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_CHAT_MESSAGE",
+      "canonical_tool_description_hash": "5cd9bf0893426f2f917a86e90aad2a2d7f02b27fe83ec12cdb82766dc981530b",
+      "canonical_tool_input_schema_hash": "1176041aab30f6651bdd873aab5f6f5237fc4956cbdb1e179b148c274ad8ee79"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["body"],
+          "properties": {
+            "body": {
+              "type": "object",
+              "required": ["content"],
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The updated content of the message"
+                },
+                "contentType": {
+                  "enum": ["text", "html"],
+                  "type": "string",
+                  "default": "text",
+                  "description": "The content type of the message body"
+                }
+              },
+              "description": "The message body",
+              "additionalProperties": false
+            }
+          },
+          "description": "The updated message content",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["chat_id", "message_id"],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "description": "The unique identifier of the chat"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to update"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__CREATE_CHAT",
+    "description": "Create a new chat conversation. This allows starting one-on-one or group chats with specified members.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_CHAT",
+      "canonical_tool_description_hash": "3aac2b2cb5838913f48e4e6b4acb103911ac6628f852443c657e01b6f60075d5",
+      "canonical_tool_input_schema_hash": "671c986dfcb7ff179d592c0dd215630775c7df91009601c4f0fc07d5ea5d66c3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["chatType", "members"],
+          "properties": {
+            "topic": {
+              "type": "string",
+              "description": "The topic/name of the chat (for group chats)"
+            },
+            "members": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["@odata.type", "roles", "user"],
+                "required": ["@odata.type", "user"],
+                "properties": {
+                  "user": {
+                    "type": "object",
+                    "visible": ["id"],
+                    "required": ["id"],
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "The user ID (GUID format)"
+                      }
+                    },
+                    "description": "The user information",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": ["owner"],
+                    "description": "The roles for this member. Use [] for basic members, ['owner'] for owners, ['guest'] for in-tenant guests. Out-of-tenant external members are assigned ['owner']."
+                  },
+                  "@odata.type": {
+                    "type": "string",
+                    "default": "#microsoft.graph.aadUserConversationMember",
+                    "description": "The OData type for the member"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "Array of chat members. For oneOnOne chats, exactly 2 members required. For group chats, 2 or more members required."
+            },
+            "chatType": {
+              "enum": ["oneOnOne", "group"],
+              "type": "string",
+              "description": "The type of chat to create"
+            }
+          },
+          "description": "The chat configuration",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__REMOVE_TEAM_MEMBER",
+    "description": "Remove a member from a team. This allows removing users from team membership.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REMOVE_TEAM_MEMBER",
+      "canonical_tool_description_hash": "84a89540a127117d79a470f8668d7b4b2641c07ce2d12de84fe3a0dfa2bf08b0",
+      "canonical_tool_input_schema_hash": "a3df82079f5b6c2942d5c50657c0f537c0ee19af056af159b4fc1822b6ffe67a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id", "member_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "member_id": {
+              "type": "string",
+              "description": "The unique identifier of the member to remove"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__UPDATE_TEAM_MEMBER",
+    "description": "Update a team member's role (e.g., promote to owner or demote to member). This allows changing member permissions within a team.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_TEAM_MEMBER",
+      "canonical_tool_description_hash": "b6e6bdf29e66f4f5d1dc1e668caa70a02f38ca7a0556c280eb4b33c7066be5bb",
+      "canonical_tool_input_schema_hash": "55c843cc5a518b552aacdf2c536eeb8187d1c056822d13c49ad15e94649e5ebe"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["@odata.type", "roles"],
+          "properties": {
+            "roles": {
+              "type": "array",
+              "items": {
+                "enum": ["owner", "guest"],
+                "type": "string"
+              },
+              "description": "Array of roles for the member. Use [] for basic members, ['owner'] for owners, ['guest'] for in-tenant guests. Out-of-tenant external members are assigned ['owner']."
+            },
+            "@odata.type": {
+              "type": "string",
+              "default": "#microsoft.graph.aadUserConversationMember",
+              "description": "The type of conversation member"
+            }
+          },
+          "description": "The member role update",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["team_id", "member_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "member_id": {
+              "type": "string",
+              "description": "The unique identifier of the member to update"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__UPDATE_CHANNEL",
+    "description": "Update the properties of a channel such as display name, description, or member settings.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_CHANNEL",
+      "canonical_tool_description_hash": "d7b0859cb119b1d8fe256aac13253bd04b4cf84bd96e86054c25d2d1bcb48e5c",
+      "canonical_tool_input_schema_hash": "68a03021ad8b5cb8f285c1d56eec8a358c47ec0ee7839002644951f5f93a4f15"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "The updated description of the channel"
+            },
+            "displayName": {
+              "type": "string",
+              "description": "The updated name of the channel"
+            }
+          },
+          "description": "The channel properties to update",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel to update"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__DELETE_CHANNEL",
+    "description": "Delete a channel from a team. Note: This cannot be used to delete the General channel.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_CHANNEL",
+      "canonical_tool_description_hash": "1aa362bdda9785d16567c48e03c6eb2fc19418f7a8f1a0ac89ee136f6658c143",
+      "canonical_tool_input_schema_hash": "5bd690e58f16d18ddb0f6bde3dfd59dcd4ca1b6911503fbfde840d4b0def79e6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel to delete"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__LIST_CHAT_MEMBERS",
+    "description": "List all members of a chat conversation. This shows who is participating in the chat.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_CHAT_MEMBERS",
+      "canonical_tool_description_hash": "ef168ad22d52c48b7af73a677d2f1effc66cfee9d326eff762481bc1534d176d",
+      "canonical_tool_input_schema_hash": "6594f553ea374afedbd50d166c6596f59627e04a6d3a97f4b03177adf351b66e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["chat_id"],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "description": "The unique identifier of the chat"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "$top": {
+              "type": "integer",
+              "description": "Maximum number of members to return"
+            },
+            "$select": {
+              "type": "string",
+              "description": "Comma-separated list of properties to include (e.g., 'id,displayName,email')"
+            }
+          },
+          "description": "Query parameters for customizing the response",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__ADD_CHAT_MEMBER",
+    "description": "Add a member to a group chat. This allows adding new participants to existing chat conversations.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ADD_CHAT_MEMBER",
+      "canonical_tool_description_hash": "1d51d0f5492ab440b10a34e997d9bf280a074878591a9501f61615a1c90ca2b6",
+      "canonical_tool_input_schema_hash": "7af9d3bf09240932a9cd71c382464bb8559e6c4b7722f8150a0b801ec9aa0a8d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["@odata.type", "user@odata.bind"],
+          "properties": {
+            "roles": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": ["owner"],
+              "description": "Roles for the member in the chat. Use [] for basic members, ['owner'] for owners, ['guest'] for in-tenant guests. Out-of-tenant external members are assigned ['owner']."
+            },
+            "@odata.type": {
+              "type": "string",
+              "default": "#microsoft.graph.aadUserConversationMember",
+              "description": "The type of conversation member"
+            },
+            "user@odata.bind": {
+              "type": "string",
+              "description": "The user reference in format: https://graph.microsoft.com/v1.0/users/USER_ID"
+            }
+          },
+          "description": "The member to add to the chat",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["chat_id"],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "description": "The unique identifier of the chat"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__REMOVE_CHAT_MEMBER",
+    "description": "Remove a member from a group chat. This allows removing participants from chat conversations.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REMOVE_CHAT_MEMBER",
+      "canonical_tool_description_hash": "5221f07b129ac74c42c18c9c7174f3f7f7cfe51136d8e41e11b21d1b30e8a796",
+      "canonical_tool_input_schema_hash": "9e174a45066413dc8862634784de45dd07990844481ac8fb6c501f6bf4ff55db"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["chat_id", "member_id"],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "description": "The unique identifier of the chat"
+            },
+            "member_id": {
+              "type": "string",
+              "description": "The unique identifier of the member to remove"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__SOFT_DELETE_CHANNEL_MESSAGE",
+    "description": "Soft delete a message in a channel. This allows safely removing messages with the ability to restore them later.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SOFT_DELETE_CHANNEL_MESSAGE",
+      "canonical_tool_description_hash": "34e64af901ba69c91c774e6a13c7b666d57fdbb1488826b67813d172332c09f9",
+      "canonical_tool_input_schema_hash": "a70a265f89e620a97777835a42732dac7bf42e9293f6a5171eca89a4a0adc99b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id", "message_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to soft delete"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__UNDO_SOFT_DELETE_CHANNEL_MESSAGE",
+    "description": "Undo soft deletion of a message in a channel. This restores a previously soft-deleted message.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UNDO_SOFT_DELETE_CHANNEL_MESSAGE",
+      "canonical_tool_description_hash": "009b47e856a01e503613ad4983202311c27eb7ea6aa24cbbd967cee3f56e52a0",
+      "canonical_tool_input_schema_hash": "e9da43b1e00720c4f5731a766dd960f1f9470c0a1f63c3c94e12851a0255fbcb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id", "message_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to restore"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__SET_CHANNEL_MESSAGE_REACTION",
+    "description": "Add a reaction (emoji) to a channel message. This allows users to react to messages with emojis.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SET_CHANNEL_MESSAGE_REACTION",
+      "canonical_tool_description_hash": "5239008e39376dde8b405d32e4faad98fb0e3c1f82b9ee411aa0ee6870087730",
+      "canonical_tool_input_schema_hash": "98c585f0fed08cd7c636383047bd33afe1a54e533617e173e09e7dce2b90dec4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["reactionType"],
+          "properties": {
+            "reactionType": {
+              "type": "string",
+              "description": "The emoji reaction as unicode (e.g., '\ud83d\udc4d', '\u2764\ufe0f', '\ud83d\ude00')"
+            }
+          },
+          "description": "The reaction to add",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id", "message_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to react to"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__UNSET_CHANNEL_MESSAGE_REACTION",
+    "description": "Remove a reaction (emoji) from a channel message. This allows users to remove their emoji reactions.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UNSET_CHANNEL_MESSAGE_REACTION",
+      "canonical_tool_description_hash": "c60925b957ce186ad534550110608ddb81eba55f5283eb9b64c4ce41d440c91d",
+      "canonical_tool_input_schema_hash": "638c043bce8792def1e6ac15d1a3390b7d71f94fec54423749c0876b7c731160"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["reactionType"],
+          "properties": {
+            "reactionType": {
+              "type": "string",
+              "description": "The emoji reaction to remove as unicode (e.g., '\ud83d\udc4d', '\u2764\ufe0f', '\ud83d\ude00')"
+            }
+          },
+          "description": "The reaction to remove",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id", "message_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to remove reaction from"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__SET_CHAT_MESSAGE_REACTION",
+    "description": "Add a reaction (emoji) to a chat message. This allows users to react to messages with emojis.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SET_CHAT_MESSAGE_REACTION",
+      "canonical_tool_description_hash": "c356db11efbb4a60e9eab272ec434bb97f4f08711485d94f41b13d5ef370beb3",
+      "canonical_tool_input_schema_hash": "e338a7f13237941583dc4db8257c4a3c121e27d7cfb3d97ccf420f9b6a2c3256"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["reactionType"],
+          "properties": {
+            "reactionType": {
+              "type": "string",
+              "description": "The emoji reaction as unicode (e.g., '\ud83d\udc4d', '\u2764\ufe0f', '\ud83d\ude00')"
+            }
+          },
+          "description": "The reaction to add",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["chat_id", "message_id"],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "description": "The unique identifier of the chat"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to react to"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__UNSET_CHAT_MESSAGE_REACTION",
+    "description": "Remove a reaction (emoji) from a chat message. This allows users to remove their emoji reactions.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UNSET_CHAT_MESSAGE_REACTION",
+      "canonical_tool_description_hash": "112fe5c0a6b1efc948dc64ef8b16cc0037079728d752f190ceff2ef7ece04536",
+      "canonical_tool_input_schema_hash": "0f5ddfa903002a4ba1db85a6751ea5bef4ccace890a96ff46df4ec2cd5f24dbd"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["reactionType"],
+          "properties": {
+            "reactionType": {
+              "type": "string",
+              "description": "The emoji reaction to remove as unicode (e.g., '\ud83d\udc4d', '\u2764\ufe0f', '\ud83d\ude00')"
+            }
+          },
+          "description": "The reaction to remove",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["chat_id", "message_id"],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "description": "The unique identifier of the chat"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to remove reaction from"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__SOFT_DELETE_CHAT_MESSAGE",
+    "description": "Soft delete a message in a chat using the correct Microsoft Graph API endpoint. This allows safely removing chat messages with the ability to restore them later.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SOFT_DELETE_CHAT_MESSAGE",
+      "canonical_tool_description_hash": "1c40ccbcaafe879e23cd8dfbe96468e490c0ad4851f026586b2ea2ba2dbeb6e0",
+      "canonical_tool_input_schema_hash": "9e54e6534e895a774d26818f3f3ccc6f2f926555236e8e834c962c11564e913f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["chat_id", "message_id"],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "description": "The unique identifier of the chat"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to soft delete"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__SOFT_DELETE_REPLY_MESSAGE",
+    "description": "Soft delete a reply message in a channel thread. This allows safely removing reply messages with the ability to restore them later.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SOFT_DELETE_REPLY_MESSAGE",
+      "canonical_tool_description_hash": "f3303b4d52d8b5d178945e51beb27d0e81ba7c01ab4323385e0d60f01c299639",
+      "canonical_tool_input_schema_hash": "c34ae05f3224593a49dd5b2c5bc8d6e20a6bea6f0dab56869ee6528dd02a479a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id", "message_id", "reply_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "reply_id": {
+              "type": "string",
+              "description": "The unique identifier of the reply to soft delete"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the parent message"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__UNDO_SOFT_DELETE_CHAT_MESSAGE",
+    "description": "Undo soft deletion of a message in a chat using the correct Microsoft Graph API endpoint. This restores a previously soft-deleted chat message.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UNDO_SOFT_DELETE_CHAT_MESSAGE",
+      "canonical_tool_description_hash": "f89c510e5b09996af992dc659aa985ff14fc3110d4f38fe695c321941003d220",
+      "canonical_tool_input_schema_hash": "fe7e11c90ba0224a8df064c4c8719e601b7acaf15ff24d5e5d0e93232cc2bc9e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["chat_id", "message_id"],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "description": "The unique identifier of the chat"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the message to restore"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "MICROSOFT_TEAMS__UNDO_SOFT_DELETE_REPLY_MESSAGE",
+    "description": "Undo soft deletion of a reply message in a channel thread. This restores a previously soft-deleted reply message.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UNDO_SOFT_DELETE_REPLY_MESSAGE",
+      "canonical_tool_description_hash": "bd34cd45d92adea7d35064b858e1f766d70a0cf5027bd39cc01cf2dec3607ff7",
+      "canonical_tool_input_schema_hash": "ce194bfaf8282fac530c4e831675f8ed4c5395d75fea835dbb2598e41ea7c851"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["team_id", "channel_id", "message_id", "reply_id"],
+          "properties": {
+            "team_id": {
+              "type": "string",
+              "description": "The unique identifier of the team"
+            },
+            "reply_id": {
+              "type": "string",
+              "description": "The unique identifier of the reply to restore"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "The unique identifier of the channel"
+            },
+            "message_id": {
+              "type": "string",
+              "description": "The unique identifier of the parent message"
+            }
+          },
+          "description": "The path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/netlify/tools.json
+++ b/backend/mcp_servers/netlify/tools.json
@@ -1,0 +1,627 @@
+[
+  {
+    "name": "NETLIFY__DELETE_SITE",
+    "description": "Permanently delete a site.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_SITE",
+      "canonical_tool_description_hash": "c997432d33c36b77bd70f3816aef754a5984be4cf5a180b2a48dd2e2e4622ed8",
+      "canonical_tool_input_schema_hash": "c08121d39200a957cd5cba3e9e2f2cec7e7b5bdd851575cce100e139a8dcb51f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["site_id"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The unique identifier of the site to delete."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__GET_ACCOUNTS",
+    "description": "List all accounts/teams that the authenticated user has access to. In Netlify's API, accounts are equivalent to teams.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ACCOUNTS",
+      "canonical_tool_description_hash": "867676391cb5dbc5a3055a12e1febe2814ad445f73a5d4f70aa20ef4e902d13c",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__GET_ACCOUNT_BY_ID",
+    "description": "Get information about a specific account/team by its ID or slug.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ACCOUNT_BY_ID",
+      "canonical_tool_description_hash": "d6449e0593b3f8da9a80aacedb53dfa1b3ffa394777f39c9daef749bdb35f761",
+      "canonical_tool_input_schema_hash": "06823982df5334f2098ae4a249c51378544cbe297023a2cc56ede6e97b3646aa"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["account_id"],
+          "properties": {
+            "account_id": {
+              "type": "string",
+              "description": "The unique identifier or slug of the account/team."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__CREATE_SITE",
+    "description": "Create a new site/project on Netlify with full support for both public and private repositories. For private repositories, use NETLIFY__CREATE_DEPLOY_KEY first to generate a deploy key, then GITHUB__CREATE_DEPLOY_KEY to add it to your repository, then use this function with the deploy_key_id parameter. IMPORTANT: Verify the correct branch name (main vs master) in your repository before deployment to avoid branch not found errors.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_SITE",
+      "canonical_tool_description_hash": "f50a3796ca23ad120f820d09a41d6f012bc5519c3e87cb55f3960f79969ad84c",
+      "canonical_tool_input_schema_hash": "70408daefd918100224d5ec5256f8ca3f9b5d69025f2298e17082e980fc062c5"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the site/project."
+            },
+            "repo": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "description": "The repository ID from GitHub/GitLab. For GitHub, get this from GITHUB__GET_REPOSITORY. Required for private repositories."
+                },
+                "cmd": {
+                  "type": "string",
+                  "description": "Build command."
+                },
+                "dir": {
+                  "type": "string",
+                  "description": "Directory to deploy from within the repository."
+                },
+                "repo": {
+                  "type": "string",
+                  "description": "Repository in format 'owner/repo'."
+                },
+                "branch": {
+                  "type": "string",
+                  "default": "main",
+                  "description": "Branch to deploy from. Most repositories use 'main' as the default branch, but some older repositories may use 'master'. Verify the correct branch name in your repository to avoid deployment failures."
+                },
+                "private": {
+                  "type": "boolean",
+                  "description": "Set to true for private repositories. This enables private repository deployment workflow."
+                },
+                "provider": {
+                  "enum": ["github", "gitlab", "bitbucket"],
+                  "type": "string",
+                  "description": "Git provider."
+                },
+                "deploy_key_id": {
+                  "type": "string",
+                  "description": "Deploy key ID for private repository access. Get this from NETLIFY__CREATE_DEPLOY_KEY, then add the public key to GitHub using GITHUB__CREATE_DEPLOY_KEY. Required for private repositories."
+                }
+              },
+              "description": "Repository configuration for continuous deployment",
+              "additionalProperties": false
+            },
+            "custom_domain": {
+              "type": "string",
+              "description": "Custom domain for the site."
+            }
+          },
+          "description": "Site configuration",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__GET_SITES",
+    "description": "Get all sites that the authenticated user has access to.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SITES",
+      "canonical_tool_description_hash": "29b79378db7ead09670f9a0ab8545f077f7a7df8d7b812eadf70faae22413155",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__GET_SITE",
+    "description": "Get information about a specific site by its ID or domain.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SITE",
+      "canonical_tool_description_hash": "09912b9522ded6d65226ef8df90486c48eda3fdde613941f4c9e55b0e7082157",
+      "canonical_tool_input_schema_hash": "ece8a9181873bbfd8a4ae9aa167a9a004cdb801dee649626beea752703990063"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["site_id"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The unique identifier or domain of the site."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__UPDATE_SITE",
+    "description": "Update an existing site's configuration.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_SITE",
+      "canonical_tool_description_hash": "f7dcd54f6c32ecd98be478ea427f37f9bb08981773017bc2d3fab636a3123dc9",
+      "canonical_tool_input_schema_hash": "b196c28be5590117e5532a046ee7012875b8ca1150a68ad9dc889f06209fac09"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The new name for the site."
+            },
+            "password": {
+              "type": "string",
+              "description": "Password for site access protection."
+            },
+            "custom_domain": {
+              "type": "string",
+              "description": "Custom domain for the site."
+            },
+            "processing_settings": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "html": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {
+                    "pretty_urls": {
+                      "type": "boolean",
+                      "description": "Enable pretty URLs."
+                    }
+                  },
+                  "description": "HTML processing settings",
+                  "additionalProperties": false
+                }
+              },
+              "description": "Site processing settings",
+              "additionalProperties": false
+            }
+          },
+          "description": "Site update configuration",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["site_id"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The unique identifier of the site."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__GET_ENV_VARIABLES",
+    "description": "Get environment variables for an account/team.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ENV_VARIABLES",
+      "canonical_tool_description_hash": "01248d1e5993165b05e73f66fd5cc523627cca628219a001eef5c6f4c997123e",
+      "canonical_tool_input_schema_hash": "dea864eddb110d0c810bce506b093409538a2cc83b7d2c9d5da4bcf0965ba224"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["account_id"],
+          "properties": {
+            "account_id": {
+              "type": "string",
+              "description": "The unique identifier of the account."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "Filter environment variables by site ID."
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__GET_DEPLOY",
+    "description": "Get information about a specific deployment.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DEPLOY",
+      "canonical_tool_description_hash": "5fb9ed23a96bdab67c99a113f3e85c7d0f2b69d12bc3165ca785f5262a6d208a",
+      "canonical_tool_input_schema_hash": "4c6c785e4dd1cd0ec1f3fea3afd12519dba448402249e8b20c9bc78a98108dad"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["deploy_id"],
+          "properties": {
+            "deploy_id": {
+              "type": "string",
+              "description": "The unique identifier of the deployment."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__LIST_DEPLOYS",
+    "description": "List all deployments for a specific site.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_DEPLOYS",
+      "canonical_tool_description_hash": "061225bb003bbf717ae768f2ce34d45d7eead36ca2e63a717ecc7ebe8bb213d1",
+      "canonical_tool_input_schema_hash": "b2bf6b5f7ecfd8d422ef47c4c8316500856a3d1340b07ce3c87a14aa6f07279b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["site_id"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The unique identifier of the site."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "page": {
+              "type": "integer",
+              "default": 1,
+              "description": "Page number for pagination."
+            },
+            "per_page": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 100,
+              "description": "Number of deployments per page."
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__GET_SITE_DEPLOY",
+    "description": "Get information about a specific deployment for a specific site.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SITE_DEPLOY",
+      "canonical_tool_description_hash": "a2997996dc34d90945eb2f75d1da29ab9bcac20715b59040744315dd543049e3",
+      "canonical_tool_input_schema_hash": "b6a4c75569976536c028d35603192a7e77232e59ebef62e21bdc44365aa37c72"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["site_id", "deploy_id"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The unique identifier of the site."
+            },
+            "deploy_id": {
+              "type": "string",
+              "description": "The unique identifier of the deployment."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__CREATE_DEPLOY_KEY",
+    "description": "Step 1 of private repository deployment: Create a new deploy key pair. This generates SSH keys that allow Netlify to access private repositories. After creating this, use NETLIFY__GET_DEPLOY_KEY or NETLIFY__LIST_DEPLOY_KEYS to get the public key, then add it to your GitHub repository using GITHUB__CREATE_DEPLOY_KEY.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_DEPLOY_KEY",
+      "canonical_tool_description_hash": "dda40107ff94ae427cfdf497a04a5df4f27303bf7a0012e3d116df8be1c2c720",
+      "canonical_tool_input_schema_hash": "c5d7d3f8942ee3b390f8ae7c8b8d4820ae87938344b4a27b3cb5d8b80ee296ab"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "A descriptive title for the deploy key."
+            }
+          },
+          "description": "Deploy key configuration",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__GET_DEPLOY_KEY",
+    "description": "Get information about a specific deploy key.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DEPLOY_KEY",
+      "canonical_tool_description_hash": "9768d4f41e86c622f788db66d417cff2216be59b71ada83e0bb20ec5879d6c58",
+      "canonical_tool_input_schema_hash": "bdbbb82424bcff66649f33c46c275303e990af8253f8ac0e69a77a3f1f6d99cf"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["key_id"],
+          "properties": {
+            "key_id": {
+              "type": "string",
+              "description": "The unique identifier of the deploy key."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__LIST_DEPLOY_KEYS",
+    "description": "List all deploy keys for the account.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_DEPLOY_KEYS",
+      "canonical_tool_description_hash": "1a9640b754abb0c703dae3fbfd758510b6ddfaefc899d6f3c6da4759fdcb64e7",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__DELETE_DEPLOY_KEY",
+    "description": "Delete a deploy key.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_DEPLOY_KEY",
+      "canonical_tool_description_hash": "b3e2e99956b2ce5a3469543045e3acf55e893152737309514b6121695e31312d",
+      "canonical_tool_input_schema_hash": "bdbbb82424bcff66649f33c46c275303e990af8253f8ac0e69a77a3f1f6d99cf"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["key_id"],
+          "properties": {
+            "key_id": {
+              "type": "string",
+              "description": "The unique identifier of the deploy key."
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__CREATE_BUILD_HOOK",
+    "description": "Create a new build hook for a site. Build hooks provide unique URLs to trigger new builds and deploys from external services or scripts. Once created, use NETLIFY__TRIGGER_BUILD_HOOK to actually trigger builds.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_BUILD_HOOK",
+      "canonical_tool_description_hash": "9fe0cecf01005654ff25d3d8339612758896c80e0602d0d7ec4b0aa445d7cd4a",
+      "canonical_tool_input_schema_hash": "ea030d6f82791d16831ab8b981a525a45d90f6d40a2cabc407f65726c6112b38"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["title"],
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "A descriptive name for the build hook. This will appear in deploy messages."
+            },
+            "branch": {
+              "type": "string",
+              "default": "main",
+              "description": "The branch to build when the hook is triggered. Defaults to the site's default branch."
+            }
+          },
+          "description": "Build hook configuration",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["site_id"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The unique identifier of the site to create a build hook for."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NETLIFY__TRIGGER_BUILD_HOOK",
+    "description": "Trigger a new build and deployment by calling a build hook URL. Build hooks pull the latest code from the connected Git repository and rebuild the site. This is the recommended method for triggering Git-based deployments.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TRIGGER_BUILD_HOOK",
+      "canonical_tool_description_hash": "65939e6f9c7e76808a95cdf794c564c927e347faf64774976622d9413b072445",
+      "canonical_tool_input_schema_hash": "c41966a856911c0f51e8b37791425a8694874b0b1602ea86f5bbae1e7cb497d2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Custom message or payload to include with the build trigger."
+            }
+          },
+          "description": "Optional payload that will be available as INCOMING_HOOK_BODY environment variable",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["hook_id"],
+          "properties": {
+            "hook_id": {
+              "type": "string",
+              "description": "The build hook ID from the build hook URL. Find this in Project configuration > Build & deploy > Build hooks."
+            }
+          },
+          "description": "Build hook parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "clear_cache": {
+              "type": "boolean",
+              "default": false,
+              "description": "When set to true, triggers a build with a cleared cache."
+            },
+            "trigger_title": {
+              "type": "string",
+              "description": "Custom title to replace the default deploy message in your site deploy list."
+            },
+            "trigger_branch": {
+              "type": "string",
+              "description": "Specify which repository branch the build will use. If not specified, uses the default branch."
+            }
+          },
+          "description": "Optional parameters to customize the build",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/notte/tools.json
+++ b/backend/mcp_servers/notte/tools.json
@@ -1,0 +1,137 @@
+[
+  {
+    "name": "NOTTE__START_SESSION",
+    "description": "Starts a new browser session and returns a session ID. An existing session cannot provide a session ID during creation.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "START_SESSION",
+      "canonical_tool_description_hash": "b63b630be5af81aefc9fc6438a3f391802424c8b5c914a355659e85ffa584426",
+      "canonical_tool_input_schema_hash": "e3204a0d5848491c44aad2d1a50778659ad01097773f15d0a9a5f25ba6aa1863"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "keep_alive": {
+              "type": "boolean",
+              "default": false,
+              "description": "Optional parameter to keep the session alive beyond its timeout period."
+            },
+            "screenshot": {
+              "type": "boolean",
+              "default": false,
+              "description": "Optional parameter to request a screenshot during the session."
+            },
+            "session_id": {
+              "type": "string",
+              "default": null,
+              "description": "Optional parameter to specify a session ID. Session ID should not be provided when starting a new session."
+            },
+            "session_timeout": {
+              "type": "integer",
+              "default": 10,
+              "description": "Optional parameter to set a custom timeout for the session. Specify the timeout in minutes."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NOTTE__OBSERVE_PAGE",
+    "description": "This endpoint observes the actions available on a given URL within the session's environment.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "OBSERVE_PAGE",
+      "canonical_tool_description_hash": "9b2f58430b08b01801cc954440290ca00edc01df6849d55738bbc5544dc58028",
+      "canonical_tool_input_schema_hash": "83cde3b60108a128295a321622ee9179888fc5dc1931dcbaa988979f741158b3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "Required parameter to specify the URL to observe. The URL to analyze and fetch available actions."
+            },
+            "keep_alive": {
+              "type": "boolean",
+              "default": false,
+              "description": "Optional parameter to keep the session alive beyond its timeout period."
+            },
+            "session_id": {
+              "type": "string",
+              "description": "Optional parameter to specify the session ID. The session ID of the session within which the environment will be observed."
+            },
+            "session_timeout": {
+              "type": "integer",
+              "default": 10,
+              "description": "Optional parameter to set a custom timeout for the session. Specify the timeout in minutes."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "NOTTE__SCRAPE_DATA",
+    "description": "This endpoint scrapes data from a specified URL within the session's environment.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SCRAPE_DATA",
+      "canonical_tool_description_hash": "82656ff221e1f98d74644c27937d3ae550c68890cc06ee358b948359bdf6cebd",
+      "canonical_tool_input_schema_hash": "4b984b593faec223e00c65859e01cd5189bc2dceb3ab138d8945be42c3ebca82"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "url": {
+              "type": "string",
+              "default": null,
+              "description": "URL to scrape data from."
+            },
+            "keep_alive": {
+              "type": "boolean",
+              "default": false,
+              "description": "Optional parameter to keep the session alive beyond its timeout period."
+            },
+            "screenshot": {
+              "type": "boolean",
+              "default": null,
+              "description": "Optional parameter to request a screenshot of the scraped page."
+            },
+            "session_id": {
+              "type": "string",
+              "default": null,
+              "description": "Optional parameter to specify the session ID."
+            },
+            "session_timeout": {
+              "type": "integer",
+              "default": 10,
+              "description": "Optional parameter to set a custom timeout for the session. Specify the timeout in minutes."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/one_signal/tools.json
+++ b/backend/mcp_servers/one_signal/tools.json
@@ -1,0 +1,450 @@
+[
+  {
+    "name": "ONE_SIGNAL__ADD_DEVICE",
+    "description": "Registers a new device with OneSignal. If a device with the specified identifier already exists, it updates the existing device record instead of creating a new one. Note: Using this endpoint directly without the OneSignal SDK may limit certain features such as conversion tracking, timezone detection, language detection, and rich push notifications.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ADD_DEVICE",
+      "canonical_tool_description_hash": "9273868238d5c4220bee21d2df2248bc9404077990eeb0ef9250371b150e9075",
+      "canonical_tool_input_schema_hash": "2c632e5bde617f792d2009ee6097539a258003a32df72cd8e8adcb71956391a4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["app_id", "device_type"],
+          "properties": {
+            "sdk": {
+              "type": "string",
+              "description": "OneSignal SDK version used in your app."
+            },
+            "tags": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "level": {
+                  "type": "string",
+                  "description": "The level of the user."
+                },
+                "last_name": {
+                  "type": "string",
+                  "description": "The last name of the user."
+                },
+                "first_name": {
+                  "type": "string",
+                  "description": "The first name of the user."
+                },
+                "account_type": {
+                  "type": "string",
+                  "description": "The type of account the user has."
+                },
+                "amount_spent": {
+                  "type": "number",
+                  "description": "The amount of money spent by the user."
+                }
+              },
+              "description": "Custom tags for the device.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "ad_id": {
+              "type": "string",
+              "description": "Ad ID for the device."
+            },
+            "app_id": {
+              "type": "string",
+              "description": "Your OneSignal App ID."
+            },
+            "language": {
+              "type": "string",
+              "description": "Language code (ISO 639-1) of the device's locale."
+            },
+            "timezone": {
+              "type": "integer",
+              "description": "Number of seconds away from UTC. Example: -28800 for PST."
+            },
+            "device_os": {
+              "type": "string",
+              "description": "Device operating system version."
+            },
+            "identifier": {
+              "type": "string",
+              "description": "Push token identifier for the device."
+            },
+            "device_type": {
+              "type": "integer",
+              "description": "The device's platform. 0 = iOS, 1 = Android, 2 = Amazon, 3 = WindowsPhone (MPNS), 4 = Chrome Apps / Extensions, 5 = Chrome Web Push, 6 = Windows (WNS), 7 = Safari, 8 = Firefox, 9 = MacOS, 10 = Alexa, 11 = Email, 12 = Huawei, 13 = SMS, 14 = Chrome Web Push (Deprecated)."
+            },
+            "device_model": {
+              "type": "string",
+              "description": "Device model."
+            },
+            "game_version": {
+              "type": "string",
+              "description": "Version of your app."
+            },
+            "session_count": {
+              "type": "integer",
+              "description": "Number of times the user has opened the app."
+            },
+            "external_user_id": {
+              "type": "string",
+              "description": "An external user ID to associate with the device."
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ONE_SIGNAL__CREATE_PUSH_NOTIFICATION",
+    "description": "Sends a push notification to users via the OneSignal API. Supports targeting by segments, filters, or specific device identifiers. Allows customization of message content, scheduling, and platform-specific options.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_PUSH_NOTIFICATION",
+      "canonical_tool_description_hash": "9dbd332191a9eaf90b1b6caadf020d7fddf5be2399d8a2d02a20177e23601d88",
+      "canonical_tool_input_schema_hash": "b0a000ce5b83848ea19b1dcad9f03178cfb49f0dc71b9487a4324e242fccbd04"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["app_id", "contents", "included_segments"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL to open when the notification is clicked."
+            },
+            "data": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "exampleKey1": {
+                  "type": "string"
+                },
+                "exampleKey2": {
+                  "type": "integer"
+                }
+              },
+              "description": "Custom key-value pairs to include with the notification.",
+              "additionalProperties": true
+            },
+            "app_id": {
+              "type": "string",
+              "description": "Your OneSignal App ID."
+            },
+            "filters": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "description": "Advanced targeting filters."
+            },
+            "contents": {
+              "type": "object",
+              "required": ["en"],
+              "properties": {
+                "en": {
+                  "type": "string",
+                  "description": "English message content."
+                }
+              },
+              "description": "Notification content per language. At least 'en' (English) is required.",
+              "additionalProperties": true
+            },
+            "headings": {
+              "type": "object",
+              "required": ["en"],
+              "properties": {
+                "en": {
+                  "type": "string",
+                  "description": "English title."
+                }
+              },
+              "description": "Notification title per language.",
+              "additionalProperties": true
+            },
+            "send_after": {
+              "type": "string",
+              "description": "Schedule the notification for future delivery. Format: 'YYYY-MM-DD HH:MM:SS GMT-0700'."
+            },
+            "excluded_segments": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Segments to exclude from receiving the notification."
+            },
+            "included_segments": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Segments to send the notification to."
+            },
+            "include_player_ids": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Specific device identifiers to send the notification to."
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ONE_SIGNAL__EDIT_DEVICE",
+    "description": "Updates an existing device (player) in a OneSignal app. This endpoint allows modification of device attributes such as language, timezone, app version, device model, operating system, and custom tags. Note: This is a legacy endpoint; it's recommended to use 'Update User' or 'Update Subscription' instead.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EDIT_DEVICE",
+      "canonical_tool_description_hash": "2c0f15c486400cc056c6eff75885f3ec30641bb40ac7eef131037508f607a3e8",
+      "canonical_tool_input_schema_hash": "3c2f404ebf8170c946c887ab9bcb934176385a2ee9872ccef6bd5d153f96eb6f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["app_id"],
+          "properties": {
+            "tags": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "level": {
+                  "type": "string",
+                  "description": "The level of the user."
+                },
+                "last_name": {
+                  "type": "string",
+                  "description": "The last name of the user."
+                },
+                "first_name": {
+                  "type": "string",
+                  "description": "The first name of the user."
+                }
+              },
+              "description": "Custom tags for the device.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "app_id": {
+              "type": "string",
+              "description": "Your OneSignal App ID."
+            },
+            "language": {
+              "type": "string",
+              "description": "Language code (ISO 639-1) of the device's locale."
+            },
+            "timezone": {
+              "type": "integer",
+              "description": "Number of seconds away from UTC. Example: -28800 for PST."
+            },
+            "device_os": {
+              "type": "string",
+              "description": "Device operating system version."
+            },
+            "device_type": {
+              "type": "integer",
+              "description": "The device's platform. 0 = iOS, 1 = Android, etc."
+            },
+            "device_model": {
+              "type": "string",
+              "description": "Device model."
+            },
+            "game_version": {
+              "type": "string",
+              "description": "Version of your app."
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["player_id"],
+          "properties": {
+            "player_id": {
+              "type": "string",
+              "description": "The unique identifier of the device (player) to update."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ONE_SIGNAL__VIEW_MESSAGES",
+    "description": "Retrieves a list of up to 50 messages (push, email, or SMS) sent via OneSignal. Supports filtering by message type, template ID, and time offset. Pagination is handled via limit and offset parameters. Note: Messages sent through the API and Automated Messages are only accessible for 30 days after creation; messages sent using the OneSignal dashboard are accessible for the app's lifetime.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "VIEW_MESSAGES",
+      "canonical_tool_description_hash": "06950edb9c7ceeacb0158aa2367607f560a2a148734c996e8e3873718e26f967",
+      "canonical_tool_input_schema_hash": "a47f37f9aaaea5095a129afa8153e8296b5eda07e10fd35b68e56e06f1ba76c1"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["app_id"],
+          "properties": {
+            "kind": {
+              "type": "integer",
+              "description": "Filter by message type: 0 = Push, 1 = Email, 2 = SMS."
+            },
+            "limit": {
+              "type": "integer",
+              "default": 50,
+              "description": "Number of messages to return (max 50)."
+            },
+            "app_id": {
+              "type": "string",
+              "description": "Your OneSignal App ID."
+            },
+            "offset": {
+              "type": "integer",
+              "description": "Pagination offset."
+            },
+            "template_id": {
+              "type": "string",
+              "description": "Filter by template ID."
+            },
+            "time_offset": {
+              "type": "integer",
+              "description": "Time offset for optimized pagination (in seconds)."
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ONE_SIGNAL__CREATE_SUBSCRIPTION_BY_ALIAS",
+    "description": "Adds a new subscription to an existing user identified by alias. Subscriptions represent a user's intent to receive messages through a given channel (e.g., push, email, SMS). Requires the user to be pre-created. If the subscription (type + token) already exists, it will be transferred to the specified user.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_SUBSCRIPTION_BY_ALIAS",
+      "canonical_tool_description_hash": "6382eeb42fcd4ac6d55493354a2818ab38fdbd2c114359c8d8d91ebadbe1e8c4",
+      "canonical_tool_input_schema_hash": "c165dee85e6d563de0ced915a9f26338d4b23789604483712d409b20053849dd"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["subscription"],
+          "properties": {
+            "subscription": {
+              "type": "object",
+              "required": ["type", "token"],
+              "properties": {
+                "sdk": {
+                  "type": "string",
+                  "description": "SDK version used."
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Type of the subscription device. Must be one of: 'Email', 'SMS', 'iOSPush', 'AndroidPush', 'HuaweiPush'."
+                },
+                "token": {
+                  "type": "string",
+                  "description": "The push token, email address, or phone number associated with the subscription."
+                },
+                "rooted": {
+                  "type": "boolean",
+                  "description": "Indicates if the device is rooted or jailbroken."
+                },
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Indicates if the subscription is enabled."
+                },
+                "web_auth": {
+                  "type": "string",
+                  "description": "Web authentication key (for web push)."
+                },
+                "web_p256": {
+                  "type": "string",
+                  "description": "Web P256 key (for web push)."
+                },
+                "device_os": {
+                  "type": "string",
+                  "description": "Device operating system version."
+                },
+                "test_type": {
+                  "type": "integer",
+                  "description": "Indicates if the subscription is a test type."
+                },
+                "app_version": {
+                  "type": "string",
+                  "description": "Version of your app."
+                },
+                "device_model": {
+                  "type": "string",
+                  "description": "Device model."
+                },
+                "session_time": {
+                  "type": "integer",
+                  "description": "Total duration of sessions in seconds."
+                },
+                "session_count": {
+                  "type": "integer",
+                  "description": "Number of sessions."
+                },
+                "notification_types": {
+                  "type": "integer",
+                  "description": "Bitmask of notification types the subscription is opted into."
+                }
+              },
+              "description": "Subscription data",
+              "additionalProperties": false
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["app_id", "alias_id"],
+          "properties": {
+            "app_id": {
+              "type": "string",
+              "description": "Your OneSignal App ID."
+            },
+            "alias_id": {
+              "type": "string",
+              "description": "Value of the alias used to identify the user."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/open_weather_map/tools.json
+++ b/backend/mcp_servers/open_weather_map/tools.json
@@ -1,0 +1,285 @@
+[
+  {
+    "name": "OPEN_WEATHER_MAP__CURRENT_WEATHER",
+    "description": "Get current weather data for a specific location by latitude and longitude.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CURRENT_WEATHER",
+      "canonical_tool_description_hash": "a5fa846c38dd3ede8c49a8553a056721b22b315ff2542c01d2e2adc7df8e1cf9",
+      "canonical_tool_input_schema_hash": "74704961ba506bc6ec8a806c036481fcdc69e5e2aafd944ff43ba50e728c5cf8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["lat", "lon"],
+          "properties": {
+            "lat": {
+              "type": "number",
+              "description": "Latitude, decimal (-90; 90)"
+            },
+            "lon": {
+              "type": "number",
+              "description": "Longitude, decimal (-180; 180)"
+            },
+            "lang": {
+              "enum": [
+                "af",
+                "al",
+                "ar",
+                "az",
+                "bg",
+                "ca",
+                "cz",
+                "da",
+                "de",
+                "el",
+                "en",
+                "eu",
+                "fa",
+                "fi",
+                "fr",
+                "gl",
+                "he",
+                "hi",
+                "hr",
+                "hu",
+                "id",
+                "it",
+                "ja",
+                "kr",
+                "la",
+                "lt",
+                "mk",
+                "no",
+                "nl",
+                "pl",
+                "pt",
+                "pt_br",
+                "ro",
+                "ru",
+                "sv",
+                "sk",
+                "sl",
+                "sp",
+                "sr",
+                "th",
+                "tr",
+                "ua",
+                "vi",
+                "zh_cn",
+                "zh_tw",
+                "zu"
+              ],
+              "type": "string",
+              "description": "Language to get the output in. Default is English (en)."
+            },
+            "units": {
+              "enum": ["standard", "metric", "imperial"],
+              "type": "string",
+              "description": "Units of measurement. standard, metric and imperial units are available. If not specified, standard units will be applied by default."
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "OPEN_WEATHER_MAP__FORECAST",
+    "description": "Get 5-day/3-hour forecast data for a specific location by latitude and longitude.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "FORECAST",
+      "canonical_tool_description_hash": "6a93bddc9bb2856692baf68d8747ac29dd5ee9ed7dbc5ce61ffd1584835329a9",
+      "canonical_tool_input_schema_hash": "68f249f01fa569b2b303dacbd2b9bdf1651c1c4ef4b208fe328a65bc56ee72c0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["lat", "lon"],
+          "properties": {
+            "cnt": {
+              "type": "integer",
+              "maximum": 40,
+              "minimum": 1,
+              "description": "A number of timestamps, which will be returned in the API response. If not specified, all 40 timestamps will be returned."
+            },
+            "lat": {
+              "type": "number",
+              "description": "Latitude, decimal (-90; 90)"
+            },
+            "lon": {
+              "type": "number",
+              "description": "Longitude, decimal (-180; 180)"
+            },
+            "lang": {
+              "enum": [
+                "af",
+                "al",
+                "ar",
+                "az",
+                "bg",
+                "ca",
+                "cz",
+                "da",
+                "de",
+                "el",
+                "en",
+                "eu",
+                "fa",
+                "fi",
+                "fr",
+                "gl",
+                "he",
+                "hi",
+                "hr",
+                "hu",
+                "id",
+                "it",
+                "ja",
+                "kr",
+                "la",
+                "lt",
+                "mk",
+                "no",
+                "nl",
+                "pl",
+                "pt",
+                "pt_br",
+                "ro",
+                "ru",
+                "sv",
+                "sk",
+                "sl",
+                "sp",
+                "sr",
+                "th",
+                "tr",
+                "ua",
+                "vi",
+                "zh_cn",
+                "zh_tw",
+                "zu"
+              ],
+              "type": "string",
+              "description": "Language to get the output in. Default is English (en)."
+            },
+            "units": {
+              "enum": ["standard", "metric", "imperial"],
+              "type": "string",
+              "description": "Units of measurement. standard, metric and imperial units are available. If not specified, standard units will be applied by default."
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "OPEN_WEATHER_MAP__CURRENT_AND_FORECAST",
+    "description": "Get current weather data for a location. The function extracts location information from your prompt and returns detailed weather data including temperature, humidity, wind, and more.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CURRENT_AND_FORECAST",
+      "canonical_tool_description_hash": "e5cf7f5c00e0a86f74a18c7b6bbd44f3b8a1c00257a395860d907338e67bfe89",
+      "canonical_tool_input_schema_hash": "15ab278e19d57547e6c1dd2b30d579be9e2af90824b30f6372479e9a6ff3c358"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["lat", "lon"],
+          "properties": {
+            "lat": {
+              "type": "number",
+              "description": "Latitude, decimal (-90; 90)"
+            },
+            "lon": {
+              "type": "number",
+              "description": "Longitude, decimal (-180; 180)"
+            },
+            "lang": {
+              "enum": [
+                "af",
+                "al",
+                "ar",
+                "az",
+                "bg",
+                "ca",
+                "cz",
+                "da",
+                "de",
+                "el",
+                "en",
+                "eu",
+                "fa",
+                "fi",
+                "fr",
+                "gl",
+                "he",
+                "hi",
+                "hr",
+                "hu",
+                "id",
+                "it",
+                "ja",
+                "kr",
+                "la",
+                "lt",
+                "mk",
+                "no",
+                "nl",
+                "pl",
+                "pt",
+                "pt_br",
+                "ro",
+                "ru",
+                "sv",
+                "sk",
+                "sl",
+                "sp",
+                "sr",
+                "th",
+                "tr",
+                "ua",
+                "vi",
+                "zh_cn",
+                "zh_tw",
+                "zu"
+              ],
+              "type": "string",
+              "default": "en",
+              "description": "Language to get the output in. Default is English (en)."
+            },
+            "units": {
+              "enum": ["standard", "metric", "imperial"],
+              "type": "string",
+              "default": "metric",
+              "description": "Units of measurement. standard, metric and imperial units are available. If not specified, standard units will be applied by default."
+            },
+            "exclude": {
+              "type": "string",
+              "default": "minutely,hourly,alerts",
+              "description": "Parts of weather data to exclude. Multiple values can be separated by commas."
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/reddit/tools.json
+++ b/backend/mcp_servers/reddit/tools.json
@@ -1,0 +1,205 @@
+[
+  {
+    "name": "REDDIT__GET_SUBREDDIT_POSTS",
+    "description": "Retrieves posts from a specified subreddit",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SUBREDDIT_POSTS",
+      "canonical_tool_description_hash": "04f5f1b32bc9d250b7c83bd8aeb31abb32f542eb7d3880d0e899aaeb7945674f",
+      "canonical_tool_input_schema_hash": "529a4015d51f6bac89c4b12d149c76de855bf1cb2dd8c3e5d9ad0d9374a42814"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["subreddit", "sort"],
+          "properties": {
+            "sort": {
+              "enum": ["hot", "new", "top", "rising"],
+              "type": "string",
+              "description": "Sort method for posts"
+            },
+            "subreddit": {
+              "type": "string",
+              "description": "The name of the subreddit"
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "after": {
+              "type": "string",
+              "description": "The fullname of a thing to use as the anchor point for pagination"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 25,
+              "description": "The maximum number of posts to return"
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "REDDIT__GET_POST_COMMENTS",
+    "description": "Retrieves comments for a specific post",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_POST_COMMENTS",
+      "canonical_tool_description_hash": "db67b1d466bc4f0e34fafaea062b25b3508925d8c2c12997bbd2e2e5639201ce",
+      "canonical_tool_input_schema_hash": "6b3c58cb36000b1abb1ad1176dec8da85be83e9efa8efb502e50453735406993"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["article"],
+          "properties": {
+            "article": {
+              "type": "string",
+              "description": "The ID of the post to get comments for"
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "sort": {
+              "enum": ["confidence", "top", "new", "controversial", "old", "random", "qa"],
+              "type": "string",
+              "default": "confidence",
+              "description": "Sort method for comments"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 25,
+              "description": "The maximum number of comments to return"
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "REDDIT__GET_USER_INFO",
+    "description": "Retrieves information about a Reddit user",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_USER_INFO",
+      "canonical_tool_description_hash": "66d140f068b275a83e72016817fc170da8b41fe0d30927ab0c0c84fcfd6318b6",
+      "canonical_tool_input_schema_hash": "837f294f3230d325414f1cc602cde43d8b3c19a9fe6afeec997930f8085ebadb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["username"],
+          "properties": {
+            "username": {
+              "type": "string",
+              "description": "The username of the Reddit user"
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "REDDIT__SEARCH",
+    "description": "Searches Reddit for posts and comments",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH",
+      "canonical_tool_description_hash": "8bfa0e9372b849c359d3345026830eafa1576872cab239bacbf824ec0d4b85ef",
+      "canonical_tool_input_schema_hash": "973e345a3804630ac61f5be32a471b4de9aedf7b52ea96071ad848870fe6f743"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "The search query"
+            },
+            "t": {
+              "enum": ["hour", "day", "week", "month", "year", "all"],
+              "type": "string",
+              "default": "all",
+              "description": "Time period for results"
+            },
+            "sort": {
+              "enum": ["relevance", "hot", "top", "new", "comments"],
+              "type": "string",
+              "default": "relevance",
+              "description": "Sort method for results"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 25,
+              "description": "The maximum number of results to return"
+            }
+          },
+          "description": "Query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "REDDIT__GET_SUBREDDIT_INFO",
+    "description": "Retrieves information about a subreddit",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SUBREDDIT_INFO",
+      "canonical_tool_description_hash": "a2a30cb5d69cbd6a730119c56ec3dfc4c83a5cfc9bf96c431211f5b279ab4923",
+      "canonical_tool_input_schema_hash": "15012c3656d2ce9c3b67968460e4ff905bee5289dc509a5ac6c52ef3abc52574"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["subreddit"],
+          "properties": {
+            "subreddit": {
+              "type": "string",
+              "description": "The name of the subreddit"
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/render/tools.json
+++ b/backend/mcp_servers/render/tools.json
@@ -31,32 +31,17 @@
         "plan": {
           "default": "free",
           "description": "Pricing plan for the Key Value instance",
-          "enum": [
-            "free",
-            "starter",
-            "standard",
-            "pro",
-            "pro_plus"
-          ],
+          "enum": ["free", "starter", "standard", "pro", "pro_plus"],
           "type": "string"
         },
         "region": {
           "default": "oregon",
           "description": "Region where the Key Value instance will be deployed",
-          "enum": [
-            "oregon",
-            "frankfurt",
-            "singapore",
-            "ohio",
-            "virginia"
-          ],
+          "enum": ["oregon", "frankfurt", "singapore", "ohio", "virginia"],
           "type": "string"
         }
       },
-      "required": [
-        "name",
-        "plan"
-      ],
+      "required": ["name", "plan"],
       "type": "object"
     }
   },
@@ -110,13 +95,7 @@
         },
         "region": {
           "description": "Region where the database will be deployed",
-          "enum": [
-            "oregon",
-            "frankfurt",
-            "singapore",
-            "ohio",
-            "virginia"
-          ],
+          "enum": ["oregon", "frankfurt", "singapore", "ohio", "virginia"],
           "type": "string"
         },
         "version": {
@@ -127,10 +106,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "name",
-        "plan"
-      ],
+      "required": ["name", "plan"],
       "type": "object"
     }
   },
@@ -148,10 +124,7 @@
         "autoDeploy": {
           "default": "yes",
           "description": "Whether to automatically deploy the service when the specified branch is updated. Defaults to 'yes'.",
-          "enum": [
-            "yes",
-            "no"
-          ],
+          "enum": ["yes", "no"],
           "type": "string"
         },
         "branch": {
@@ -176,10 +149,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "key",
-              "value"
-            ],
+            "required": ["key", "value"],
             "type": "object"
           },
           "type": "array"
@@ -198,10 +168,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "name",
-        "buildCommand"
-      ],
+      "required": ["name", "buildCommand"],
       "type": "object"
     }
   },
@@ -219,10 +186,7 @@
         "autoDeploy": {
           "default": "yes",
           "description": "Whether to automatically deploy the service when the specified branch is updated. Defaults to 'yes'.",
-          "enum": [
-            "yes",
-            "no"
-          ],
+          "enum": ["yes", "no"],
           "type": "string"
         },
         "branch": {
@@ -247,10 +211,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "key",
-              "value"
-            ],
+            "required": ["key", "value"],
             "type": "object"
           },
           "type": "array"
@@ -262,26 +223,13 @@
         "plan": {
           "default": "starter",
           "description": "The pricing plan for your service. Different plans offer different levels of resources and features.",
-          "enum": [
-            "starter",
-            "standard",
-            "pro",
-            "pro_max",
-            "pro_plus",
-            "pro_ultra"
-          ],
+          "enum": ["starter", "standard", "pro", "pro_max", "pro_plus", "pro_ultra"],
           "type": "string"
         },
         "region": {
           "default": "oregon",
           "description": "The geographic region where your service will be deployed. Defaults to Oregon. Choose the region closest to your users for best performance.",
-          "enum": [
-            "oregon",
-            "frankfurt",
-            "singapore",
-            "ohio",
-            "virginia"
-          ],
+          "enum": ["oregon", "frankfurt", "singapore", "ohio", "virginia"],
           "type": "string"
         },
         "repo": {
@@ -290,15 +238,7 @@
         },
         "runtime": {
           "description": "The runtime environment for your service. This determines how your service is built and run.",
-          "enum": [
-            "node",
-            "python",
-            "go",
-            "rust",
-            "ruby",
-            "elixir",
-            "docker"
-          ],
+          "enum": ["node", "python", "go", "rust", "ruby", "elixir", "docker"],
           "type": "string"
         },
         "startCommand": {
@@ -306,12 +246,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "name",
-        "runtime",
-        "buildCommand",
-        "startCommand"
-      ],
+      "required": ["name", "runtime", "buildCommand", "startCommand"],
       "type": "object"
     }
   },
@@ -335,10 +270,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "serviceId",
-        "deployId"
-      ],
+      "required": ["serviceId", "deployId"],
       "type": "object"
     }
   },
@@ -358,9 +290,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "keyValueId"
-      ],
+      "required": ["keyValueId"],
       "type": "object"
     }
   },
@@ -377,20 +307,13 @@
       "properties": {
         "aggregateHttpRequestCountsBy": {
           "description": "Field to aggregate HTTP request metrics by. Only supported for http_request_count metric. Options: host (aggregate by request host), statusCode (aggregate by HTTP status code). When not specified, returns total request counts.",
-          "enum": [
-            "host",
-            "statusCode"
-          ],
+          "enum": ["host", "statusCode"],
           "type": "string"
         },
         "cpuUsageAggregationMethod": {
           "default": "AVG",
           "description": "Method for aggregating metric values over time intervals. Only supported for CPU usage metrics. Options: AVG, MAX, MIN. Defaults to AVG.",
-          "enum": [
-            "AVG",
-            "MAX",
-            "MIN"
-          ],
+          "enum": ["AVG", "MAX", "MIN"],
           "type": "string"
         },
         "endTime": {
@@ -445,10 +368,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "resourceId",
-        "metricTypes"
-      ],
+      "required": ["resourceId", "metricTypes"],
       "type": "object"
     }
   },
@@ -468,9 +388,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "postgresId"
-      ],
+      "required": ["postgresId"],
       "type": "object"
     }
   },
@@ -504,9 +422,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "serviceId"
-      ],
+      "required": ["serviceId"],
       "type": "object"
     }
   },
@@ -538,9 +454,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "serviceId"
-      ],
+      "required": ["serviceId"],
       "type": "object"
     }
   },
@@ -572,10 +486,7 @@
         "direction": {
           "default": "backward",
           "description": "The direction to query logs for. Backward will return most recent logs first. Forward will start with the oldest logs in the time range.",
-          "enum": [
-            "backward",
-            "forward"
-          ],
+          "enum": ["backward", "forward"],
           "type": "string"
         },
         "endTime": {
@@ -598,14 +509,7 @@
         },
         "label": {
           "description": "The label to list values for.",
-          "enum": [
-            "host",
-            "instance",
-            "level",
-            "method",
-            "statusCode",
-            "type"
-          ],
+          "enum": ["host", "instance", "level", "method", "statusCode", "type"],
           "type": "string"
         },
         "level": {
@@ -662,10 +566,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "label",
-        "resource"
-      ],
+      "required": ["label", "resource"],
       "type": "object"
     }
   },
@@ -683,10 +584,7 @@
         "direction": {
           "default": "backward",
           "description": "The direction to query logs for. Backward will return most recent logs first. Forward will start with the oldest logs in the time range.",
-          "enum": [
-            "backward",
-            "forward"
-          ],
+          "enum": ["backward", "forward"],
           "type": "string"
         },
         "endTime": {
@@ -767,9 +665,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "resource"
-      ],
+      "required": ["resource"],
       "type": "object"
     }
   },
@@ -841,10 +737,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "postgresId",
-        "sql"
-      ],
+      "required": ["postgresId", "sql"],
       "type": "object"
     }
   },
@@ -864,9 +757,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "ownerID"
-      ],
+      "required": ["ownerID"],
       "type": "object"
     }
   },
@@ -895,10 +786,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "key",
-              "value"
-            ],
+            "required": ["key", "value"],
             "type": "object"
           },
           "type": "array"
@@ -913,10 +801,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "serviceId",
-        "envVars"
-      ],
+      "required": ["serviceId", "envVars"],
       "type": "object"
     }
   },
@@ -936,9 +821,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "serviceId"
-      ],
+      "required": ["serviceId"],
       "type": "object"
     }
   },
@@ -958,9 +841,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "serviceId"
-      ],
+      "required": ["serviceId"],
       "type": "object"
     }
   }

--- a/backend/mcp_servers/resend/tools.json
+++ b/backend/mcp_servers/resend/tools.json
@@ -1,0 +1,1072 @@
+[
+  {
+    "name": "RESEND__SEND_EMAIL",
+    "description": "Start sending emails through the Resend Email API.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND_EMAIL",
+      "canonical_tool_description_hash": "be0790cf2fc90d18d44cb925d70453ad292f88149d739b27596eb6306312655f",
+      "canonical_tool_input_schema_hash": "fbc46d309bfc0a78f81995a0838ad495d926e7a7984fc70a5ff59282830d1052"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["from", "to", "subject"],
+          "properties": {
+            "cc": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Cc recipient email address(es)"
+            },
+            "to": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Recipient email address(es)"
+            },
+            "bcc": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Bcc recipient email address(es)"
+            },
+            "from": {
+              "type": "string",
+              "description": "Sender email address"
+            },
+            "html": {
+              "type": "string",
+              "description": "The HTML version of the message"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["name", "value"],
+                "required": ["name", "value"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the email tag"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value of the email tag"
+                  }
+                }
+              },
+              "description": "Custom data passed in key/value pairs"
+            },
+            "text": {
+              "type": "string",
+              "description": "The plain text version of the message"
+            },
+            "subject": {
+              "type": "string",
+              "description": "Email subject"
+            },
+            "reply_to": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "format": "email",
+                  "description": "Single reply-to email address"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "description": "Multiple reply-to email addresses"
+                }
+              ],
+              "description": "Reply-to email address(es). Can be a single email or an array of emails."
+            },
+            "scheduled_at": {
+              "type": "string",
+              "description": "Schedule email to be sent later. The date should be in natural language (e.g.: in 1 min) or ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z)."
+            }
+          },
+          "description": "Body parameters for the email request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__RETRIVE_EMAIL",
+    "description": "Retrieve a single email.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RETRIVE_EMAIL",
+      "canonical_tool_description_hash": "1ef6b7216a335c78b03a99695209a09f22931bc6bee08558ceb99f46f9228014",
+      "canonical_tool_input_schema_hash": "9eb959adb3049bf7550682df676f3fa99d5ebd36fd2114c29a19f9b50aaab36d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the email to retrieve"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__SEND_BATCH_EMAILS",
+    "description": "Trigger up to 100 batch emails at once.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND_BATCH_EMAILS",
+      "canonical_tool_description_hash": "2ee675340de6e0b3e4913c5aabf446ab0e76186de280ca156f9882d0d9543e0d",
+      "canonical_tool_input_schema_hash": "96eab16510cdcb114d6726a2993f814a40f0fc2bd43897a056e79370d9b5bdcf"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "visible": [
+              "from",
+              "to",
+              "subject",
+              "bcc",
+              "cc",
+              "scheduled_at",
+              "reply_to",
+              "html",
+              "text",
+              "tags"
+            ],
+            "required": ["from", "to", "subject"],
+            "properties": {
+              "cc": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Cc recipient email address(es)"
+              },
+              "to": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Recipient email address(es)"
+              },
+              "bcc": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Bcc recipient email address(es)"
+              },
+              "from": {
+                "type": "string",
+                "description": "Sender email address"
+              },
+              "html": {
+                "type": "string",
+                "description": "The HTML version of the message"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "visible": ["name", "value"],
+                  "required": ["name", "value"],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the email tag"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The value of the email tag"
+                    }
+                  }
+                },
+                "description": "Custom data passed in key/value pairs"
+              },
+              "text": {
+                "type": "string",
+                "description": "The plain text version of the message"
+              },
+              "subject": {
+                "type": "string",
+                "description": "Email subject"
+              },
+              "reply_to": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Single reply-to email address"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "description": "Multiple reply-to email addresses"
+                  }
+                ],
+                "description": "Reply-to email address(es). Can be a single email or an array of emails."
+              },
+              "scheduled_at": {
+                "type": "string",
+                "description": "Schedule email to be sent later. The date should be in natural language (e.g.: in 1 min) or ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z)."
+              }
+            },
+            "additionalProperties": false
+          },
+          "description": "Array of email objects to send in batch"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__UPDATE_EMAIL",
+    "description": "Update a scheduled email.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_EMAIL",
+      "canonical_tool_description_hash": "a640ddce6c6e5f4dcd51eca2fa819310492a8320855a4d293e2d056e56a4f675",
+      "canonical_tool_input_schema_hash": "4005263324dd971000b2e2c10d7fde58595cc24bd1c075a8fa45403081122eae"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["scheduled_at"],
+          "properties": {
+            "scheduled_at": {
+              "type": "string",
+              "description": "Schedule email to be sent later. The date should be in ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z)."
+            }
+          },
+          "description": "Body parameters for the email update request",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the email to update"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__CANCEL_EMAIL",
+    "description": "Cancel a scheduled email.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CANCEL_EMAIL",
+      "canonical_tool_description_hash": "6f14d9854458e0a034071b2b17a274cfcc1a2aebee38aa3e3af15b0ae120dccb",
+      "canonical_tool_input_schema_hash": "9f9c789a28d77002264e93a2aad526b69d6c39bef44ac18a991debe7f845878d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the email to cancel"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__CREATE_DOMAIN",
+    "description": "Add a domain to your Resend account.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_DOMAIN",
+      "canonical_tool_description_hash": "59c5bbd06ac28beea4028944d4faaad9654c23550515e4af4821f46405922c3a",
+      "canonical_tool_input_schema_hash": "26fd018098b2fa7391004ba4051a1d41f4a368ac1b1fb6a721e4188abf4e5717"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The domain name to add"
+            },
+            "region": {
+              "type": "string",
+              "description": "The region to create the domain in"
+            }
+          },
+          "description": "Body parameters for the domain creation request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__RETRIEVE_DOMAIN",
+    "description": "Retrieve a single domain.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RETRIEVE_DOMAIN",
+      "canonical_tool_description_hash": "30621a35d734e312ae458ea932808ab47458c130dda97b92548523f11fdb50e8",
+      "canonical_tool_input_schema_hash": "5b7044038235b7c0f6a8a5330e64bda1c9bb927215734062fe71a44ad5c73e67"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the domain to retrieve"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__VERIFY_DOMAIN",
+    "description": "Verify a domain.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "VERIFY_DOMAIN",
+      "canonical_tool_description_hash": "cc8e205e6bce7287f51de5146d15c80e7f031e92dfcb78a0b74cf148a4095328",
+      "canonical_tool_input_schema_hash": "6c914cb6d894f4e8af3f88081fe966e345a1b0eea7ece46fb516faa8f45b1204"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the domain to verify"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__UPDATE_DOMAIN",
+    "description": "Update a domain.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_DOMAIN",
+      "canonical_tool_description_hash": "2589f4ca27027315037a1bd82b4a0f1e18e375b7ea1de66b4762c0bdb70daed6",
+      "canonical_tool_input_schema_hash": "5476c70097993da4758cbb2f1fd60b3ea21c22bd90028dd4aef3e4d89862e870"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "open_tracking": {
+              "type": "boolean",
+              "description": "Enable or disable open tracking"
+            },
+            "click_tracking": {
+              "type": "boolean",
+              "description": "Enable or disable click tracking"
+            }
+          },
+          "description": "Body parameters for the domain update request",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the domain to update"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__LIST_DOMAINS",
+    "description": "Returns a list of your domains.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_DOMAINS",
+      "canonical_tool_description_hash": "2d93d367a1c3c761e1af58863dcd9156c0093d8d2399cf2b91579ce325df8a4b",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__DELETE_DOMAIN",
+    "description": "Delete a domain.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_DOMAIN",
+      "canonical_tool_description_hash": "fea6f5f4870436df3042c6191c81c1c721ae5b24683ffd1c3d0563c39f04a285",
+      "canonical_tool_input_schema_hash": "5da663c36c4ae81d4091bc84432b5b9d90695b2663225134972ea7a417a66682"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the domain to delete"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__RETRIEVE_CONTACT",
+    "description": "Retrieve a single contact.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RETRIEVE_CONTACT",
+      "canonical_tool_description_hash": "14bfdb1d66a62732acf23c761d8f9550c0074039a5f378d9feb8578b45e9aa63",
+      "canonical_tool_input_schema_hash": "b2fb1479f15c8173edd4ec48f272ae274c19b190cf718fc33f95473cd9595411"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["audience_id", "id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the contact to retrieve"
+            },
+            "audience_id": {
+              "type": "string",
+              "description": "The ID of the audience containing the contact"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__CREATE_API_KEY",
+    "description": "Add a new API key to authenticate communications with Resend.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_API_KEY",
+      "canonical_tool_description_hash": "cc9ccaa3268fcf566654e5189d245d6ce87e3a91a3eaaa89700d30c39319f3ca",
+      "canonical_tool_input_schema_hash": "e1bec9c72cd81085a621e60b54d368591566b42d42047acf6413b4919a6bcd40"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The API key name"
+            },
+            "domain_id": {
+              "type": "string",
+              "description": "Restrict API key to send emails only from a specific domain (only used with sending_access permission)"
+            },
+            "permission": {
+              "enum": ["full_access", "sending_access"],
+              "type": "string",
+              "description": "The API key permission level (full_access or sending_access)"
+            }
+          },
+          "description": "Body parameters for the API key creation request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__LIST_API_KEYS",
+    "description": "Retrieve a list of API keys for the authenticated user.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_API_KEYS",
+      "canonical_tool_description_hash": "1e20e11e087925ec4c7811f914ad23b5c6acee20915c537c5e1465421cb56d2a",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__DELETE_API_KEY",
+    "description": "Remove an existing API key.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_API_KEY",
+      "canonical_tool_description_hash": "ec5afca522c63f27adc415ae2cea24d445d256f37eb337e63af7d25abd18af97",
+      "canonical_tool_input_schema_hash": "b19e36f1732ecd66c806caf231789ebff0c16a35459b5df13119819ecfaaabf6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["api_key_id"],
+          "properties": {
+            "api_key_id": {
+              "type": "string",
+              "description": "The API key ID to delete"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__CREATE_AUDIENCE",
+    "description": "Create a list of contacts.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_AUDIENCE",
+      "canonical_tool_description_hash": "99ea0de42dffebedcd6cd23a0d4cc63b10b0877bf593301bbeb264947985cbc9",
+      "canonical_tool_input_schema_hash": "c199e88c3aafe1c882a6575881acb8a0236c8af51cb8c8ccd1cb607f2e1a8dc4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the audience you want to create"
+            }
+          },
+          "description": "Body parameters for the audience creation request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__RETRIEVE_AUDIENCE",
+    "description": "Retrieve a single audience.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RETRIEVE_AUDIENCE",
+      "canonical_tool_description_hash": "43089b187a160635318ed932c3b03027a7ca985b662f2bebca53954e899a022a",
+      "canonical_tool_input_schema_hash": "a6543b607fe886997e8e7e9a749522eb0f0b604c5fbf9594eb7f1f15cc45ec54"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the audience to retrieve"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__DELETE_AUDIENCE",
+    "description": "Remove an existing audience.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_AUDIENCE",
+      "canonical_tool_description_hash": "fa5259c96fe5c2df8c90f9ce44b5428456e30262dfb8265bae5e032c6b46e7ab",
+      "canonical_tool_input_schema_hash": "fa42695e1e45afe1b671496a3fbc6846a7a692839564076dbe25ddcacd80a33e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the audience to delete"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__LIST_AUDIENCES",
+    "description": "Retrieve a list of audiences.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_AUDIENCES",
+      "canonical_tool_description_hash": "30d4591b0afcedae4a80da401b684fdb4880f43e9169037288ac75fe99e62368",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__CREATE_CONTACT",
+    "description": "Add a contact to an audience.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_CONTACT",
+      "canonical_tool_description_hash": "1b0a7621ca61d48817f73e59be996a517dd86f2d9783ada6d939743f608d7dac",
+      "canonical_tool_input_schema_hash": "cae3faad175465e7109dfab27c97d113b7c94dcede4b19a81c81c80593980f95"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["email"],
+          "properties": {
+            "email": {
+              "type": "string",
+              "description": "Email address of the contact"
+            },
+            "last_name": {
+              "type": "string",
+              "description": "Last name of the contact"
+            },
+            "first_name": {
+              "type": "string",
+              "description": "First name of the contact"
+            },
+            "unsubscribed": {
+              "type": "boolean",
+              "description": "Whether the contact is unsubscribed"
+            }
+          },
+          "description": "Body parameters for the contact creation request",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["audience_id"],
+          "properties": {
+            "audience_id": {
+              "type": "string",
+              "description": "The ID of the audience to add the contact to"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__UPDATE_CONTACT",
+    "description": "Update a contact.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_CONTACT",
+      "canonical_tool_description_hash": "487e5f297f1f039c78779af0b7cc9849c874b3b173c6844015a06d6da730f04a",
+      "canonical_tool_input_schema_hash": "c75eef2af10a9c60427d713aa53855462f10fbe94cd18bcd714a15ec1b5770b6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "last_name": {
+              "type": "string",
+              "description": "Last name of the contact"
+            },
+            "first_name": {
+              "type": "string",
+              "description": "First name of the contact"
+            },
+            "unsubscribed": {
+              "type": "boolean",
+              "description": "Whether the contact is unsubscribed"
+            }
+          },
+          "description": "Body parameters for the contact update request",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["audience_id", "id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the contact to update"
+            },
+            "audience_id": {
+              "type": "string",
+              "description": "The ID of the audience containing the contact"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__DELETE_CONTACT",
+    "description": "Remove an existing contact.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_CONTACT",
+      "canonical_tool_description_hash": "e4d572d7dab0745750ab1be24ce6c5f9b92abacc99b20d94bf6326919d8f266e",
+      "canonical_tool_input_schema_hash": "89c388bb5049b63640d1c5565f65bbd809c82348e0465641146427ae9f68882e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["audience_id", "id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the contact to delete"
+            },
+            "audience_id": {
+              "type": "string",
+              "description": "The ID of the audience containing the contact"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__LIST_CONTACTS",
+    "description": "Returns a list of contacts for an audience.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_CONTACTS",
+      "canonical_tool_description_hash": "990d5e5611a4f8f04a13955733cc06ca341be50364b248dfbff33d301f184a2b",
+      "canonical_tool_input_schema_hash": "a7f1c21e6b3605fdc0a1cec7f97963239aadbf1ae9e19bbbf5228d16af8d6d54"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["audience_id"],
+          "properties": {
+            "audience_id": {
+              "type": "string",
+              "description": "The ID of the audience to list contacts from"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__CREATE_BROADCAST",
+    "description": "Create a new broadcast to send to your audience.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_BROADCAST",
+      "canonical_tool_description_hash": "8024d3f5e297cb6b852a82ffb5cf161f9992530c75392498128726631724b9c6",
+      "canonical_tool_input_schema_hash": "384fe2cb2ed0a259b858ecfd88633dc64bbf89dbe1157b8cbd3623d180155807"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["audience_id", "from", "subject"],
+          "properties": {
+            "from": {
+              "type": "string",
+              "description": "Sender email address. To include a friendly name, use the format \"Your Name <sender@domain.com>\""
+            },
+            "html": {
+              "type": "string",
+              "description": "The HTML version of the message"
+            },
+            "name": {
+              "type": "string",
+              "description": "The friendly name of the broadcast. Only used for internal reference"
+            },
+            "text": {
+              "type": "string",
+              "description": "The plain text version of the message"
+            },
+            "subject": {
+              "type": "string",
+              "description": "Email subject"
+            },
+            "reply_to": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "format": "email",
+                  "description": "Single reply-to email address"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "description": "Multiple reply-to email addresses"
+                }
+              ],
+              "description": "Reply-to email address(es). Can be a single email or an array of emails"
+            },
+            "audience_id": {
+              "type": "string",
+              "description": "The ID of the audience you want to send to"
+            }
+          },
+          "description": "Body parameters for the broadcast creation request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__RETRIEVE_BROADCAST",
+    "description": "Retrieve a single broadcast.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RETRIEVE_BROADCAST",
+      "canonical_tool_description_hash": "f6fc3e65c14b33fb09811d6b70f9806862dd142f2ace39d477193d056d5474d6",
+      "canonical_tool_input_schema_hash": "aaffc48c8031879ded538a01c48af8c8a875420b1c6263f58beb4d1ba2a6967e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the broadcast to retrieve"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__SEND_BROADCAST",
+    "description": "Start sending broadcasts to your audience through the Resend API.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND_BROADCAST",
+      "canonical_tool_description_hash": "a6c6b96370bd0473e209e87586b048d6e617cb9824303f5c37a297743de3176a",
+      "canonical_tool_input_schema_hash": "6c03e7cec8941717b57ea96581a362c8e93264824c29a76f8a9b590a33c44d01"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "scheduled_at": {
+              "type": "string",
+              "description": "Schedule email to be sent later. The date should be in natural language (e.g.: in 1 min) or ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z)"
+            }
+          },
+          "description": "Body parameters for the send broadcast request",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The broadcast ID"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__DELETE_BROADCAST",
+    "description": "Delete a broadcast.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_BROADCAST",
+      "canonical_tool_description_hash": "8d0516b0ea8f07f5ad4183b4fb743c938c4c8186f08ad64bf09088aace69342e",
+      "canonical_tool_input_schema_hash": "9af3af1a0332044dd7e20bc6ec1db3dbee51c287ec24c30d30d80764ee9928e4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the broadcast to delete"
+            }
+          },
+          "description": "Path parameters for the requests",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "RESEND__LIST_BROADCASTS",
+    "description": "Returns a list of your broadcasts.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_BROADCASTS",
+      "canonical_tool_description_hash": "60a4bfb5b8ad457bc40d74433eb5a8148fa5de5d5f747a722b74228f031f5d88",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/rocketreach/tools.json
+++ b/backend/mcp_servers/rocketreach/tools.json
@@ -1,0 +1,479 @@
+[
+  {
+    "name": "ROCKETREACH__ACCOUNT_INFO",
+    "description": "Retrieve & manage RocketReach API account details, view usage metrics, and access account configuration.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ACCOUNT_INFO",
+      "canonical_tool_description_hash": "01c0b525d2ce868dbd004769a67ef49f070f520da3fb99afe0ed4fb22953ccc2",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ROCKETREACH__CREATE_API_KEY",
+    "description": "Create a new API key for your RocketReach account. Your previous API key will immediately be invalidated.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_API_KEY",
+      "canonical_tool_description_hash": "439267793db73bc5a57070f91f4e928426dd9f74ba056afe78510ad516df4459",
+      "canonical_tool_input_schema_hash": "d5147ca549cb2a0c5bc5406be8b44bbe60facb080cea2c18b7bad5ea25f42a88"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["api_key"],
+          "properties": {
+            "api_key": {
+              "type": "string",
+              "description": "The API key for your account"
+            }
+          },
+          "description": "request body",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ROCKETREACH__PEOPLE_LOOKUP",
+    "description": "Person Enrichment API. Provide identifiers such as name, employer, or location to quickly retrieve matching professional profiles.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PEOPLE_LOOKUP",
+      "canonical_tool_description_hash": "c68cfbb3bc663e817c9c3cfe116ecdb25be19436f4d7d756728d37ebd72b11f9",
+      "canonical_tool_input_schema_hash": "cb7a407e59780fbc2242e102d913a1f2882dc731b84c0c36f6f8a6b0d3dda23d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "RocketReach internal unique profile ID"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the desired profile. Must specify along with current_employer (minimum length: 1)"
+            },
+            "email": {
+              "type": "string",
+              "description": "An email address for the desired profile (minimum length: 1)"
+            },
+            "title": {
+              "type": "string",
+              "description": "Job title of the desired profile (minimum length: 1)"
+            },
+            "npi_number": {
+              "type": "integer",
+              "description": "An NPI number for the desired profile (US healthcare professional)"
+            },
+            "lookup_type": {
+              "enum": [
+                "standard",
+                "premium",
+                "premium (feeds disabled)",
+                "bulk",
+                "phone",
+                "enrich"
+              ],
+              "type": "string",
+              "description": "Lookup type for the request"
+            },
+            "linkedin_url": {
+              "type": "string",
+              "description": "LinkedIn URL of the desired profile (minimum length: 1)"
+            },
+            "current_employer": {
+              "type": "string",
+              "description": "Current employer of the desired profile. Must specify along with name (minimum length: 1)"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ROCKETREACH__PEOPLE_SEARCH",
+    "description": "Search for people by criteria such as name, company, title, location, and more. Discover and filter over 700M professional profiles. Returns a list of possible matches without contact information.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PEOPLE_SEARCH",
+      "canonical_tool_description_hash": "de0bb6bea88637990a1cda60f713c4c184bfe9329d03f2c959ba4eb52444d5b1",
+      "canonical_tool_input_schema_hash": "fd6307a3a0d98958b68bc68284712383ecf4272bdb8db9592ce801d97997b583"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "query": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "name": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include profiles with these names"
+                },
+                "skills": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include profiles listed with these skills"
+                },
+                "keyword": {
+                  "type": "string",
+                  "description": "Include results matching keyword"
+                },
+                "industry": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include profiles employed in these industries"
+                },
+                "location": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include profiles located in these locations. You can add radius: 'San Francisco::~50mi'"
+                },
+                "company_name": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include profiles employed by these company names"
+                },
+                "company_size": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include profiles with employers with these sizes"
+                },
+                "current_title": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include profiles with these current job titles"
+                },
+                "current_employer": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include profiles employed by these companies"
+                },
+                "management_levels": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include profiles at these management levels"
+                }
+              },
+              "description": "Search query object containing search criteria",
+              "additionalProperties": false
+            },
+            "order_by": {
+              "enum": ["relevance", "popularity"],
+              "type": "string",
+              "default": "relevance",
+              "description": "Specifies the ordering of search results"
+            },
+            "page_size": {
+              "type": "integer",
+              "default": 10,
+              "description": "Maximum number of results to return per page (minimum: 1, maximum: 100)"
+            }
+          },
+          "description": "request body",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ROCKETREACH__CHECK_LOOKUP_STATUS",
+    "description": "Check the status of person lookup requests. Returns complete, failed, waiting, searching, or in progress status with available profile data.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CHECK_LOOKUP_STATUS",
+      "canonical_tool_description_hash": "6cff574ea7f2cd763860f50c024e6d6a5d07d148baf6b7dbcb968caa57c3a0d8",
+      "canonical_tool_input_schema_hash": "a2f70239b6aa738f3690c537a2ae0616d57542c98f22ab7ec9049a7edc4b1e3a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["ids"],
+          "properties": {
+            "ids": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "description": "List of Profile IDs to check status for"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ROCKETREACH__PROFILE_COMPANY_LOOKUP",
+    "description": "Person and Company Lookup API. Retrieve both profile data and company data for a person in a single request. Provides comprehensive professional and organizational information.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PROFILE_COMPANY_LOOKUP",
+      "canonical_tool_description_hash": "d25ec25f03b85e6d0a576ce3636e7d68758e8642b1b325673a52325a311b2ca1",
+      "canonical_tool_input_schema_hash": "cb7a407e59780fbc2242e102d913a1f2882dc731b84c0c36f6f8a6b0d3dda23d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "RocketReach internal unique profile ID"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the desired profile. Must specify along with current_employer (minimum length: 1)"
+            },
+            "email": {
+              "type": "string",
+              "description": "An email address for the desired profile (minimum length: 1)"
+            },
+            "title": {
+              "type": "string",
+              "description": "Job title of the desired profile (minimum length: 1)"
+            },
+            "npi_number": {
+              "type": "integer",
+              "description": "An NPI number for the desired profile (US healthcare professional)"
+            },
+            "lookup_type": {
+              "enum": [
+                "standard",
+                "premium",
+                "premium (feeds disabled)",
+                "bulk",
+                "phone",
+                "enrich"
+              ],
+              "type": "string",
+              "description": "Lookup type for the request"
+            },
+            "linkedin_url": {
+              "type": "string",
+              "description": "LinkedIn URL of the desired profile (minimum length: 1)"
+            },
+            "current_employer": {
+              "type": "string",
+              "description": "Current employer of the desired profile. Must specify along with name (minimum length: 1)"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ROCKETREACH__COMPANY_SEARCH",
+    "description": "Search Companies by Criteria. Find and filter millions of business records with fast name, domain, industry, and location queries for any size company.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "COMPANY_SEARCH",
+      "canonical_tool_description_hash": "b00bf1d48d8bff181601c5127ecffdb5ebeccf8a1162b528605c52ea97864577",
+      "canonical_tool_input_schema_hash": "fd24bf188263c1f09557522c17822b21a2ca9455371cec0a027dfd3558b6ef22"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "query": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "name": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include companies with these names"
+                },
+                "domain": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include companies with these domains"
+                },
+                "keyword": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include companies matching these keywords"
+                },
+                "revenue": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include companies with these revenue values"
+                },
+                "industry": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include companies focused in these industries"
+                },
+                "location": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include companies located in these locations"
+                },
+                "employees": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include companies with this number of employees"
+                },
+                "website_url": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include companies with these website URLs"
+                },
+                "total_funding": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include companies who have raised this amount of capital"
+                },
+                "publicly_traded": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Include companies that are publicly traded"
+                }
+              },
+              "description": "Search query object containing company search criteria",
+              "additionalProperties": false
+            },
+            "order_by": {
+              "enum": ["relevance", "popularity"],
+              "type": "string",
+              "default": "relevance",
+              "description": "Specifies the ordering of search results"
+            },
+            "page_size": {
+              "type": "integer",
+              "default": 10,
+              "description": "Maximum number of results to return per page (minimum: 1, maximum: 100)"
+            }
+          },
+          "description": "request body",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ROCKETREACH__COMPANY_LOOKUP",
+    "description": "Company Lookup API. Retrieve detailed metadata information for a specific company using domain, name, LinkedIn URL, ID, or ticker symbol. Provides comprehensive company profile data.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "COMPANY_LOOKUP",
+      "canonical_tool_description_hash": "26c9e8f53c4841ee9f32c013ba9de9065b8886a3259d2c3e055f0b1989ab48d0",
+      "canonical_tool_input_schema_hash": "bfbe3e6d65c0ee62fc62ac4e07a5cd06caf57bfbcddc0b3dc1d5c18169cf5195"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "RocketReach internal unique company ID"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the desired company to lookup (minimum length: 1)"
+            },
+            "domain": {
+              "type": "string",
+              "description": "Domain of the desired company to lookup (preferred) (minimum length: 1)"
+            },
+            "ticker": {
+              "type": "string",
+              "description": "Stock ticker of the desired company to lookup (minimum length: 1)"
+            },
+            "linkedin_url": {
+              "type": "string",
+              "description": "LinkedIn URL of the desired company to lookup (minimum length: 1)"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/scrapybara/tools.json
+++ b/backend/mcp_servers/scrapybara/tools.json
@@ -1,0 +1,1271 @@
+[
+  {
+    "name": "SCRAPYBARA__GET_STREAM_URL",
+    "description": "Get the stream URL for a running Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_STREAM_URL",
+      "canonical_tool_description_hash": "f511f9579e50f4830382ed112fb0b45f4c32b5752c4d4da1c63d0cc903ac2965",
+      "canonical_tool_input_schema_hash": "926a100a4e6e0399a854155d7e610ad90c2b4fa30457b1a0fcf2ef40f8a471c9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to get the stream URL for"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__ENV_GET",
+    "description": "Get environment variables from a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ENV_GET",
+      "canonical_tool_description_hash": "1399ec5623c0dfdcb956fe2c4ff3df294eb7fb10583ca0f09434b9fd66f6201a",
+      "canonical_tool_input_schema_hash": "5e6a7db273ae2e2a32113b2dfa8dc6888185b5ae6d360dd835cb2543952bd2e7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to get environment variables from"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__START_INSTANCE",
+    "description": "Start a new instance of Scrapybara for web scraping",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "START_INSTANCE",
+      "canonical_tool_description_hash": "b44a78da9686ca776207d179bb04b8881f68cb2b44df39058a8e42c0cbc73a72",
+      "canonical_tool_input_schema_hash": "9fd423f4ca03eaa2a67b19f35926ad0913725424db3a9b863bc5c7f2f543a6cf"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "instance_type": {
+              "enum": ["ubuntu", "browser", "windows"],
+              "type": "string",
+              "default": "ubuntu",
+              "description": "The type of instance to launch."
+            },
+            "timeout_hours": {
+              "type": "number",
+              "maximum": 24,
+              "minimum": 0.01,
+              "description": "Number of hours before the instance times out."
+            },
+            "blocked_domains": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of domains to block during scraping."
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__GET_INSTANCE_BY_ID",
+    "description": "Get details of a Scrapybara instance by its ID",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_INSTANCE_BY_ID",
+      "canonical_tool_description_hash": "273aec3b428953f13e0ec54f8a0936c5e82cabdeba8a2bb84a8a1335c2f8fe3a",
+      "canonical_tool_input_schema_hash": "75e8d34b316ca4884abd9214868dd8c1e83831b12de103df3121fac52d913ac1"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to retrieve"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__LIST_ALL_INSTANCES",
+    "description": "List all Scrapybara instances",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_ALL_INSTANCES",
+      "canonical_tool_description_hash": "7e05075eb6d2c24a9ae3a48fc6d10afc74dc0e6e2444d1705ae0a6d0e3d9123d",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__LIST_ALL_BROWSER_AUTH_STATES",
+    "description": "List all browser authentication states",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_ALL_BROWSER_AUTH_STATES",
+      "canonical_tool_description_hash": "d64c50556472bec7e3223419c55a9c0f5061794cc7d4fdab77943bbdf3ad5b2f",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__TAKE_SCREENSHOT",
+    "description": "Take a screenshot of a running Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TAKE_SCREENSHOT",
+      "canonical_tool_description_hash": "8710d80d132b3f3f48cd79725c34dadc9e8ccf079cf7cd84b7775dfe18b8e479",
+      "canonical_tool_input_schema_hash": "806d8779cee2fffe3b1558ae903238cf5beac67f5c8e66c5a975e1dd76b5bc0c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to take a screenshot of"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__RUN_COMPUTER_ACTIONS",
+    "description": "Run computer actions on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RUN_COMPUTER_ACTIONS",
+      "canonical_tool_description_hash": "ddfc4caa27d08428c3fb5369257a0df5853e465005f864da10a963c3c2a3040d",
+      "canonical_tool_input_schema_hash": "76d9ecf68127c6a71a250c62cbfd65ba7e445a2a591159e0985ee8ff0e1a7a65"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["action"],
+          "properties": {
+            "keys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Keys to press"
+            },
+            "path": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              },
+              "description": "Path for drag mouse action [[x1, y1], [x2, y2], ...]"
+            },
+            "text": {
+              "type": "string",
+              "description": "Text to type"
+            },
+            "action": {
+              "enum": [
+                "move_mouse",
+                "click_mouse",
+                "drag_mouse",
+                "scroll",
+                "press_key",
+                "type_text",
+                "wait",
+                "take_screenshot",
+                "get_cursor_position"
+              ],
+              "type": "string",
+              "description": "The type of action to perform"
+            },
+            "button": {
+              "enum": ["left", "right", "middle", "back", "forward"],
+              "type": "string",
+              "description": "Mouse button to use for click actions"
+            },
+            "delta_x": {
+              "type": "number",
+              "description": "Horizontal scroll amount"
+            },
+            "delta_y": {
+              "type": "number",
+              "description": "Vertical scroll amount"
+            },
+            "duration": {
+              "type": "number",
+              "description": "Duration in seconds for wait or key press actions"
+            },
+            "hold_keys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Keys to hold during the action"
+            },
+            "click_type": {
+              "enum": ["down", "up", "click"],
+              "type": "string",
+              "description": "Type of click to perform"
+            },
+            "num_clicks": {
+              "type": "integer",
+              "description": "Number of clicks to perform"
+            },
+            "coordinates": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "description": "Coordinates for mouse actions [x, y]"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to run actions on"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__RUN_BASH_ACTIONS",
+    "description": "Run bash commands on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RUN_BASH_ACTIONS",
+      "canonical_tool_description_hash": "1abb5548460e071f7575ede3c388024d57366b08f16e83139a77aab905063e4a",
+      "canonical_tool_input_schema_hash": "a851ff99b4417c649319126da0a27459cdd3fcf212d3945f8e0880a97266e6f3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "The bash command to execute"
+            },
+            "restart": {
+              "type": "boolean",
+              "description": "Whether to restart the instance after executing the command"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to run bash commands on"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__RUN_EDIT_ACTIONS",
+    "description": "Run file editing actions on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RUN_EDIT_ACTIONS",
+      "canonical_tool_description_hash": "3e9ca8eaa3fd5fdf0ce0f3d12a7faf7100c736f08c4989e612b653d75d40dfca",
+      "canonical_tool_input_schema_hash": "32eabd27bf84acfe61fb8ea0be36e7a3cb6637b9ccfdc3aa73de6f81424cb8ab"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["command", "path"],
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "The file path to edit"
+            },
+            "command": {
+              "enum": ["view", "create", "str_replace", "insert", "undo_edit"],
+              "type": "string",
+              "description": "The type of edit action to perform"
+            },
+            "new_str": {
+              "type": "string",
+              "description": "The new string in str_replace action"
+            },
+            "old_str": {
+              "type": "string",
+              "description": "The string to replace in str_replace action"
+            },
+            "file_text": {
+              "type": "string",
+              "description": "The text content for file creation"
+            },
+            "view_range": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "description": "Line range to view [start_line, end_line]"
+            },
+            "insert_line": {
+              "type": "integer",
+              "description": "The line number to insert text at"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to run edit actions on"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__RUN_FILE_ACTIONS",
+    "description": "Run file operations on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RUN_FILE_ACTIONS",
+      "canonical_tool_description_hash": "b54c49ec002942d8aaf7ffc6cfbd2d7bd83c0373254574f650cdc4ea7a13bdd2",
+      "canonical_tool_input_schema_hash": "dda75a31c40f79a0575be3555c51a4f5b7de2c449027c61ac8c39a14bf76bf10"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["command"],
+          "properties": {
+            "dst": {
+              "type": "string",
+              "description": "Destination path for copy or move operations"
+            },
+            "src": {
+              "type": "string",
+              "description": "Source path for copy or move operations"
+            },
+            "line": {
+              "type": "integer",
+              "description": "Line number for operations that work on specific lines"
+            },
+            "mode": {
+              "type": "string",
+              "description": "File access mode (e.g., 'r', 'w', 'a')"
+            },
+            "path": {
+              "type": "string",
+              "description": "The path of the file or directory to operate on"
+            },
+            "text": {
+              "type": "string",
+              "description": "Text content for operations like insertion"
+            },
+            "lines": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "description": "Specific line numbers to operate on"
+            },
+            "command": {
+              "enum": ["read", "write", "copy", "delete", "list", "find", "move", "search", "view"],
+              "type": "string",
+              "description": "The type of file operation to perform (e.g., 'read', 'write', 'copy', 'delete', 'list', 'find')"
+            },
+            "content": {
+              "type": "string",
+              "description": "The content to write to a file when using 'write' command"
+            },
+            "new_str": {
+              "type": "string",
+              "description": "Replacement string for search and replace operations"
+            },
+            "old_str": {
+              "type": "string",
+              "description": "String to replace in search and replace operations"
+            },
+            "pattern": {
+              "type": "string",
+              "description": "Pattern to match in search operations, can be regex"
+            },
+            "encoding": {
+              "type": "string",
+              "description": "Encoding to use for file operations (e.g., 'utf-8', 'base64')"
+            },
+            "recursive": {
+              "type": "boolean",
+              "description": "Whether to perform operations recursively on directories"
+            },
+            "view_range": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "description": "Line range for viewing file content [start_line, end_line]"
+            },
+            "line_numbers": {
+              "type": "boolean",
+              "description": "Whether to include line numbers in output"
+            },
+            "case_sensitive": {
+              "type": "boolean",
+              "description": "Whether searches should be case sensitive"
+            },
+            "all_occurrences": {
+              "type": "boolean",
+              "description": "Whether to replace all occurrences in search and replace operations"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to perform file operations on"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__STOP_INSTANCE",
+    "description": "Stop a running Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "STOP_INSTANCE",
+      "canonical_tool_description_hash": "3217822a3b8bf32c037f3c63754f95ef7e3ca5430a43eac223c5e85d37efcfa7",
+      "canonical_tool_input_schema_hash": "2771a6cc4209538580d7f7b9928b6c405f216db909c8bc269e01b1042ba89f9f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to stop"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__PAUSE_INSTANCE",
+    "description": "Pause a running Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PAUSE_INSTANCE",
+      "canonical_tool_description_hash": "900d0c531dce956a1d0a11cefe4314dd6e0fd94253fd84dfc7b93838c0bb8ab9",
+      "canonical_tool_input_schema_hash": "c355cd32bcc64661ef5325edcfb8ca6ea5a865c5477b0bb2e9a671e25849989e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to pause"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__RESUME_INSTANCE",
+    "description": "Resume a paused Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RESUME_INSTANCE",
+      "canonical_tool_description_hash": "4d73459f1841f111a9656e496e7063e321ebca8564ec02c312d4238e118f1915",
+      "canonical_tool_input_schema_hash": "539d74878af45b057b87cc3713b7ea7b106efaceb0bd1566a685fbb3800aa9bb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to resume"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "timeout_hours": {
+              "type": "number",
+              "description": "Number of hours before the instance times out (defaults to 1)"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__BROWSER_START",
+    "description": "Start a browser on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BROWSER_START",
+      "canonical_tool_description_hash": "837d35406857c58f7b2ac4e5dbe038323d2c1d9e4f16fe6d2766b5c72e4c04eb",
+      "canonical_tool_input_schema_hash": "50f756f5dded85293f04ab0db6d9a94321428d42be5a60180a1d8bb670181c40"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to start a browser on"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__BROWSER_GET_CDP_URL",
+    "description": "Get the Chrome DevTools Protocol URL for a browser on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BROWSER_GET_CDP_URL",
+      "canonical_tool_description_hash": "64e5e888ebb3333f23081f25fcd0d7605c135ff7cc973ec4b067b739391b00f7",
+      "canonical_tool_input_schema_hash": "7113fa90deb11b53b0db991b0c1c1fb2b6abfaacf345f5e15cd0a8a006264abc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to get the CDP URL for"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__BROWSER_GET_CURRENT_URL",
+    "description": "Get the current URL of the browser on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BROWSER_GET_CURRENT_URL",
+      "canonical_tool_description_hash": "3179171a81399f8a957ab2603f3ab0c4d74872f919e557e9dcb04318c2a887df",
+      "canonical_tool_input_schema_hash": "dacce3bb8c2f63d2e032fe818a137a31c0cfa29f72f0eaad66598a7c405d7dfa"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to get the current URL for"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__BROWSER_SAVE_AUTH",
+    "description": "Save the browser authentication state from a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BROWSER_SAVE_AUTH",
+      "canonical_tool_description_hash": "6a981e9f0b03cbd0ed344b489742cd0a90a35952faa64963f1196d1bb74f87b3",
+      "canonical_tool_input_schema_hash": "7dcd925b4f0396ac426957f2e4889a0e9573b99ac2572da84487414f66bd9274"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to save authentication state from"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Optional name for the saved authentication state"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__BROWSER_MODIFY_AUTH",
+    "description": "Modify a browser authentication state on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BROWSER_MODIFY_AUTH",
+      "canonical_tool_description_hash": "0a024e1943c1e345d8cf8cab61df49e341e86c5789bd461dfa875f4f750f4538",
+      "canonical_tool_input_schema_hash": "cb4898446d40a3ef53bb4a5fa525c5e4bfbbf68845bf25a96e14d351033c8d75"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to modify authentication state on"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["auth_state_id"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Optional new name for the authentication state"
+            },
+            "auth_state_id": {
+              "type": "string",
+              "description": "The ID of the authentication state to modify"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__BROWSER_AUTHENTICATE",
+    "description": "Authenticate browser using a saved authentication state",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BROWSER_AUTHENTICATE",
+      "canonical_tool_description_hash": "07445a1a4753b40248d03c33460104c5898995b28ef845f8b6ada244ee17d378",
+      "canonical_tool_input_schema_hash": "0a4af8247f1dc5c02d044c2028c66fa384ce98a6ce3d090030a137c2f0ee7388"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to authenticate the browser on"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["auth_state_id"],
+          "properties": {
+            "auth_state_id": {
+              "type": "string",
+              "description": "The ID of the saved authentication state to use"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__BROWSER_STOP",
+    "description": "Stop a browser on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BROWSER_STOP",
+      "canonical_tool_description_hash": "0c13191cb423048698cd5c7c41cfff9fde42e3a2c96482808bc164ea5e098b81",
+      "canonical_tool_input_schema_hash": "8e55e8f2338811a48750e91f35d6205c9dec9aee7220c26cf01fcbfa68a2c67f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to stop the browser on"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__CODE_EXECUTE",
+    "description": "Execute code on a Scrapybara instance without using a notebook",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CODE_EXECUTE",
+      "canonical_tool_description_hash": "0b3e8e9822ac3d9e82cdf7c9fcf82dcebad32626b00a3d1c0f5125fbab034164",
+      "canonical_tool_input_schema_hash": "0f54a95508151bb57449739ccac3233461a76f98cb1effba57f76aeb9e065371"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["code"],
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "The code to execute"
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "Timeout in seconds for code execution"
+            },
+            "kernel_name": {
+              "type": "string",
+              "default": "python3",
+              "description": "The kernel to use for execution (defaults to python3)"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to execute code on"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__LIST_NOTEBOOK_KERNELS",
+    "description": "List available notebook kernels on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_NOTEBOOK_KERNELS",
+      "canonical_tool_description_hash": "aefafcab9632e934eba75cda86e2d87ef3d70cbafbde4b5b3a0013fbb0311ecc",
+      "canonical_tool_input_schema_hash": "6a9d78c4977fc185c39ea2504236d149ed2df8ab092ce54b9197a50671f4691f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to list notebook kernels for"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__NOTEBOOK_CREATE",
+    "description": "Create a new notebook on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "NOTEBOOK_CREATE",
+      "canonical_tool_description_hash": "ac169db6a2be92a996ca54c76839db0cf25676166472566717d262645a7135dc",
+      "canonical_tool_input_schema_hash": "128bb90c089f9290a5cbb244cfb607de42b73fb7a3416f2cb166f87a03be123b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name for the new notebook"
+            },
+            "kernel_name": {
+              "type": "string",
+              "default": "python3",
+              "description": "The kernel to use for the notebook (defaults to python3)"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to create a notebook on"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__NOTEBOOK_GET",
+    "description": "Get a notebook by ID from a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "NOTEBOOK_GET",
+      "canonical_tool_description_hash": "4efb148c56a5242c36dacea8b20d0fe81ad9c60d7307db711149814c6cc832f5",
+      "canonical_tool_input_schema_hash": "e1705629346056a9be521e559fc68213481fd555b44218ef6c8f623f807c4cf0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id", "notebook_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance that contains the notebook"
+            },
+            "notebook_id": {
+              "type": "string",
+              "description": "The ID of the notebook to retrieve"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__NOTEBOOK_DELETE",
+    "description": "Delete a notebook from a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "NOTEBOOK_DELETE",
+      "canonical_tool_description_hash": "25c226c442ba5d23ceca28fa5d55096b2eaa338cc1407f16718c320b61daa008",
+      "canonical_tool_input_schema_hash": "a37348954513b972ed987d83d577bd2d9e8b37f602d3c1ef9c9503f432c0c400"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id", "notebook_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance that contains the notebook"
+            },
+            "notebook_id": {
+              "type": "string",
+              "description": "The ID of the notebook to delete"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__NOTEBOOK_ADD_CELL",
+    "description": "Add a cell to a notebook on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "NOTEBOOK_ADD_CELL",
+      "canonical_tool_description_hash": "3b8609ee364dc1d63e2bdd235bfa925de25a0ea7a5ee2ae36aba62913ea44b6c",
+      "canonical_tool_input_schema_hash": "3922dc2c65c0b524640b22756581a7a131034f3edf5a391d523c3f2a90f68760"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["type", "content"],
+          "properties": {
+            "type": {
+              "enum": ["code", "markdown", "raw"],
+              "type": "string",
+              "description": "The type of cell to add (code, markdown, or raw)"
+            },
+            "content": {
+              "type": "string",
+              "description": "The content of the cell"
+            },
+            "metadata": {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "description": "Optional metadata for the cell",
+              "additionalProperties": true
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["instance_id", "notebook_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance that contains the notebook"
+            },
+            "notebook_id": {
+              "type": "string",
+              "description": "The ID of the notebook to add a cell to"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__NOTEBOOK_EXECUTE_CELL",
+    "description": "Execute a cell in a notebook on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "NOTEBOOK_EXECUTE_CELL",
+      "canonical_tool_description_hash": "3dd97561c76fd5a264bf58b5de5ffdfd836865b9b4c842766adb2a4d82814282",
+      "canonical_tool_input_schema_hash": "00549b4c4e7ab6fb99d8791d5cf395f3b92e5aee355f0392b67eff0acb66d61e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "timeout": {
+              "type": "integer",
+              "description": "Optional timeout in seconds for cell execution"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["instance_id", "notebook_id", "cell_id"],
+          "properties": {
+            "cell_id": {
+              "type": "string",
+              "description": "The ID of the cell to execute"
+            },
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance that contains the notebook"
+            },
+            "notebook_id": {
+              "type": "string",
+              "description": "The ID of the notebook that contains the cell"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__ENV_SET",
+    "description": "Set environment variables on a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ENV_SET",
+      "canonical_tool_description_hash": "58650b965570780d644b824b980599d1a7272e7ce745bc3fc8309fb24c432af2",
+      "canonical_tool_input_schema_hash": "0ec34d2a852f5125e88588a45c0c33f8908cdf65b47abbeb768cc609e466385e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["variables"],
+          "properties": {
+            "variables": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "EXAMPLE_KEY": {
+                  "type": "string",
+                  "description": "Example environment variable"
+                }
+              },
+              "description": "Key-value pairs of environment variables to set.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Body parameter: environment variable key-value pairs",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the instance to configure."
+            }
+          },
+          "description": "Path parameter: instance ID",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SCRAPYBARA__ENV_DELETE",
+    "description": "Delete environment variables from a Scrapybara instance",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ENV_DELETE",
+      "canonical_tool_description_hash": "bc691124c22b6401bfbb6269988e50655ffc24a55b5e7c64997a192832c5b80a",
+      "canonical_tool_input_schema_hash": "aad1cc2ae8110fe4718e08d92919229310837a4f253f207c9f2a50a83d5d9846"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["keys"],
+          "properties": {
+            "keys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of environment variable names to delete"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the Scrapybara instance to delete environment variables from"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/sendgrid/tools.json
+++ b/backend/mcp_servers/sendgrid/tools.json
@@ -1,0 +1,2471 @@
+[
+  {
+    "name": "SENDGRID__SEND_EMAIL",
+    "description": "Send email over SendGrid's v3 Web API",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND_EMAIL",
+      "canonical_tool_description_hash": "ed60e1598bce9d3e5a7b7a13fb9ad1972d43ffd450d8d443e078f23d428de49d",
+      "canonical_tool_input_schema_hash": "76cca0cc6cab3e500bf450de9bb45d87eea3eb0f82cd2b70476457b08df58739"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["from", "personalizations", "content", "subject"],
+          "properties": {
+            "from": {
+              "type": "object",
+              "required": ["email"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the sender"
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "Email address of the sender"
+                }
+              },
+              "description": "Sender information",
+              "additionalProperties": false
+            },
+            "content": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["type", "value"],
+                "required": ["type", "value"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "default": "text/plain",
+                    "description": "MIME type of the content (e.g., text/plain, text/html)"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The actual content of the email"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "Content of the email"
+            },
+            "subject": {
+              "type": "string",
+              "description": "Subject line of the email"
+            },
+            "personalizations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["to", "cc", "bcc"],
+                "required": ["to"],
+                "properties": {
+                  "cc": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "visible": ["email", "name"],
+                      "required": ["email"],
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Name of the CC recipient"
+                        },
+                        "email": {
+                          "type": "string",
+                          "format": "email",
+                          "description": "Email address of the CC recipient"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "description": "Carbon copy recipients"
+                  },
+                  "to": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "visible": ["email", "name"],
+                      "required": ["email"],
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Name of the recipient"
+                        },
+                        "email": {
+                          "type": "string",
+                          "format": "email",
+                          "description": "Email address of the recipient"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "description": "Recipients of the email"
+                  },
+                  "bcc": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "visible": ["email", "name"],
+                      "required": ["email"],
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Name of the BCC recipient"
+                        },
+                        "email": {
+                          "type": "string",
+                          "format": "email",
+                          "description": "Email address of the BCC recipient"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "description": "Blind carbon copy recipients"
+                  },
+                  "subject": {
+                    "type": "string",
+                    "description": "Subject line of the email"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "An array of different recipient groups"
+            }
+          },
+          "description": "Email content and configuration",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__CREATE_DOMAIN_AUTHENTICATION",
+    "description": "Create a new authenticated domain",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_DOMAIN_AUTHENTICATION",
+      "canonical_tool_description_hash": "4973a5e1a983c5aac40df146dfa33697174cfa235ffb6416bccdb5f1c04f773a",
+      "canonical_tool_input_schema_hash": "97cb060bbe1e4d41428e55a751d289ecdda4c7f56bc5775b580cde676aa12709"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["domain"],
+          "properties": {
+            "ips": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of IPs to associate with the domain"
+            },
+            "domain": {
+              "type": "string",
+              "description": "Domain to authenticate"
+            },
+            "default": {
+              "type": "boolean",
+              "description": "Whether this is the default domain"
+            },
+            "username": {
+              "type": "string",
+              "format": "email",
+              "description": "Username associated with the domain"
+            },
+            "subdomain": {
+              "type": "string",
+              "description": "Subdomain for authentication"
+            },
+            "custom_spf": {
+              "type": "boolean",
+              "description": "Whether to use custom SPF"
+            },
+            "automatic_security": {
+              "type": "boolean",
+              "description": "Whether to enable automatic security"
+            }
+          },
+          "description": "Domain authentication configuration",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_DEFAULT_DOMAIN_AUTHENTICATION",
+    "description": "Retrieve the default authentication for a domain. Returns default domain and its details if a default is set. If no default domain is set, returns general information about domain authentication status.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DEFAULT_DOMAIN_AUTHENTICATION",
+      "canonical_tool_description_hash": "0e2d3d60fd92b7eb5a56158c8ffa891d90086b857a213834d37005e63ebdc988",
+      "canonical_tool_input_schema_hash": "86b80fafc3c072167942b924b71001218308f30a41d96fbbf01b31ad9b8d2cb3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "domain": {
+              "type": "string",
+              "description": "The domain to find a default authentication"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_DOMAIN_AUTHENTICATION_BY_ID",
+    "description": "Retrieve a specific domain authentication by ID. Returns detailed information about the authenticated domain including DNS records and validation status.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DOMAIN_AUTHENTICATION_BY_ID",
+      "canonical_tool_description_hash": "f7fd3b2dfb57a618649aacad447018b036f73fab9500d5bd4c3efe3515f06768",
+      "canonical_tool_input_schema_hash": "94206497314c894dbf966da4a9e3845be70f27a204d311fb632052e068f2bb59"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the domain authentication to retrieve"
+            }
+          },
+          "description": "Path parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__LIST_AUTHENTICATED_DOMAINS",
+    "description": "List all authenticated domains",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_AUTHENTICATED_DOMAINS",
+      "canonical_tool_description_hash": "28936af929359c276440e6d8ab78424d8ada86fd1dfc6cced22366f50b296cf5",
+      "canonical_tool_input_schema_hash": "c6dfc540e30e661a59a24371ff17e3ec3e29be80596bd1a8a996946fd2ecb8fd"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of domains to return"
+            },
+            "offset": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Paging offset"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__VALIDATE_DOMAIN_AUTHENTICATION",
+    "description": "Validate a domain authentication",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "VALIDATE_DOMAIN_AUTHENTICATION",
+      "canonical_tool_description_hash": "62792ee65f25bbf6efc4657d7a182bed565fa04d6c7ff8a45d9bf8f769852b2a",
+      "canonical_tool_input_schema_hash": "aac8ed27b7edbb66ba2d643d7cac5d1cb72700d8b21f91f21e4d4b7fb7915660"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["domain_id"],
+          "properties": {
+            "domain_id": {
+              "type": "integer",
+              "description": "ID of the domain to validate"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__UPDATE_DOMAIN_AUTHENTICATION",
+    "description": "Update the settings for an authenticated domain",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_DOMAIN_AUTHENTICATION",
+      "canonical_tool_description_hash": "0fb05c10334568743b3a6967eb85d0bb301e71d319ad05f0adb1c6573e6f5579",
+      "canonical_tool_input_schema_hash": "d23799698444698d87cd1a13be3d144506666cba67208ac21ab862abf88a930f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "default": {
+              "type": "boolean",
+              "description": "Indicates whether this is the default authenticated domain"
+            },
+            "custom_spf": {
+              "type": "boolean",
+              "description": "Indicates whether to generate a custom SPF record for manual security"
+            }
+          },
+          "description": "Update settings for the domain authentication",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["domain_id"],
+          "properties": {
+            "domain_id": {
+              "type": "integer",
+              "description": "ID of the domain authentication to update"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__DELETE_DOMAIN_AUTHENTICATION",
+    "description": "Delete an authenticated domain",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_DOMAIN_AUTHENTICATION",
+      "canonical_tool_description_hash": "b1148386145eeb7f15ccd30265f98c38bc10bb705438194fdbeb2106ddd95b39",
+      "canonical_tool_input_schema_hash": "e2b2f57dd9889d8ffa042be8242b1d5c3df71a71697554c9076ea948458b00a6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["domain_id"],
+          "properties": {
+            "domain_id": {
+              "type": "integer",
+              "description": "ID of the domain authentication to delete"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__LIST_BRANDED_LINKS",
+    "description": "Retrieve all branded links.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_BRANDED_LINKS",
+      "canonical_tool_description_hash": "69ba0af6990f9d8948736d3b34497955ce56ddd55e86c025fa60efcc6b7d1e0f",
+      "canonical_tool_input_schema_hash": "af18e98f5d5e13fab7ce3f01f711c5386f95d0380771b4aa9c3e7f4d5308e662"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of links to return"
+            },
+            "offset": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Paging offset"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__ASSOCIATE_DOMAIN_WITH_SUBUSER",
+    "description": "Associate a specific authenticated domain with a subuser. This allows subusers to send mail using their parent's authenticated domain.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ASSOCIATE_DOMAIN_WITH_SUBUSER",
+      "canonical_tool_description_hash": "c187f52329ff95b87f90c4791c1d223d12279bbef32764b4b8cd9992f68d5eae",
+      "canonical_tool_input_schema_hash": "efd93c26ac47ce5b60d134d15af489fab9f3616ae7a49e3df35089e06a487b53"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["username"],
+          "properties": {
+            "username": {
+              "type": "string",
+              "description": "Username of the subuser to associate with the authenticated domain"
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["domain_id"],
+          "properties": {
+            "domain_id": {
+              "type": "integer",
+              "description": "ID of the authenticated domain to associate with the subuser"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__EMAIL_DNS_RECORDS",
+    "description": "Share DNS records with a colleague to help them enter it into your DNS provider to validate your domain and link branding. The email includes a direct link to the DNS records which expires after some time.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EMAIL_DNS_RECORDS",
+      "canonical_tool_description_hash": "4fd6539e7a17036bfaebaaec9dd2154c79d3bdbb5e52be9d13f12a7f5e9762e7",
+      "canonical_tool_input_schema_hash": "27197c9241e43dcd5b767037af9ddda812d98ef89ae3ff53f10b3f6d3ca4cf6e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["email"],
+          "properties": {
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The email address to send the DNS information to"
+            },
+            "link_id": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The ID of the branded link"
+            },
+            "message": {
+              "type": "string",
+              "default": "Please set these DNS records in our hosting solution.",
+              "description": "Optional custom text block to include in the email body sent with the records"
+            },
+            "domain_id": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The ID of your SendGrid domain record"
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__CREATE_BRANDED_LINK",
+    "description": "Create a new branded link for your SendGrid account. Link branding allows all click-tracked links and images in your emails to be served from your domain rather than sendgrid.net.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_BRANDED_LINK",
+      "canonical_tool_description_hash": "650d21ddc064c5048bee5477cc9afdd445b8a02da1a8a14c78363b2d8640816a",
+      "canonical_tool_input_schema_hash": "c565292c6031667b48ccab894e9a389d8ee314bf773c14e6732b9e71fc5f3560"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["domain"],
+          "properties": {
+            "domain": {
+              "type": "string",
+              "description": "The domain to be branded"
+            },
+            "default": {
+              "type": "boolean",
+              "description": "Whether this should be the default branded link"
+            },
+            "subdomain": {
+              "type": "string",
+              "description": "The subdomain to use for branding"
+            }
+          },
+          "description": "Link branding configuration",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__VALIDATE_BRANDED_LINK",
+    "description": "Validate a branded link. Returns validation results for the DNS records.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "VALIDATE_BRANDED_LINK",
+      "canonical_tool_description_hash": "0d2589cd468697f0423e6a226be29a9ecc20820922d48cfc60954f503d13a900",
+      "canonical_tool_input_schema_hash": "4f5f4fad7c2c7a3b203c164558e12787d9e326eea60c41c0a4d6030080654b9d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "ID of the branded link to validate"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_DEFAULT_BRANDED_LINK",
+    "description": "Retrieve the default branded link. Returns the default branded link if one exists.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DEFAULT_BRANDED_LINK",
+      "canonical_tool_description_hash": "f67cae1d4781224a730c98dd5292e22453076486650288e725e49d6d328377ab",
+      "canonical_tool_input_schema_hash": "3b7f810b0e98baf3bd4c78d067a17ffaea4368931b5aad4aa84f2f52b5e52ba8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "domain": {
+              "type": "string",
+              "description": "The domain to find a default branded link for"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_BRANDED_LINK",
+    "description": "Retrieve a specific branded link by ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_BRANDED_LINK",
+      "canonical_tool_description_hash": "124e4fcc3d11bc4bda7dec9718de379a02fd2e1e04e2034e26e04080dddd5c8f",
+      "canonical_tool_input_schema_hash": "cc54fe3a67a8c5d66914192a55859c7a0ecfe81797693a96ef9c35dde0a3a5b9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "ID of the branded link to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__UPDATE_BRANDED_LINK",
+    "description": "Update a branded link.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_BRANDED_LINK",
+      "canonical_tool_description_hash": "588db684d24bef8a9584520933134a44f88498811b7ddcea74736dee900e5c2f",
+      "canonical_tool_input_schema_hash": "0f2a90f210029e0bf0f91376a477d291a836b439380d63ce7f69f64ef0edbae5"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "default": {
+              "type": "boolean",
+              "description": "Whether this should be the default branded link"
+            }
+          },
+          "description": "Update settings for the branded link",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "ID of the branded link to update"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__DELETE_BRANDED_LINK",
+    "description": "Delete a branded link.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_BRANDED_LINK",
+      "canonical_tool_description_hash": "ecd3cef16647cf8d9b477fbdcc0266f41a24d9da9be663502211907bf5ea8373",
+      "canonical_tool_input_schema_hash": "6bfdb26e050047261743dd1cc1b4c0dad1010381711fab2f52565dbd260b4cfe"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "ID of the branded link to delete"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__CREATE_VERIFIED_SENDER",
+    "description": "Create a new verified sender identity for your SendGrid account.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_VERIFIED_SENDER",
+      "canonical_tool_description_hash": "8f41bfa1aaf0c3d640695465ceb9997d0d8caa6f971d207f0b4bae0a60500b1b",
+      "canonical_tool_input_schema_hash": "10f041aa73abff7af2c5234987a58cbd174969af6be909c268a23ea73d65a119"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["from_email", "from_name", "address", "city", "country"],
+          "properties": {
+            "zip": {
+              "type": "string",
+              "description": "The zip/postal code of the sender"
+            },
+            "city": {
+              "type": "string",
+              "description": "The city of the sender"
+            },
+            "state": {
+              "type": "string",
+              "description": "The state/province of the sender"
+            },
+            "address": {
+              "type": "string",
+              "description": "The physical address of the sender"
+            },
+            "country": {
+              "type": "string",
+              "description": "The country of the sender"
+            },
+            "address2": {
+              "type": "string",
+              "description": "Additional address information"
+            },
+            "nickname": {
+              "type": "string",
+              "description": "A nickname for the sender identity"
+            },
+            "reply_to": {
+              "type": "string",
+              "format": "email",
+              "description": "The reply-to email address"
+            },
+            "from_name": {
+              "type": "string",
+              "description": "The name to be associated with the sender"
+            },
+            "from_email": {
+              "type": "string",
+              "format": "email",
+              "description": "The email address to be verified"
+            },
+            "reply_to_name": {
+              "type": "string",
+              "description": "The name associated with the reply-to address"
+            }
+          },
+          "description": "Verified sender details",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_ALL_VERIFIED_SENDERS",
+    "description": "Retrieve all verified senders for your account.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ALL_VERIFIED_SENDERS",
+      "canonical_tool_description_hash": "2b498243d359561fc3642209b950e4cd138284ca42b1a2655d24861c8a91bed4",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__EDIT_VERIFIED_SENDER",
+    "description": "Update the details of a verified sender.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EDIT_VERIFIED_SENDER",
+      "canonical_tool_description_hash": "fcbf27234336d8848f5ba673218c2056ed8ef1dc857e8249b58eaee5ddba2ae7",
+      "canonical_tool_input_schema_hash": "b040b20a95d8d8363e40837b1092165a47e76a57816f0abbb36dc1532f2581fa"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["from_name", "address", "city", "country"],
+          "properties": {
+            "zip": {
+              "type": "string",
+              "description": "The zip/postal code of the sender"
+            },
+            "city": {
+              "type": "string",
+              "description": "The city of the sender"
+            },
+            "state": {
+              "type": "string",
+              "description": "The state/province of the sender"
+            },
+            "address": {
+              "type": "string",
+              "description": "The physical address of the sender"
+            },
+            "country": {
+              "type": "string",
+              "description": "The country of the sender"
+            },
+            "address2": {
+              "type": "string",
+              "description": "Additional address information"
+            },
+            "nickname": {
+              "type": "string",
+              "description": "A nickname for the sender identity"
+            },
+            "reply_to": {
+              "type": "string",
+              "format": "email",
+              "description": "The reply-to email address"
+            },
+            "from_name": {
+              "type": "string",
+              "description": "The name to be associated with the sender"
+            },
+            "reply_to_name": {
+              "type": "string",
+              "description": "The name associated with the reply-to address"
+            }
+          },
+          "description": "Updated sender details",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["sender_id"],
+          "properties": {
+            "sender_id": {
+              "type": "integer",
+              "description": "ID of the sender identity to update"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__DELETE_VERIFIED_SENDER",
+    "description": "Delete a verified sender identity.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_VERIFIED_SENDER",
+      "canonical_tool_description_hash": "feabbf2f4c6e15b0a2ea85ca69c827c6a95c4daa09a086f0974bb108c313fad1",
+      "canonical_tool_input_schema_hash": "836a45d08581b3020989b8e6cf9d843569c8384aa42e9c1f77b8f1f183d81c65"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["sender_id"],
+          "properties": {
+            "sender_id": {
+              "type": "integer",
+              "description": "ID of the sender identity to delete"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_COMPLETED_STEPS",
+    "description": "Get the completed verification steps for a sender identity.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_COMPLETED_STEPS",
+      "canonical_tool_description_hash": "1c6348b82843f2d9967ea58795aaa1617f637b19bb054ad9c7e5f5d510e9001d",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_DOMAIN_WARN_LIST",
+    "description": "Get a list of domains known to implement DMARC.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DOMAIN_WARN_LIST",
+      "canonical_tool_description_hash": "34897b8749ebdff8b8f260ebddb09ca395d7dec5485ad7ee9c7f1d7d29db45e4",
+      "canonical_tool_input_schema_hash": "4280414c80f90390d347f9564f450c84270740735a4ff084658ac93d39f9f39d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["domain"],
+          "properties": {
+            "domain": {
+              "type": "string",
+              "description": "Domain to check against the warn list"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_ENGAGEMENT_QUALITY_SCORES",
+    "description": "Retrieve SendGrid Engagement Quality (SEQ) scores for a specified date range. SEQ scores indicate the quality of your email program based on factors like engagement recency, open rates, bounce rates, and spam rates. Scores range from 1 to 5, with higher numbers representing better engagement quality. To receive scores, you must have open tracking enabled and send at least 1,000 messages during the previous 30 days.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ENGAGEMENT_QUALITY_SCORES",
+      "canonical_tool_description_hash": "3b1a1e6acb0a918509d8354a81a3b6e2db6e334d3f2fd353f340f0f357520d78",
+      "canonical_tool_input_schema_hash": "7e6246c3b94d4a5eba3fb0ae3c7ac53b4660523d385c6a5a44bb442b8857527f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["from", "to"],
+          "properties": {
+            "to": {
+              "type": "string",
+              "format": "date",
+              "description": "The ending date in YYYY-MM-DD format (UTC) for which you want to retrieve scores"
+            },
+            "from": {
+              "type": "string",
+              "format": "date",
+              "description": "The starting date in YYYY-MM-DD format (UTC) for which you want to retrieve scores"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_SUBUSERS_ENGAGEMENT_QUALITY_SCORES",
+    "description": "Retrieve SendGrid Engagement Quality (SEQ) scores for your Subusers or customer accounts for a specific date. SEQ scores indicate the quality of your email program based on factors like engagement recency, open rates, bounce rates, and spam rates. Scores range from 1 to 5, with higher numbers representing better engagement quality.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SUBUSERS_ENGAGEMENT_QUALITY_SCORES",
+      "canonical_tool_description_hash": "01a63315a51bd78c2a78c32abe662f5bf8f8b79f894ba8515af251249f2d5156",
+      "canonical_tool_input_schema_hash": "861324b6ae611ea0125c0740760381d49f68d5118961ab0198c78dc3328ce25b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["date"],
+          "properties": {
+            "date": {
+              "type": "string",
+              "format": "date",
+              "description": "The date in YYYY-MM-DD format (UTC) for which you want to retrieve a SendGrid Engagement Quality score"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 0,
+              "description": "Specifies the number of results to be returned by the API. Can be used to limit results or with after_key for pagination."
+            },
+            "after_key": {
+              "type": "string",
+              "description": "Specifies which items to be returned by the API. Used with limit for pagination. Value should be the after_key from the previous response."
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__CREATE_DESIGN",
+    "description": "Create a new design in the SendGrid Design Library",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_DESIGN",
+      "canonical_tool_description_hash": "e589b45f1b65e33fc4c9d50227d0a5090784bb4dbc5859998f33c702f1b7005d",
+      "canonical_tool_input_schema_hash": "def3467a59a8b05a782f9635330f5d4493060e1cdf3b621da8b25a6b0ffc07df"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the design"
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Categories to associate with the design"
+            },
+            "html_content": {
+              "type": "string",
+              "description": "HTML content of the design"
+            },
+            "plain_content": {
+              "type": "string",
+              "description": "Plain text content of the design"
+            },
+            "generate_plain_content": {
+              "type": "boolean",
+              "description": "Whether to automatically generate plain content from HTML"
+            }
+          },
+          "description": "Design configuration",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__DUPLICATE_DESIGN",
+    "description": "Duplicate an existing design in the SendGrid Design Library",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DUPLICATE_DESIGN",
+      "canonical_tool_description_hash": "8da3f4914d87f88b5bcdc19fcdec44f5f66b46bce3500bec986ef538a6bbb728",
+      "canonical_tool_input_schema_hash": "cf468daae06c69d38e59a14d0fda3e8acc6cd37b53ac6e5c0f522432b6508a86"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name for the duplicated design"
+            },
+            "editor": {
+              "enum": ["design", "code"],
+              "type": "string",
+              "description": "Editor type (design or code)"
+            }
+          },
+          "description": "Duplicate design options",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the design to duplicate"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_DESIGN",
+    "description": "Retrieve a specific design from the SendGrid Design Library",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DESIGN",
+      "canonical_tool_description_hash": "f525e5459388b095762cb1ead278c5523ed990d3e87bbd61a6b1f2a8b2fab8f9",
+      "canonical_tool_input_schema_hash": "fc07730a167233adda1d11664a06d18c1ce7072eb8335000d65a67b3b82f8d16"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the design to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_CLICK_TRACKING_SETTINGS",
+    "description": "Retrieve click tracking settings for your SendGrid account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CLICK_TRACKING_SETTINGS",
+      "canonical_tool_description_hash": "e41e3d9ad9c121c6ee29d3c03e806f6ee656983c77d3577ea5f0a3b290f80055",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__LIST_DESIGNS",
+    "description": "List all designs in the SendGrid Design Library",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_DESIGNS",
+      "canonical_tool_description_hash": "b56b2d38d26f7288d05ec7b7c42054c2edc3cd4b9ef04aaf61d82f13234aab19",
+      "canonical_tool_input_schema_hash": "3528b62b7f7b1fef6e589840f3eda488c1a70a58a5e0bdbe3c7bc551dbee6b8b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "summary": {
+              "type": "boolean",
+              "description": "Whether to return only summary information"
+            },
+            "page_size": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of results to return per page"
+            },
+            "page_token": {
+              "type": "string",
+              "description": "Token for pagination"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__UPDATE_DESIGN",
+    "description": "Update an existing design in the SendGrid Design Library",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_DESIGN",
+      "canonical_tool_description_hash": "40a7ff38f1f7f42efeb18e9cc5286e3012eb2f4b2538d89040d226ee1f5cf21a",
+      "canonical_tool_input_schema_hash": "694bf57f33e6f8acda50eb7ac320b2e01b7744b2a5d3ba0961c0e55397c7e648"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "New name for the design"
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Updated categories"
+            },
+            "html_content": {
+              "type": "string",
+              "description": "Updated HTML content"
+            },
+            "plain_content": {
+              "type": "string",
+              "description": "Updated plain text content"
+            },
+            "generate_plain_content": {
+              "type": "boolean",
+              "description": "Whether to automatically generate plain content from HTML"
+            }
+          },
+          "description": "Updated design properties",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the design to update"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__DUPLICATE_PREBUILT_DESIGN",
+    "description": "Duplicate a SendGrid pre-built design template",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DUPLICATE_PREBUILT_DESIGN",
+      "canonical_tool_description_hash": "838208fefc352276c685bc45a26b910ec840dc6df0c24d0e7d548e1fe3a7f17a",
+      "canonical_tool_input_schema_hash": "21912c1c6cd4238cc6dcd9450cbe41e500e35892015dcb0572858cecd8183b24"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name for the duplicated design"
+            },
+            "editor": {
+              "enum": ["design", "code"],
+              "type": "string",
+              "description": "Editor type (design or code)"
+            }
+          },
+          "description": "Duplication options",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the pre-built design to duplicate"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_PREBUILT_DESIGN",
+    "description": "Retrieve a SendGrid pre-built design template",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PREBUILT_DESIGN",
+      "canonical_tool_description_hash": "a2ef4e11bef35119194107bb3ae009d87ad926d858850eb4f50b899e6fac25d8",
+      "canonical_tool_input_schema_hash": "5a318fc92960c663855f227976d499792bc501370ae35a9695d2d5d4cf36c24f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the pre-built design to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__LIST_PREBUILT_DESIGNS",
+    "description": "List all SendGrid pre-built design templates",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_PREBUILT_DESIGNS",
+      "canonical_tool_description_hash": "b267e7ea52b51783c2ecba14137a4209bf4e699fa19b54602c0705e7549df7f4",
+      "canonical_tool_input_schema_hash": "6ac01b87de15fc02400e92aee8c1e6f147e551538222fb107ba3f95ee09cb75b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "page_size": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of results to return per page"
+            },
+            "page_token": {
+              "type": "string",
+              "description": "Token for pagination"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__DELETE_DESIGN",
+    "description": "Delete a design from the SendGrid Design Library",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_DESIGN",
+      "canonical_tool_description_hash": "5b4f9316b5ba91d0ec5193290d48d76bf4983d9fcdcdfdaccf7f3d51306ee67f",
+      "canonical_tool_input_schema_hash": "68e18aa559ba4498dee48f70d26d5d8fe6743fe37870f9dafda6832018b15ff2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the design to delete"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_TRACKING_SETTINGS",
+    "description": "Retrieve all tracking settings for your SendGrid account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_TRACKING_SETTINGS",
+      "canonical_tool_description_hash": "521a1d862752aaf0607258854a2641d7fc418559094d0ba9716a8f6361331ef1",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__UPDATE_CLICK_TRACKING_SETTINGS",
+    "description": "Update click tracking settings for your SendGrid account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_CLICK_TRACKING_SETTINGS",
+      "canonical_tool_description_hash": "1dac0e736d244a3b898a88bb50f57a513558c72bf4aa948f7240c30762a04d95",
+      "canonical_tool_input_schema_hash": "85d93a0726b43747fe0cda5f361726154c6f8656f9bd229de0c2092667677590"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Indicates if click tracking is enabled"
+            }
+          },
+          "description": "Click tracking settings",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_GOOGLE_ANALYTICS_SETTINGS",
+    "description": "Retrieve Google Analytics settings for your SendGrid account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_GOOGLE_ANALYTICS_SETTINGS",
+      "canonical_tool_description_hash": "5229b9ab02c0734c57348d6f6b33f136e243452e5da847c99ca2f7377016ccf4",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__UPDATE_GOOGLE_ANALYTICS_SETTINGS",
+    "description": "Update Google Analytics settings for your SendGrid account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_GOOGLE_ANALYTICS_SETTINGS",
+      "canonical_tool_description_hash": "c76afda7f6dfd6081240663fe8d63e63179bbf3ec98710dc1fb144e78acfbd8e",
+      "canonical_tool_input_schema_hash": "fb4c9beb690a2d06314a5ab7b74f869fbfb6d105f3f1b11630c46b629dd1f7b4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Indicates if Google Analytics tracking is enabled"
+            },
+            "utm_term": {
+              "type": "string",
+              "description": "Identify paid keywords"
+            },
+            "utm_medium": {
+              "type": "string",
+              "description": "Name of the marketing medium"
+            },
+            "utm_source": {
+              "type": "string",
+              "description": "Name of the referrer source"
+            },
+            "utm_content": {
+              "type": "string",
+              "description": "Use to differentiate ads"
+            },
+            "utm_campaign": {
+              "type": "string",
+              "description": "Name of the campaign"
+            }
+          },
+          "description": "Google Analytics settings",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_OPEN_TRACKING_SETTINGS",
+    "description": "Retrieve open tracking settings for your SendGrid account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_OPEN_TRACKING_SETTINGS",
+      "canonical_tool_description_hash": "ce53d40d2ff27ae28a8d5503b2df056dc9fe2ac522f21c284e8333810977c232",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__UPDATE_OPEN_TRACKING_SETTINGS",
+    "description": "Update open tracking settings for your SendGrid account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_OPEN_TRACKING_SETTINGS",
+      "canonical_tool_description_hash": "dd5071069075534e36dddb8a7a69e59b76171d144d786b3db61337c5dc05969e",
+      "canonical_tool_input_schema_hash": "852e31fec96af0a8677c5e9d37f5584a74aff7b9183471ae66b6caec53a767fc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Indicates if open tracking is enabled"
+            }
+          },
+          "description": "Open tracking settings",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_SUBSCRIPTION_TRACKING_SETTINGS",
+    "description": "Retrieve subscription tracking settings for your SendGrid account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SUBSCRIPTION_TRACKING_SETTINGS",
+      "canonical_tool_description_hash": "f5b3c13235de87168d8abeda7f4149510e6c4b7f07ae7505631dc6891451963f",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__UPDATE_SUBSCRIPTION_TRACKING_SETTINGS",
+    "description": "Update subscription tracking settings for your SendGrid account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_SUBSCRIPTION_TRACKING_SETTINGS",
+      "canonical_tool_description_hash": "f2963749df3783f9ba636d05b81ac289f14681f2ec34fa2a81f8c2e4fb8e80ad",
+      "canonical_tool_input_schema_hash": "ecf07c9fd50e96c64aeecdc779c7ae1194a771d0f962fba5da3e2207400553f9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL that allows a recipient to unsubscribe"
+            },
+            "enabled": {
+              "type": "boolean",
+              "description": "Indicates if subscription tracking is enabled"
+            },
+            "landing": {
+              "type": "string",
+              "description": "URL of the landing page where users are sent after unsubscribing"
+            },
+            "replace": {
+              "type": "string",
+              "description": "Text to be replaced with the unsubscribe link"
+            },
+            "html_content": {
+              "type": "string",
+              "description": "HTML content of the unsubscribe link"
+            },
+            "text_content": {
+              "type": "string",
+              "description": "Text content of the unsubscribe link"
+            }
+          },
+          "description": "Subscription tracking settings",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_GLOBAL_STATS",
+    "description": "Retrieve global email statistics for your SendGrid account. Returns statistics about your email activity including requests, deliveries, opens, clicks, bounces, spam reports, and more.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_GLOBAL_STATS",
+      "canonical_tool_description_hash": "2728aa1fcd89e90679c244210ee72e2292426a65872222c4afcda599443a8b7c",
+      "canonical_tool_input_schema_hash": "bd386feee0ca971535b9ec677030b196d524e1894222a239a30dadcca2a1d912"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["start_date"],
+          "properties": {
+            "end_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The end date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "start_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The starting date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "aggregated_by": {
+              "enum": ["day", "week", "month"],
+              "type": "string",
+              "description": "How to group the statistics (day, week, or month)"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_BROWSER_STATS",
+    "description": "Retrieve email statistics by browser. Returns statistics about email activity broken down by browser (Chrome, Firefox, etc.).",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_BROWSER_STATS",
+      "canonical_tool_description_hash": "4e7e01bbff438141400a08615fa7648db3b4b865c70621a02235dc426c034dca",
+      "canonical_tool_input_schema_hash": "bd386feee0ca971535b9ec677030b196d524e1894222a239a30dadcca2a1d912"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["start_date"],
+          "properties": {
+            "end_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The end date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "start_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The starting date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "aggregated_by": {
+              "enum": ["day", "week", "month"],
+              "type": "string",
+              "description": "How to group the statistics (day, week, or month)"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_CLIENT_TYPE_STATS",
+    "description": "Retrieve email statistics by specific client type (e.g., phone). Returns statistics about email activity broken down by client type.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CLIENT_TYPE_STATS",
+      "canonical_tool_description_hash": "5e07e0dd28a9b9a76f759c5070646da5388a4e0e37905e2f6cea58b527d729d3",
+      "canonical_tool_input_schema_hash": "cc42088e0bf50ce8361943d07159357d1e45ac0a4c22b896566be3a11e597db3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["client_type"],
+          "properties": {
+            "client_type": {
+              "enum": ["phone", "webmail", "desktop"],
+              "type": "string",
+              "description": "The type of client to get statistics for (e.g., phone, webmail, desktop)"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["start_date"],
+          "properties": {
+            "end_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The end date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "start_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The starting date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "aggregated_by": {
+              "enum": ["day", "week", "month"],
+              "type": "string",
+              "description": "How to group the statistics (day, week, or month)"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_CLIENTS_STATS",
+    "description": "Retrieve email statistics by all client types. Returns statistics about email activity broken down by all client types.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CLIENTS_STATS",
+      "canonical_tool_description_hash": "9cf26592bcf295db3df997bfc4d65358ad3df5b7484f99c39ab43726330597ff",
+      "canonical_tool_input_schema_hash": "bd386feee0ca971535b9ec677030b196d524e1894222a239a30dadcca2a1d912"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["start_date"],
+          "properties": {
+            "end_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The end date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "start_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The starting date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "aggregated_by": {
+              "enum": ["day", "week", "month"],
+              "type": "string",
+              "description": "How to group the statistics (day, week, or month)"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_GEO_STATS",
+    "description": "Retrieve email statistics by geographical location (country and state/province). Returns statistics about email activity broken down by geographic location.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_GEO_STATS",
+      "canonical_tool_description_hash": "76a1b66e89e295ba4a70ceae57c16a43eb3fbd38658a589c18896362609acad7",
+      "canonical_tool_input_schema_hash": "bd386feee0ca971535b9ec677030b196d524e1894222a239a30dadcca2a1d912"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["start_date"],
+          "properties": {
+            "end_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The end date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "start_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The starting date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "aggregated_by": {
+              "enum": ["day", "week", "month"],
+              "type": "string",
+              "description": "How to group the statistics (day, week, or month)"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_DEVICES_STATS",
+    "description": "Retrieve email statistics by device type. Returns statistics about email activity broken down by device type (desktop, mobile, etc.).",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DEVICES_STATS",
+      "canonical_tool_description_hash": "92126f1f969b59270f3b6909fa91136e3ebba5bc746c3ef529425a67a616fb38",
+      "canonical_tool_input_schema_hash": "bd386feee0ca971535b9ec677030b196d524e1894222a239a30dadcca2a1d912"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["start_date"],
+          "properties": {
+            "end_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The end date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "start_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The starting date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "aggregated_by": {
+              "enum": ["day", "week", "month"],
+              "type": "string",
+              "description": "How to group the statistics (day, week, or month)"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_MAILBOX_PROVIDERS_STATS",
+    "description": "Retrieve email statistics by mailbox provider. Returns statistics about email activity broken down by recipient's mailbox provider (Gmail, Yahoo, etc.).",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_MAILBOX_PROVIDERS_STATS",
+      "canonical_tool_description_hash": "68988e83f7367d1e0d5bcf1234d75bbfc2377cc6a28f4a249d0ba2487aa4f9ab",
+      "canonical_tool_input_schema_hash": "bd386feee0ca971535b9ec677030b196d524e1894222a239a30dadcca2a1d912"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["start_date"],
+          "properties": {
+            "end_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The end date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "start_date": {
+              "type": "string",
+              "format": "date",
+              "description": "The starting date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "aggregated_by": {
+              "enum": ["day", "week", "month"],
+              "type": "string",
+              "description": "How to group the statistics (day, week, or month)"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__CREATE_EVENT_WEBHOOK",
+    "description": "Create a new event webhook to receive real-time event notifications from SendGrid",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_EVENT_WEBHOOK",
+      "canonical_tool_description_hash": "6830de41839b746456d1e13122980b9d2edfebc37d822a4f0138e0f77d07becb",
+      "canonical_tool_input_schema_hash": "2237e52fbcefbf594d2287cad004506d389e03efccb843cd8160b0858f0bdf9c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["enabled", "url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL to receive webhook notifications"
+            },
+            "open": {
+              "type": "boolean",
+              "description": "Receive open events"
+            },
+            "click": {
+              "type": "boolean",
+              "description": "Receive click events"
+            },
+            "bounce": {
+              "type": "boolean",
+              "description": "Receive bounce events"
+            },
+            "dropped": {
+              "type": "boolean",
+              "description": "Receive dropped email events"
+            },
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable/disable the webhook"
+            },
+            "deferred": {
+              "type": "boolean",
+              "description": "Receive deferred email events"
+            },
+            "delivered": {
+              "type": "boolean",
+              "description": "Receive delivered email events"
+            },
+            "processed": {
+              "type": "boolean",
+              "description": "Receive processed email events"
+            },
+            "spam_report": {
+              "type": "boolean",
+              "description": "Receive spam report events"
+            },
+            "unsubscribe": {
+              "type": "boolean",
+              "description": "Receive unsubscribe events"
+            },
+            "group_resubscribe": {
+              "type": "boolean",
+              "description": "Receive group resubscribe events"
+            },
+            "group_unsubscribe": {
+              "type": "boolean",
+              "description": "Receive group unsubscribe events"
+            }
+          },
+          "description": "Event webhook configuration",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__TEST_EVENT_WEBHOOK",
+    "description": "Test event notification settings by sending a test event to your webhook URL",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TEST_EVENT_WEBHOOK",
+      "canonical_tool_description_hash": "70c991adee46baf79ab7c5cf3a03a6eb7097aec2af372dc6e6a02153a00c53a6",
+      "canonical_tool_input_schema_hash": "c823df4ed2a169c413a3e9f5cd56faf3a0e2dcae2b36ab89bed73090ff4b573c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL to test webhook notifications"
+            }
+          },
+          "description": "Test webhook configuration",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_EVENT_WEBHOOK_SETTINGS",
+    "description": "Retrieve current event webhook settings",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_EVENT_WEBHOOK_SETTINGS",
+      "canonical_tool_description_hash": "839842a529059ce63371d776979a127f3b5cf6bbbda0544b4e6864474c081898",
+      "canonical_tool_input_schema_hash": "cdfcc9aa1eb3c67c7a2a57901497bafc3c168b33612dd726c415ed8e50c28ba4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the event webhook to retrieve settings for"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__UPDATE_EVENT_WEBHOOK_SETTINGS",
+    "description": "Update event webhook settings",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_EVENT_WEBHOOK_SETTINGS",
+      "canonical_tool_description_hash": "afc0d899b372ba7a2a2d13270199f5310c090fbd92dabc4520a8b4ab5c0af074",
+      "canonical_tool_input_schema_hash": "9894ca99b146adfc79925d31dbfd62261973d03cc1493110c04f2113bac1180e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["enabled", "url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL to receive webhook notifications"
+            },
+            "open": {
+              "type": "boolean",
+              "description": "Receive open events"
+            },
+            "click": {
+              "type": "boolean",
+              "description": "Receive click events"
+            },
+            "bounce": {
+              "type": "boolean",
+              "description": "Receive bounce events"
+            },
+            "dropped": {
+              "type": "boolean",
+              "description": "Receive dropped email events"
+            },
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable/disable the webhook"
+            },
+            "deferred": {
+              "type": "boolean",
+              "description": "Receive deferred email events"
+            },
+            "delivered": {
+              "type": "boolean",
+              "description": "Receive delivered email events"
+            },
+            "processed": {
+              "type": "boolean",
+              "description": "Receive processed email events"
+            },
+            "spam_report": {
+              "type": "boolean",
+              "description": "Receive spam report events"
+            },
+            "unsubscribe": {
+              "type": "boolean",
+              "description": "Receive unsubscribe events"
+            },
+            "group_resubscribe": {
+              "type": "boolean",
+              "description": "Receive group resubscribe events"
+            },
+            "group_unsubscribe": {
+              "type": "boolean",
+              "description": "Receive group unsubscribe events"
+            }
+          },
+          "description": "Updated webhook settings",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the webhook to update"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__DELETE_EVENT_WEBHOOK",
+    "description": "Delete the event webhook",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_EVENT_WEBHOOK",
+      "canonical_tool_description_hash": "fb0eca8a8bf90f866aa4e1ce2ca84b65db58fc6f4b9d1a972ddec3d51ec38986",
+      "canonical_tool_input_schema_hash": "b9efc761ca9380ea98f3018e1249310b3479876b10eb72bf476e6a14710e51ca"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the webhook to delete"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__TOGGLE_SIGNATURE_VERIFICATION",
+    "description": "Toggle signature verification for event webhook",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "TOGGLE_SIGNATURE_VERIFICATION",
+      "canonical_tool_description_hash": "ed13cd3aa1f732932364fbeed1b392433ff98afbbb68451641182b9752e50802",
+      "canonical_tool_input_schema_hash": "355e0279551b73e4d3570d503d84122a8d10eb0cc8410ab8b110fb942b6d6919"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable/disable signature verification"
+            }
+          },
+          "description": "Signature verification settings",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the webhook to toggle signature verification for"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_SIGNED_WEBHOOK_PUBLIC_KEY",
+    "description": "Retrieve the public key for signed event webhook verification",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SIGNED_WEBHOOK_PUBLIC_KEY",
+      "canonical_tool_description_hash": "02f8158a3e7001b0543fa44924a13b6aeb518045045a364c2cb700dfe9df2d23",
+      "canonical_tool_input_schema_hash": "e565575044d25110bfc5de6ed7ef84b74c11456a4999470b1398785319a1c7fe"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of the signed webhook to get public key for"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_PARSE_WEBHOOK_SETTINGS",
+    "description": "Retrieve Parse Webhook settings",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PARSE_WEBHOOK_SETTINGS",
+      "canonical_tool_description_hash": "057f1a14fb6c8ee49e119978b38b29cd851d50cea84162b6cd937a62f07573a9",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_PARSE_WEBHOOK_STATS",
+    "description": "Retrieve Inbound Parse Webhook statistics",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PARSE_WEBHOOK_STATS",
+      "canonical_tool_description_hash": "e893f72c0a4504622b3a0a1a5b5e9d8c2bd8e78ea1ab2c0a2c95e775757740fb",
+      "canonical_tool_input_schema_hash": "923ed294d83e995e6e2432d99896327cedb86da7dce744d44c95fb5d13b081b4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["start_date"],
+          "properties": {
+            "end_date": {
+              "type": "string",
+              "description": "The end date of the statistics to retrieve (YYYY-MM-DD)"
+            },
+            "start_date": {
+              "type": "string",
+              "description": "The starting date of the statistics to retrieve (YYYY-MM-DD)"
+            }
+          },
+          "description": "Query parameters for statistics",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_ALL_EVENT_WEBHOOKS",
+    "description": "Retrieve all event webhooks configured for your account",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ALL_EVENT_WEBHOOKS",
+      "canonical_tool_description_hash": "85ba7407262497264f2e096205992602a599fd0dda3eab880ee9887de1b22b5c",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__CREATE_PARSE_WEBHOOK",
+    "description": "Create a new parse webhook setting for inbound email parsing",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_PARSE_WEBHOOK",
+      "canonical_tool_description_hash": "bdbbf42eaf551c4cd0c15afa1299ed2de3287365045199741d3f49c91c79b339",
+      "canonical_tool_input_schema_hash": "e1a18f5e1b6daf1e61e6e6e0e88ab702b76a945ffb5d7508a26367e97d5112ed"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["url", "hostname"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The URL that you would like your parsed data to be POSTed to"
+            },
+            "hostname": {
+              "type": "string",
+              "description": "The domain that will receive the emails to be parsed"
+            },
+            "send_raw": {
+              "type": "boolean",
+              "description": "Whether to send the raw email content in the webhook POST"
+            },
+            "spam_check": {
+              "type": "boolean",
+              "description": "Whether to check incoming emails for spam"
+            }
+          },
+          "description": "Parse webhook settings",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__LIST_PARSE_WEBHOOKS",
+    "description": "Retrieve all parse webhook settings",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_PARSE_WEBHOOKS",
+      "canonical_tool_description_hash": "0b0b525093f4cad1900a67755135c2c155706b5d66d46cbde9e5530fbc699536",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__GET_PARSE_WEBHOOK",
+    "description": "Retrieve a specific parse webhook setting by hostname",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PARSE_WEBHOOK",
+      "canonical_tool_description_hash": "b5af8d601580180db31f9f241ccd4ac159d6f1a61bfbe666c2eb1c3d73d6c571",
+      "canonical_tool_input_schema_hash": "1688ff05aeb3deef22a5a714d353387732af15e2963d8c376ffd166f7b41a800"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["hostname"],
+          "properties": {
+            "hostname": {
+              "type": "string",
+              "description": "The hostname of the parse webhook setting to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__UPDATE_PARSE_WEBHOOK",
+    "description": "Update a specific parse webhook setting",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_PARSE_WEBHOOK",
+      "canonical_tool_description_hash": "d378458cbc5d6703396d80a36aa4557137df78f1828c1a0dc69d94540906f990",
+      "canonical_tool_input_schema_hash": "ad2214eddca41ed0344118d7e0941d4758fbc8a5135ce94c487eeebc60935af0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The new URL that you would like your parsed data to be POSTed to"
+            },
+            "send_raw": {
+              "type": "boolean",
+              "description": "Whether to send the raw email content in the webhook POST"
+            },
+            "spam_check": {
+              "type": "boolean",
+              "description": "Whether to check incoming emails for spam"
+            }
+          },
+          "description": "Updated parse webhook settings",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["hostname"],
+          "properties": {
+            "hostname": {
+              "type": "string",
+              "description": "The hostname of the parse webhook setting to update"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SENDGRID__DELETE_PARSE_WEBHOOK",
+    "description": "Delete a specific parse webhook setting",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_PARSE_WEBHOOK",
+      "canonical_tool_description_hash": "022274532dbb08199847bba5eb24f20dc2dbe0ce0ff227c105eac7934ec0f78d",
+      "canonical_tool_input_schema_hash": "13e1aa39d638f66bb84541559ca806bee97dfbb11b3a6775513c0ed36ceffd94"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["hostname"],
+          "properties": {
+            "hostname": {
+              "type": "string",
+              "description": "The hostname of the parse webhook setting to delete"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/sentry/tools.json
+++ b/backend/mcp_servers/sentry/tools.json
@@ -52,9 +52,7 @@
           "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
         }
       },
-      "required": [
-        "organizationSlug"
-      ],
+      "required": ["organizationSlug"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -80,9 +78,7 @@
           "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
         }
       },
-      "required": [
-        "organizationSlug"
-      ],
+      "required": ["organizationSlug"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -116,9 +112,7 @@
           "description": "Search for versions which contain the provided string."
         }
       },
-      "required": [
-        "organizationSlug"
-      ],
+      "required": ["organizationSlug"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -187,10 +181,7 @@
           "description": "The trace ID. e.g. `a4d1aae7216b47ff8117cf4e09ce9d0a`"
         }
       },
-      "required": [
-        "organizationSlug",
-        "traceId"
-      ],
+      "required": ["organizationSlug", "traceId"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -228,11 +219,7 @@
           "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
         }
       },
-      "required": [
-        "organizationSlug",
-        "projectSlug",
-        "eventId"
-      ],
+      "required": ["organizationSlug", "projectSlug", "eventId"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -268,12 +255,7 @@
         },
         "status": {
           "type": "string",
-          "enum": [
-            "resolved",
-            "resolvedInNextRelease",
-            "unresolved",
-            "ignored"
-          ],
+          "enum": ["resolved", "resolvedInNextRelease", "unresolved", "ignored"],
           "description": "The new status for the issue. Valid values are 'resolved', 'resolvedInNextRelease', 'unresolved', and 'ignored'."
         },
         "assignedTo": {
@@ -327,10 +309,7 @@
           "description": "Include explanation of how the query was translated"
         }
       },
-      "required": [
-        "organizationSlug",
-        "naturalLanguageQuery"
-      ],
+      "required": ["organizationSlug", "naturalLanguageQuery"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -360,10 +339,7 @@
           "description": "The name of the team to create."
         }
       },
-      "required": [
-        "organizationSlug",
-        "name"
-      ],
+      "required": ["organizationSlug", "name"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -401,11 +377,7 @@
           "description": "The platform for the project. e.g., python, javascript, react, etc."
         }
       },
-      "required": [
-        "organizationSlug",
-        "teamSlug",
-        "name"
-      ],
+      "required": ["organizationSlug", "teamSlug", "name"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -451,10 +423,7 @@
           "description": "The team to assign this project to. Note: this will replace the current team assignment."
         }
       },
-      "required": [
-        "organizationSlug",
-        "projectSlug"
-      ],
+      "required": ["organizationSlug", "projectSlug"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -488,11 +457,7 @@
           "description": "The name of the DSN to create, for example 'Production'."
         }
       },
-      "required": [
-        "organizationSlug",
-        "projectSlug",
-        "name"
-      ],
+      "required": ["organizationSlug", "projectSlug", "name"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -522,10 +487,7 @@
           "description": "The project's slug. You can find a list of existing projects in an organization using the `find_projects()` tool."
         }
       },
-      "required": [
-        "organizationSlug",
-        "projectSlug"
-      ],
+      "required": ["organizationSlug", "projectSlug"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -726,9 +688,7 @@
           "description": "Optional guide filter to limit search results to specific documentation sections. Use either a platform (e.g., 'javascript', 'python') or platform/guide combination (e.g., 'javascript/nextjs', 'python/django')."
         }
       },
-      "required": [
-        "query"
-      ],
+      "required": ["query"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -750,9 +710,7 @@
           "description": "The documentation path (e.g., '/platforms/javascript/guides/nextjs.md'). Get this from search_docs results."
         }
       },
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
@@ -799,10 +757,7 @@
           "description": "Include explanation of how the query was translated"
         }
       },
-      "required": [
-        "organizationSlug",
-        "naturalLanguageQuery"
-      ],
+      "required": ["organizationSlug", "naturalLanguageQuery"],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }

--- a/backend/mcp_servers/serpapi/tools.json
+++ b/backend/mcp_servers/serpapi/tools.json
@@ -1,0 +1,495 @@
+[
+  {
+    "name": "SERPAPI__GOOGLE_SEARCH",
+    "description": "Perform web searches using Google Search API",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GOOGLE_SEARCH",
+      "canonical_tool_description_hash": "5123e60c622f9fb3f707c27612aa908d670415e1aafd073ee262ecd8c2ead4e5",
+      "canonical_tool_input_schema_hash": "643aa110a9f5adaad92aba789b39f14646a467831dd80d7e58c9f5aff06e7f3f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["engine", "q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "Search query"
+            },
+            "gl": {
+              "type": "string",
+              "default": "us",
+              "description": "Country to search from"
+            },
+            "hl": {
+              "type": "string",
+              "default": "en",
+              "description": "Search language"
+            },
+            "num": {
+              "type": "integer",
+              "default": 10,
+              "description": "Number of results to return"
+            },
+            "tbm": {
+              "type": "string",
+              "description": "Search type (nws, isch, vid, shop, bks, app)"
+            },
+            "tbs": {
+              "type": "string",
+              "description": "Time range (qdr:d, qdr:w, qdr:m, qdr:y)"
+            },
+            "safe": {
+              "type": "string",
+              "default": "active",
+              "description": "Safe search filter"
+            },
+            "async": {
+              "type": "boolean",
+              "default": false,
+              "description": "Submit search asynchronously"
+            },
+            "start": {
+              "type": "integer",
+              "default": 0,
+              "description": "Starting position for results"
+            },
+            "device": {
+              "type": "string",
+              "default": "desktop",
+              "description": "Device to use for results (desktop, tablet, mobile)"
+            },
+            "engine": {
+              "type": "string",
+              "default": "google",
+              "description": "Search engine"
+            },
+            "filter": {
+              "type": "integer",
+              "default": 0,
+              "description": "Filter duplicate results (0 or 1)"
+            },
+            "output": {
+              "type": "string",
+              "default": "json",
+              "description": "Output format (json, html)"
+            },
+            "location": {
+              "type": "string",
+              "default": "United States",
+              "description": "Search location"
+            },
+            "no_cache": {
+              "type": "boolean",
+              "default": false,
+              "description": "Force fresh results instead of cached ones"
+            },
+            "google_domain": {
+              "type": "string",
+              "default": "google.com",
+              "description": "Google domain"
+            }
+          },
+          "description": "Query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERPAPI__GOOGLE_IMAGES",
+    "description": "Search for images using Google Images API",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GOOGLE_IMAGES",
+      "canonical_tool_description_hash": "969835f7a08bd8e30834c14e892d5262cd069e3ba785b13c2175826f75843c63",
+      "canonical_tool_input_schema_hash": "44c29f0e7d6622f325f2bb3c730401a823d41c5f81d87f29387ee953077d7dfb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "Image search query"
+            },
+            "gl": {
+              "type": "string",
+              "default": "us",
+              "description": "Country to search from"
+            },
+            "hl": {
+              "type": "string",
+              "default": "en",
+              "description": "Search language"
+            },
+            "ijn": {
+              "type": "integer",
+              "default": 0,
+              "description": "Page number for pagination"
+            },
+            "num": {
+              "type": "integer",
+              "default": 10,
+              "description": "Number of images to return"
+            },
+            "imgc": {
+              "type": "string",
+              "default": "color",
+              "description": "Image colorization (color, gray, trans)"
+            },
+            "safe": {
+              "type": "string",
+              "default": "active",
+              "description": "Safe search filter"
+            },
+            "async": {
+              "type": "boolean",
+              "default": false,
+              "description": "Submit search asynchronously"
+            },
+            "imgar": {
+              "type": "string",
+              "default": "s",
+              "description": "Image aspect ratio (s, w, h, sq, t, p)"
+            },
+            "start": {
+              "type": "integer",
+              "default": 0,
+              "description": "Starting position for results"
+            },
+            "device": {
+              "type": "string",
+              "default": "desktop",
+              "description": "Device to use for results (desktop, tablet, mobile)"
+            },
+            "output": {
+              "type": "string",
+              "default": "json",
+              "description": "Output format (json, html)"
+            },
+            "imgdims": {
+              "type": "string",
+              "description": "Image dimensions (large, medium, icon)"
+            },
+            "imgtype": {
+              "type": "string",
+              "default": "photo",
+              "description": "Image type (photo, clipart, lineart, face, animated)"
+            },
+            "imgcolor": {
+              "type": "string",
+              "description": "Image color (black, blue, brown, gray, green, orange, pink, purple, red, teal, white, yellow)"
+            },
+            "location": {
+              "type": "string",
+              "default": "United States",
+              "description": "Search location"
+            },
+            "no_cache": {
+              "type": "boolean",
+              "default": false,
+              "description": "Force fresh results instead of cached ones"
+            },
+            "google_domain": {
+              "type": "string",
+              "default": "google.com",
+              "description": "Google domain"
+            }
+          },
+          "description": "Query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERPAPI__GOOGLE_NEWS",
+    "description": "Search news articles using Google News API",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GOOGLE_NEWS",
+      "canonical_tool_description_hash": "a1e9f13af5a72badc4542972810fb0ff855747e54fe784b296733225ed909d97",
+      "canonical_tool_input_schema_hash": "844deec32b600be159f89c49f66d85bf77de8f2c4ccbfbddf892784a5fffc104"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["engine", "q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "News search query"
+            },
+            "gl": {
+              "type": "string",
+              "default": "us",
+              "description": "Country to search from"
+            },
+            "hl": {
+              "type": "string",
+              "default": "en",
+              "description": "Search language"
+            },
+            "num": {
+              "type": "integer",
+              "default": 10,
+              "description": "Number of news articles to return"
+            },
+            "tbm": {
+              "type": "string",
+              "default": "d",
+              "description": "Time range (d, w, m, y)"
+            },
+            "async": {
+              "type": "boolean",
+              "default": false,
+              "description": "Submit search asynchronously"
+            },
+            "device": {
+              "type": "string",
+              "default": "desktop",
+              "description": "Device to use for results (desktop, tablet, mobile)"
+            },
+            "engine": {
+              "type": "string",
+              "default": "google_news",
+              "description": "Search engine"
+            },
+            "output": {
+              "type": "string",
+              "default": "json",
+              "description": "Output format (json, html)"
+            },
+            "location": {
+              "type": "string",
+              "default": "United States",
+              "description": "Search location"
+            },
+            "no_cache": {
+              "type": "boolean",
+              "default": false,
+              "description": "Force fresh results instead of cached ones"
+            },
+            "story_token": {
+              "type": "string",
+              "description": "Story token for specific news stories"
+            },
+            "topic_token": {
+              "type": "string",
+              "description": "Topic token for specific news topics"
+            },
+            "google_domain": {
+              "type": "string",
+              "default": "google.com",
+              "description": "Google domain"
+            },
+            "section_token": {
+              "type": "string",
+              "description": "Section token for specific news sections"
+            },
+            "publication_token": {
+              "type": "string",
+              "description": "Publication token for specific news publications"
+            }
+          },
+          "description": "Query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERPAPI__GOOGLE_SCHOLAR",
+    "description": "Search academic papers using Google Scholar API",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GOOGLE_SCHOLAR",
+      "canonical_tool_description_hash": "f0225e43fc2b54928726182ff93d50d848067775e5e50bc755f779302ff74ce9",
+      "canonical_tool_input_schema_hash": "d777c590d35cef41695b8e87326d970fccd7530dbc24eb2621825c271aef6f34"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["engine", "q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "Scholar search query"
+            },
+            "hl": {
+              "type": "string",
+              "default": "en",
+              "description": "Search language"
+            },
+            "num": {
+              "type": "integer",
+              "default": 10,
+              "description": "Number of results to return"
+            },
+            "cites": {
+              "type": "string",
+              "description": "Cited by ID for papers citing a specific paper"
+            },
+            "start": {
+              "type": "integer",
+              "default": 0,
+              "description": "Starting position for results"
+            },
+            "as_qdr": {
+              "type": "string",
+              "default": "y",
+              "description": "Time range (y=year, m=month, w=week, d=day)"
+            },
+            "as_sdt": {
+              "type": "string",
+              "default": "0,5",
+              "description": "Include/exclude patents and citations (0=include, 1=exclude)"
+            },
+            "as_vis": {
+              "type": "integer",
+              "default": 0,
+              "description": "Include/exclude patents (0=include, 1=exclude)"
+            },
+            "as_yhi": {
+              "type": "integer",
+              "default": 2024,
+              "description": "Year until which to search"
+            },
+            "as_ylo": {
+              "type": "integer",
+              "default": 2020,
+              "description": "Year from which to start the search"
+            },
+            "engine": {
+              "type": "string",
+              "default": "google_scholar",
+              "description": "Search engine"
+            },
+            "scisbd": {
+              "type": "integer",
+              "default": 0,
+              "description": "Sort by date (0=relevance, 1=date)"
+            },
+            "as_occt": {
+              "type": "string",
+              "default": "any",
+              "description": "Occurrence type (any=anywhere, title=in title, author=in author, pub=in publication)"
+            },
+            "cluster": {
+              "type": "string",
+              "description": "Cluster ID for specific paper versions"
+            },
+            "as_author": {
+              "type": "string",
+              "description": "Author name"
+            },
+            "as_publication": {
+              "type": "string",
+              "description": "Publication name"
+            }
+          },
+          "description": "Query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERPAPI__GOOGLE_TRENDS",
+    "description": "Get trending topics and search analytics using Google Trends API",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GOOGLE_TRENDS",
+      "canonical_tool_description_hash": "00ff564e51aa8c9226a70f707965dd6c22dbe61be40e35be04a34c707cd3e2d4",
+      "canonical_tool_input_schema_hash": "f064079cc3511aa64214c4dbdafcb434a63978b71294a6502608c252e23dd398"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["engine", "q"],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "Trend search query"
+            },
+            "hl": {
+              "type": "string",
+              "default": "en",
+              "description": "Language"
+            },
+            "tz": {
+              "type": "string",
+              "default": "-420",
+              "description": "Timezone offset in minutes (e.g., -420 for US Pacific Time)"
+            },
+            "geo": {
+              "type": "string",
+              "default": "US",
+              "description": "Geographic location"
+            },
+            "date": {
+              "type": "string",
+              "default": "today 12-m",
+              "description": "Time range (today 12-m, today 5-y, 2020-01-01 2020-12-31, now 1-H, now 1-d, now 7-d)"
+            },
+            "engine": {
+              "type": "string",
+              "default": "google_trends",
+              "description": "Search engine"
+            },
+            "category": {
+              "type": "integer",
+              "default": 0,
+              "description": "Category ID (0=All categories, 5=Arts & Entertainment, 12=Beauty & Fitness, etc.)"
+            },
+            "property": {
+              "type": "string",
+              "default": "",
+              "description": "Property type (empty=Web searches, NEWS=News searches, YOUTUBE=YouTube searches, IMAGES=Image searches, SHOPPING=Shopping searches)"
+            },
+            "data_type": {
+              "type": "string",
+              "default": "TIMESERIES",
+              "description": "Data type (TIMESERIES, GEO_MAP, RELATED_TOPICS, RELATED_QUERIES)"
+            },
+            "include_geo_restrictions": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include geo-restricted regions in results"
+            },
+            "include_low_search_volume": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include low search volume regions in results"
+            }
+          },
+          "description": "Query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/share_point/tools.json
+++ b/backend/mcp_servers/share_point/tools.json
@@ -1,0 +1,336 @@
+[
+  {
+    "name": "SHARE_POINT__LIST_SUBSITES_FOR_A_SITE",
+    "description": "List all subsites for a site.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_SUBSITES_FOR_A_SITE",
+      "canonical_tool_description_hash": "b11644258a435f1c663be5c91f685c204fb5deaf510acf13bcf3f539ae5fa333",
+      "canonical_tool_input_schema_hash": "2235d74dd986ce3cadf37c05d9f6df6dfd7ef8e2bf721c080922390662cee59d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["site_id"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The ID of the site to list subsites for. e.g., 'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE'"
+            }
+          },
+          "description": "the http path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SHARE_POINT__LIST_DRIVES_FOR_A_SITE",
+    "description": "List the document libraries for a site",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_DRIVES_FOR_A_SITE",
+      "canonical_tool_description_hash": "5a7d6754127f1c6fbdffa14624bd92618d91a06d15f0eee22863d2086a04f7ed",
+      "canonical_tool_input_schema_hash": "617d9a8146e9809c2495c8221ca14a559f1da45a4aa01b1fe534aa6b89af7a0e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["site_id"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The ID of the SharePoint site."
+            }
+          },
+          "description": "the http path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SHARE_POINT__SEARCH_FOR_SITES",
+    "description": "Search across a SharePoint tenant for sites that match keywords provided.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_FOR_SITES",
+      "canonical_tool_description_hash": "6ea6133467ca8a399ec88e66867e0afa90483ba3ed0706cc9bf0a5efe075bf1b",
+      "canonical_tool_input_schema_hash": "9f621f5489e00ad90208923927ac12469d36d4cfcfdc956ca175cbf25c8be9b2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["search_text"],
+          "properties": {
+            "search_text": {
+              "type": "string",
+              "description": "The search filter is a free text search that uses multiple properties when retrieving the search results"
+            }
+          },
+          "description": "the http path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SHARE_POINT__GET_ROOT_SITE",
+    "description": "Get the root site of a SharePoint tenant.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ROOT_SITE",
+      "canonical_tool_description_hash": "9a70d35f8b7718a506b9573f8e5889a0df57dd25b0ac7cc86b25210a7b0daef9",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SHARE_POINT__GET_SITE_BY_ID",
+    "description": "Get a site by its ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SITE_BY_ID",
+      "canonical_tool_description_hash": "f6d97ffc86927cd6e006eb18f2d368900ab3ca825d5a794d2278a6a57753b952",
+      "canonical_tool_input_schema_hash": "2dd97f49062f88c635f22b9c5236ebbed837cc809e57b983bf37ab887a2f244e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["site_id"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The ID of the site to get. e.g., 'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE'"
+            }
+          },
+          "description": "the http path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SHARE_POINT__GET_SITE_BY_PATH",
+    "description": "retrieve a site based on server-relative URL path. Site collection hostname and Site path, relative to server hostname.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SITE_BY_PATH",
+      "canonical_tool_description_hash": "e140f127a1afe94913ae70716bd33bfbdd50a821c88fdcf4a616e4e13a3d96aa",
+      "canonical_tool_input_schema_hash": "b389d91434c081ecca072d3826565b1e0c8b987702ddf52bee90e26638782fa1"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["hostname", "relative_path"],
+          "properties": {
+            "hostname": {
+              "type": "string",
+              "description": "The hostname of the site to get. e.g., 'xxx.sharepoint.com'"
+            },
+            "relative_path": {
+              "type": "string",
+              "description": "The relative path of the site to get. e.g., '/sites/mySite'"
+            }
+          },
+          "description": "the http path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SHARE_POINT__SERACH_FOR_ITEMS_IN_A_SITE_DRIVE",
+    "description": "Search the hierarchy of items for items matching a query. searches for a match across several fields in the signed-in user's drive items.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SERACH_FOR_ITEMS_IN_A_SITE_DRIVE",
+      "canonical_tool_description_hash": "8f5880162e571bd7e70be31b8a38f8cc0d3a3c05f942cd7269222d922c8c46ca",
+      "canonical_tool_input_schema_hash": "049b4712f704e989a5d62e4a973c6194da5807a2f6dbe721388fff0986281477"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["site_id", "search_text"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The ID of the SharePoint site."
+            },
+            "search_text": {
+              "type": "string",
+              "description": "The text to search for."
+            }
+          },
+          "description": "the http path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SHARE_POINT__CREATE_FOLDER_IN_SITE_DRIVE",
+    "description": "Create a new folder in a SharePoint site's document library (drive).",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_FOLDER_IN_SITE_DRIVE",
+      "canonical_tool_description_hash": "3df2e4a59b9a177f0ec42718c4d97c59c3f596de5decbc15ffb9d6bd3e1dcf95",
+      "canonical_tool_input_schema_hash": "cb26a2d35be5251f6d40f9b4b4bfc2882089e18527010a228084d524bea71393"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the new folder."
+            },
+            "@microsoft.graph.conflictBehavior": {
+              "enum": ["rename", "fail", "replace"],
+              "type": "string",
+              "description": "Specifies what to do if a folder with the same name already exists."
+            }
+          },
+          "description": "The body payload containing the folder information.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["site_id", "parent_item_id"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The ID of the SharePoint site."
+            },
+            "parent_item_id": {
+              "type": "string",
+              "description": "The ID of the parent folder or 'root' to create in the root directory."
+            }
+          },
+          "description": "The path parameters for the request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SHARE_POINT__DELETE_ITEM_IN_SITE_DRIVE",
+    "description": "Delete a DriveItem by using its ID from a SharePoint site's document library.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_ITEM_IN_SITE_DRIVE",
+      "canonical_tool_description_hash": "85fcf3d3b643f05d7e162ec1241580111b49b49f07130152a122661833b6c4b4",
+      "canonical_tool_input_schema_hash": "b12ad64e410d081e00ffa0769540662c9f9f9a44645ec758c1a0077397ad48b6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["site_id", "item_id"],
+          "properties": {
+            "item_id": {
+              "type": "string",
+              "description": "The ID of the item (file or folder) to delete."
+            },
+            "site_id": {
+              "type": "string",
+              "description": "The ID of the SharePoint site."
+            }
+          },
+          "description": "The path parameters identifying the SharePoint site and the item to delete.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SHARE_POINT__CREATE_LIST_IN_A_SITE",
+    "description": "Creates a new list in a SharePoint site.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_LIST_IN_A_SITE",
+      "canonical_tool_description_hash": "07f10972e38e4297eb51c25f009a8516145820c445f25088619fec08c7f78835",
+      "canonical_tool_input_schema_hash": "50e331ba4cfa5927944ee93c3d4a550512127509a20913dbacc20efcbb9207aa"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["displayName", "list"],
+          "properties": {
+            "list": {
+              "type": "object",
+              "required": ["template"],
+              "properties": {
+                "template": {
+                  "type": "string",
+                  "description": "The list template to use (e.g., 'genericList', 'task', 'issue')."
+                }
+              },
+              "description": "Metadata for the list creation.",
+              "additionalProperties": false
+            },
+            "displayName": {
+              "type": "string",
+              "description": "The display name of the list."
+            }
+          },
+          "description": "The body payload for creating the list.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["site_id"],
+          "properties": {
+            "site_id": {
+              "type": "string",
+              "description": "The ID of the SharePoint site where the list will be created."
+            }
+          },
+          "description": "The path parameters for the request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/slack/tools.json
+++ b/backend/mcp_servers/slack/tools.json
@@ -1,0 +1,1774 @@
+[
+  {
+    "name": "SLACK__CONVERSATIONS_LIST",
+    "description": "Lists all channels in a Slack team",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_LIST",
+      "canonical_tool_description_hash": "842a8bdc14a363c969f21ab23ad6278312e4d4cff9bd57b4be2e01779fdb030b",
+      "canonical_tool_input_schema_hash": "1816310fd840b933515dd54084525c59977c84e8caccb986421e03e995ac1714"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the list hasn't been reached. Must be an integer under 1000."
+            },
+            "types": {
+              "type": "array",
+              "items": {
+                "enum": ["public_channel", "private_channel", "mpim", "im"],
+                "type": "string"
+              },
+              "description": "Mix and match channel types by providing a comma-separated list of any combination of public_channel, private_channel, mpim, im"
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Paginate through collections of data by setting the cursor parameter to a next_cursor attribute returned by a previous request's response_metadata. Default value fetches the first \"page\" of the collection."
+            },
+            "exclude_archived": {
+              "type": "boolean",
+              "default": false,
+              "description": "Exclude archived channels from the list"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_MEMBERS",
+    "description": "Retrieve members of a conversation",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_MEMBERS",
+      "canonical_tool_description_hash": "363ab37e7bc2230465789968e2fd860b0aaa927f3d6381b57854ebd76c0af6d0",
+      "canonical_tool_input_schema_hash": "fecf2169d4867ce32b25a752a0473ce9b3a8f0b83022355c4bc97ef78b213776"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["channel"],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The maximum number of items to return"
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Pagination cursor for next page"
+            },
+            "channel": {
+              "type": "string",
+              "description": "The ID of the conversation to fetch members for"
+            }
+          },
+          "description": "Query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_INFO",
+    "description": "Retrieves information about a conversation (channel)",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_INFO",
+      "canonical_tool_description_hash": "73d89bfe906a65b70147da3d2aef1b48f0fed3e1b8d6fa1698d2bd6b6cd028bf",
+      "canonical_tool_input_schema_hash": "169081e14e632ee83ee7ce31b6dfd35dc899d2ad642d8499ee4e1a1c726f5081"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["channel"],
+          "properties": {
+            "channel": {
+              "type": "string",
+              "description": "Conversation ID of the channel to get information about"
+            },
+            "include_locale": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to true to receive the locale for this conversation"
+            },
+            "include_num_members": {
+              "type": "boolean",
+              "default": false,
+              "description": "Set to true to include the member count for the specified conversation"
+            }
+          },
+          "description": "Query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__USERS_CONVERSATIONS",
+    "description": "List conversations the calling user may access",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "USERS_CONVERSATIONS",
+      "canonical_tool_description_hash": "624765768dd77dc68741d2a1ae366cff9333f708d7cc924106807b08e2585205",
+      "canonical_tool_input_schema_hash": "236abe390277bf0c5c4f6084300c262a72c5cc58a395e0aef49cc2544a0ebb49"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "user": {
+              "type": "string",
+              "description": "Browse conversations by a specific user ID's membership"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The maximum number of items to return (max value: 999)"
+            },
+            "types": {
+              "type": "string",
+              "default": "public_channel",
+              "description": "Comma-separated list of channel types (public_channel, private_channel, mpim, im)"
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Pagination cursor for navigating through data collections"
+            },
+            "exclude_archived": {
+              "type": "boolean",
+              "default": false,
+              "description": "Set to true to exclude archived channels from the list"
+            }
+          },
+          "description": "Query parameters for the HTTP request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_HISTORY",
+    "description": "Fetches a conversation's history of messages and events",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_HISTORY",
+      "canonical_tool_description_hash": "0f9ffac4ef56b864a0bf663034279ff931b75292213ee973545a014d67ca7ed0",
+      "canonical_tool_input_schema_hash": "fb0c8c3078d910a9ae1efd3463750469d9361b3da777c8aff7b89cf1490b6887"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["channel"],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The maximum number of items to return"
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Pagination cursor for next page"
+            },
+            "latest": {
+              "type": "string",
+              "default": "now",
+              "description": "End of time range of messages to include in results"
+            },
+            "oldest": {
+              "type": "string",
+              "default": "0",
+              "description": "Start of time range of messages to include in results"
+            },
+            "channel": {
+              "type": "string",
+              "description": "Conversation ID to fetch history for"
+            },
+            "inclusive": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include messages with latest or oldest timestamp in results"
+            },
+            "include_all_metadata": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include all metadata in the response"
+            }
+          },
+          "description": "Query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_REPLIES",
+    "description": "Retrieve a thread of messages posted to a conversation",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_REPLIES",
+      "canonical_tool_description_hash": "3606296efc3bc8198ff128620fa02ab2ceadd4072408bf2ce1cd86fd791562c2",
+      "canonical_tool_input_schema_hash": "40c4c20eabf33d0f11753283f7e4f6777525a0068425828fcc7a0c68d56a5a5c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["channel", "ts"],
+          "properties": {
+            "ts": {
+              "type": "string",
+              "description": "Unique identifier of either a thread's parent message or a message in the thread"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The maximum number of items to return"
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Pagination cursor for navigating through collections of data"
+            },
+            "latest": {
+              "type": "string",
+              "default": "now",
+              "description": "Only messages before this Unix timestamp will be included in results"
+            },
+            "oldest": {
+              "type": "string",
+              "default": "0",
+              "description": "Only messages after this Unix timestamp will be included in results"
+            },
+            "channel": {
+              "type": "string",
+              "description": "Conversation ID to fetch thread from"
+            },
+            "inclusive": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include messages with oldest or latest timestamps in results"
+            },
+            "include_all_metadata": {
+              "type": "boolean",
+              "default": false,
+              "description": "Return all metadata associated with this message"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_CREATE",
+    "description": "Initiates a public or private channel-based conversation",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_CREATE",
+      "canonical_tool_description_hash": "b4f06e4b5ca2deff95867525fbac32b7f7ccd3eb1ea504fe90580c33817e4340",
+      "canonical_tool_input_schema_hash": "cc599e1bc371e8124d764e7da4c85e288ebeb7385fde8375ac989ad09b53e6de"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the public or private channel to create"
+            },
+            "is_private": {
+              "type": "boolean",
+              "description": "Create a private channel instead of a public one"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_RENAME",
+    "description": "Renames a conversation",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_RENAME",
+      "canonical_tool_description_hash": "a5368f159fba2bad91f2fbf4f7675be02a18f8c7e699257f26ab3fe9e138617f",
+      "canonical_tool_input_schema_hash": "dc6459a216bcee2c434ea36c56f6b607bd3c72810cfc4c3b92fc1c5fbbe2b8c8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel", "name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "New name for conversation"
+            },
+            "channel": {
+              "type": "string",
+              "description": "ID of conversation to rename"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_SET_PURPOSE",
+    "description": "Sets the channel description",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_SET_PURPOSE",
+      "canonical_tool_description_hash": "3748dd75f277a3aec224f26b94c5f762453787421b83d2f34f4a71c407b86722",
+      "canonical_tool_input_schema_hash": "7977f78568ead49f0ca4dd83e620cc9b7f21a6b1cbaee99b98756b1d7acb7723"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel", "purpose"],
+          "properties": {
+            "channel": {
+              "type": "string",
+              "description": "Channel to set the description of"
+            },
+            "purpose": {
+              "type": "string",
+              "description": "The description to set for the channel"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_SET_TOPIC",
+    "description": "Sets the topic for a conversation",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_SET_TOPIC",
+      "canonical_tool_description_hash": "71cd70be20d5c487f59403de09331cf78c8d836bbd08ebfc4f355544dcb9f17c",
+      "canonical_tool_input_schema_hash": "80dde8db616acc3ee651cf04b48e64fd2cfe6ee379259e984d78c1168e2ebfd5"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel", "topic"],
+          "properties": {
+            "topic": {
+              "type": "string",
+              "description": "The new topic string. Does not support formatting or linkification."
+            },
+            "channel": {
+              "type": "string",
+              "description": "Conversation ID to set the topic of"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_ARCHIVE",
+    "description": "Archives a conversation",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_ARCHIVE",
+      "canonical_tool_description_hash": "a1c08a562527c61ffb9c490f58a53113e75352e30bfc4d7e43ca31d2cefc19df",
+      "canonical_tool_input_schema_hash": "4ac0f9fc0de473afc9a96b060089ea3286943088f769e22f6edfc52fe4132e2c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel"],
+          "properties": {
+            "channel": {
+              "type": "string",
+              "description": "ID of conversation to archive"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_UNARCHIVE",
+    "description": "Reverses conversation archival",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_UNARCHIVE",
+      "canonical_tool_description_hash": "285df793ce99a60ba42bd00fed2bfa9353c7d140ff4e5db2774a48f4875316df",
+      "canonical_tool_input_schema_hash": "e34bc8965fdf9206137073365d4ca527721b92cfdc6b807768bd97e23f7b345a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel"],
+          "properties": {
+            "channel": {
+              "type": "string",
+              "description": "ID of conversation to unarchive"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_OPEN",
+    "description": "Opens or resumes a direct message or multi-person direct message",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_OPEN",
+      "canonical_tool_description_hash": "9ba96902be3a9e9471e3fe59554285986fd5b03c40d14b12949b1466ecae132e",
+      "canonical_tool_input_schema_hash": "3587176bd1bfc0150f2d3bbe5cca2d54322ad06259ff2cf8e6b59621c57793f0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "users": {
+              "type": "string",
+              "description": "Comma separated lists of users. If only one user is included, this creates a 1:1 DM"
+            },
+            "channel": {
+              "type": "string",
+              "description": "Resume a conversation by supplying an 'im' or 'mpim's ID"
+            },
+            "return_im": {
+              "type": "boolean",
+              "description": "Indicates you want the full IM channel definition in the response"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CONVERSATIONS_CLOSE",
+    "description": "Closes a direct message or multi-person direct message",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERSATIONS_CLOSE",
+      "canonical_tool_description_hash": "f91a91475b46263144351cbbd0b9b57fdbd2ca4c0f8cbc6f9e533956330cb79c",
+      "canonical_tool_input_schema_hash": "33bdce9333766b1f69b497fa15933fd9bb18e509dcce9aec29143a438cdbbfc7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel"],
+          "properties": {
+            "channel": {
+              "type": "string",
+              "description": "Conversation ID to close"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CHAT_POST_MESSAGE",
+    "description": "Sends a message to a Slack channel, private group, or direct message",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CHAT_POST_MESSAGE",
+      "canonical_tool_description_hash": "d5e038bab43c2ffa016ffe47385ffe9bf3b49bc380213100fa1a0154f59ba44b",
+      "canonical_tool_input_schema_hash": "7cba66bb9a482794877d0c9a978e78489e4aafae3af6240666b6e92d41753031"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel"],
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "The text of the message. When using blocks or attachments, this is used as fallback text for notifications"
+            },
+            "parse": {
+              "enum": ["none", "full"],
+              "type": "string",
+              "description": "Change how messages are treated. Set to 'none' to remove hyperlinks, 'full' to ignore mrkdwn formatting"
+            },
+            "blocks": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "description": "A JSON-based array of structured blocks"
+            },
+            "mrkdwn": {
+              "type": "boolean",
+              "default": true,
+              "description": "Disable Slack markup parsing by setting to false. Enabled by default"
+            },
+            "channel": {
+              "type": "string",
+              "description": "An encoded ID or channel name that represents a channel, private group, or IM channel to send the message to"
+            },
+            "icon_url": {
+              "type": "string",
+              "description": "URL to an image to use as the icon for this message"
+            },
+            "thread_ts": {
+              "type": "string",
+              "description": "Provide another message's ts value to make this message a reply. Avoid using a reply's ts value; use its parent instead"
+            },
+            "icon_emoji": {
+              "type": "string",
+              "description": "Emoji to use as the icon for this message. Overrides icon_url"
+            },
+            "link_names": {
+              "type": "boolean",
+              "description": "Find and link user groups"
+            },
+            "unfurl_links": {
+              "type": "boolean",
+              "description": "Pass true to enable unfurling of primarily text-based content"
+            },
+            "unfurl_media": {
+              "type": "boolean",
+              "description": "Pass false to disable unfurling of media content"
+            },
+            "markdown_text": {
+              "type": "string",
+              "description": "Message text formatted in markdown. Should not be used with blocks or text. Limit to 12,000 characters"
+            },
+            "reply_broadcast": {
+              "type": "boolean",
+              "default": false,
+              "description": "Used with thread_ts to make reply visible to everyone in the channel. Defaults to false"
+            }
+          },
+          "description": "Message content and configuration",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CHAT_POST_EPHEMERAL",
+    "description": "Sends an ephemeral message to a user in a channel",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CHAT_POST_EPHEMERAL",
+      "canonical_tool_description_hash": "c6396d81c9ac290e1af927ac6fe65e9fa1ceab30a204719c1c06e75e0c637c05",
+      "canonical_tool_input_schema_hash": "c83055a4e71be9e33d89d0e039bdc8bdee75fc8c1eb9b12d8b9e2423139709fa"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel", "user"],
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "Text of the message to send. When attachments or blocks are included, text will be used as fallback text for notifications only"
+            },
+            "user": {
+              "type": "string",
+              "description": "ID of the user who will receive the ephemeral message. The user should be in the channel specified by the channel argument"
+            },
+            "parse": {
+              "type": "string",
+              "description": "Change how messages are treated. Defaults to none"
+            },
+            "blocks": {
+              "type": "string",
+              "description": "A JSON-based array of structured blocks, presented as a URL-encoded string"
+            },
+            "channel": {
+              "type": "string",
+              "description": "Channel, private group, or IM channel to send message to. Can be an encoded ID, or a name"
+            },
+            "icon_url": {
+              "type": "string",
+              "description": "URL to an image to use as the icon for this message"
+            },
+            "username": {
+              "type": "string",
+              "description": "Set your bot's user name"
+            },
+            "thread_ts": {
+              "type": "string",
+              "description": "Provide another message's ts value to post this message in a thread. Avoid using a reply's ts value; use its parent's value instead. Ephemeral messages in threads are only shown if there is already an active thread"
+            },
+            "icon_emoji": {
+              "type": "string",
+              "description": "Emoji to use as the icon for this message. Overrides icon_url"
+            },
+            "link_names": {
+              "type": "boolean",
+              "description": "Find and link channel names and usernames"
+            },
+            "markdown_text": {
+              "type": "string",
+              "description": "Accepts message text formatted in markdown. This argument should not be used in conjunction with blocks or text. Limit this field to 12,000 characters"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CHAT_UPDATE",
+    "description": "Updates a message in a Slack channel",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CHAT_UPDATE",
+      "canonical_tool_description_hash": "6b52b7f344fbba112dcc5f2e587d318c200c863befe4beefa2a35afadffcaf2d",
+      "canonical_tool_input_schema_hash": "ed28e25f125399e8b5d2120969e4a1641ee19ffd9942be7b151832b58e874a97"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel", "ts"],
+          "properties": {
+            "ts": {
+              "type": "string",
+              "description": "Timestamp of the message to be updated"
+            },
+            "text": {
+              "type": "string",
+              "description": "New text for the message. If not specified and blocks are specified, the message's previous text will be overwritten"
+            },
+            "parse": {
+              "enum": ["none", "full"],
+              "type": "string",
+              "description": "Change how messages are treated. Defaults to client, unlike chat.postMessage. Accepts either none or full"
+            },
+            "blocks": {
+              "type": "string",
+              "description": "A JSON-based array of structured blocks, presented as a URL-encoded string"
+            },
+            "channel": {
+              "type": "string",
+              "description": "Channel containing the message to be updated. For direct messages, ensure that this value is a DM ID (starts with D) instead of a User ID"
+            },
+            "file_ids": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of new file ids that will be sent with this message"
+            },
+            "metadata": {
+              "type": "string",
+              "description": "JSON object with event_type and event_payload fields, presented as a URL-encoded string"
+            },
+            "link_names": {
+              "type": "boolean",
+              "description": "Find and link channel names and usernames. Defaults to none"
+            },
+            "markdown_text": {
+              "type": "string",
+              "description": "Accepts message text formatted in markdown. This argument should not be used in conjunction with blocks or text"
+            },
+            "reply_broadcast": {
+              "type": "boolean",
+              "default": false,
+              "description": "Broadcast an existing thread reply to make it visible to everyone in the channel or conversation"
+            }
+          },
+          "description": "Parameters for updating a message",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CHAT_DELETE",
+    "description": "Deletes a message from a conversation",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CHAT_DELETE",
+      "canonical_tool_description_hash": "c25a4dcb7322ee421cf3cd003600ce188aa7935a5bf6e5ba766ee5cfa793047c",
+      "canonical_tool_input_schema_hash": "9887245f08d36642ff9c0762089a9c5aaedb3a6fdebf12b365651535545c8a77"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel", "ts"],
+          "properties": {
+            "ts": {
+              "type": "string",
+              "description": "Timestamp of the message to be deleted"
+            },
+            "channel": {
+              "type": "string",
+              "description": "Channel containing the message to be deleted"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__USERS_GET_PRESENCE",
+    "description": "Gets user presence information",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "USERS_GET_PRESENCE",
+      "canonical_tool_description_hash": "c14b3e34954e1a2776313b38eb103f81002b5bd98fbcf63161e990451e5e5380",
+      "canonical_tool_input_schema_hash": "a08d487e69c077d3bdcc40f519319990e9242bf599b32b2b91ada9480500a507"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "user": {
+              "type": "string",
+              "description": "User to get presence info on. Defaults to the authed user."
+            }
+          },
+          "description": "Query parameters for the HTTP request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CHAT_SCHEDULE_MESSAGE",
+    "description": "Schedules a message to be sent to a channel at a specified time in the future",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CHAT_SCHEDULE_MESSAGE",
+      "canonical_tool_description_hash": "330720075c17201993fdee299c434ae916dc9941e90744833384590a5610387b",
+      "canonical_tool_input_schema_hash": "8a3f6927a5347294c66de5bc2f1344f80fce7e18726eb164524970e40a7758b6"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel", "post_at"],
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "The text content of the message. When attachments or blocks are included, text will be used as fallback text for notifications only."
+            },
+            "parse": {
+              "enum": ["none", "full"],
+              "type": "string",
+              "description": "Change how messages are treated."
+            },
+            "blocks": {
+              "type": "string",
+              "description": "A JSON-based array of structured blocks, presented as a URL-encoded string."
+            },
+            "channel": {
+              "type": "string",
+              "description": "Channel, private group, or DM channel to send message to. Can be an encoded ID, or a name."
+            },
+            "post_at": {
+              "type": "integer",
+              "description": "Unix timestamp representing the future time the message should post to Slack (up to 120 days in the future)."
+            },
+            "metadata": {
+              "type": "string",
+              "description": "JSON object with event_type and event_payload fields, presented as a URL-encoded string."
+            },
+            "thread_ts": {
+              "type": "string",
+              "description": "Provide another message's ts value to make this message a reply."
+            },
+            "link_names": {
+              "type": "boolean",
+              "description": "Find and link user groups. No longer supports linking individual users."
+            },
+            "unfurl_links": {
+              "type": "boolean",
+              "description": "Pass true to enable unfurling of primarily text-based content."
+            },
+            "unfurl_media": {
+              "type": "boolean",
+              "description": "Pass false to disable unfurling of media content."
+            },
+            "markdown_text": {
+              "type": "string",
+              "description": "Accepts message text formatted in markdown. This argument should not be used with blocks or text. Limit to 12,000 characters."
+            },
+            "reply_broadcast": {
+              "type": "boolean",
+              "description": "Used with thread_ts to make reply visible to everyone in the channel. Defaults to false."
+            }
+          },
+          "description": "Parameters for scheduling a message",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CHAT_SCHEDULED_MESSAGES_LIST",
+    "description": "Returns a list of scheduled messages",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CHAT_SCHEDULED_MESSAGES_LIST",
+      "canonical_tool_description_hash": "ab4d1599efbd9ca516294837b98f8c4bd48fa5ba37e094c6a117108cc4d11be3",
+      "canonical_tool_input_schema_hash": "73da29e1db11ba74a889f9bcacc1e69a3c1a608e53e1a54d9fde0ba480315474"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "default": 100,
+              "description": "Maximum number of original entries to return"
+            },
+            "cursor": {
+              "type": "string",
+              "description": "For pagination purposes, this is the cursor value returned from a previous call indicating where you want to start this call from"
+            },
+            "latest": {
+              "type": "string",
+              "description": "A Unix timestamp of the latest value in the time range"
+            },
+            "oldest": {
+              "type": "string",
+              "description": "A Unix timestamp of the oldest value in the time range"
+            },
+            "channel": {
+              "type": "string",
+              "description": "The channel of the scheduled messages"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__CHAT_DELETE_SCHEDULED_MESSAGE",
+    "description": "Deletes a pending scheduled message from the queue.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CHAT_DELETE_SCHEDULED_MESSAGE",
+      "canonical_tool_description_hash": "4d63854925c410da62a899794ab65382ea571bd5bc50cb66d0e9fcdc0f440da5",
+      "canonical_tool_input_schema_hash": "2a286458cbca6ff33aa290377b99a8f27d9903fe09f54b3eaabde4915dc1daa9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel", "scheduled_message_id"],
+          "properties": {
+            "channel": {
+              "type": "string",
+              "description": "The channel the scheduled_message is posting to"
+            },
+            "scheduled_message_id": {
+              "type": "string",
+              "description": "scheduled_message_id returned from call to chat.scheduleMessage"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__USERS_LIST",
+    "description": "Lists all users in a Slack team",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "USERS_LIST",
+      "canonical_tool_description_hash": "787672102530d44e7d75ffec36b3048c5b0a9eeda67c31835f84b48fb381eaa6",
+      "canonical_tool_input_schema_hash": "78b73d74ef480c95f7e4e4efc255c2233982e49945a1a9bcbad6de895d7c3c38"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "default": 0,
+              "description": "The maximum number of items to return (recommended: no more than 200)"
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Pagination cursor for navigating through collections of data"
+            },
+            "include_locale": {
+              "type": "boolean",
+              "default": false,
+              "description": "Set to true to receive the locale for users"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__USERS_INFO",
+    "description": "Gets information about a user",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "USERS_INFO",
+      "canonical_tool_description_hash": "a6a4599d31f7a1826ba4a9552e377874c57109e99e5477ad7ecb515f34686766",
+      "canonical_tool_input_schema_hash": "96a2ec4f655c8c08c3ef8ab7fc3483db3369ac0b3b528307742e0e9c75e0aa17"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["user"],
+          "properties": {
+            "user": {
+              "type": "string",
+              "description": "User ID to get information on"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__USERS_SET_PRESENCE",
+    "description": "Sets user presence information",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "USERS_SET_PRESENCE",
+      "canonical_tool_description_hash": "01b7bedae090e018d99a044a4482bb2ffd3284bcd0b0334dd928f02696335660",
+      "canonical_tool_input_schema_hash": "0107301414cfcf463b5f0f7bf48d9a3053f6b0afb07d80a36f85ab7003714998"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["presence"],
+          "properties": {
+            "presence": {
+              "enum": ["auto", "away"],
+              "type": "string",
+              "description": "Either 'auto' or 'away'"
+            }
+          },
+          "description": "Body parameters for the HTTP request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__EMOJI_LIST",
+    "description": "Lists custom emoji for a team",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EMOJI_LIST",
+      "canonical_tool_description_hash": "93efe51f27033e30dada4f84ed80eb4f89c7d0e1b7654f18745c01d1a93cb4bd",
+      "canonical_tool_input_schema_hash": "6e31629ac96f94bdcff181d8986034995ca7c25aadd82dc44a9f0527aca10ed4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "include_categories": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include a list of categories for Unicode emoji and the emoji in each category"
+            }
+          },
+          "description": "Query parameters for the HTTP request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__BOOKMARKS_LIST",
+    "description": "List bookmarks for a channel in Slack",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BOOKMARKS_LIST",
+      "canonical_tool_description_hash": "e5bc64a1c9dbe9cfca99d25f8f031c635210f62c06bcaf8cba59e74baa9e6113",
+      "canonical_tool_input_schema_hash": "748028cd9eb584c5e73099760d0652b5f1f22a318d2b47fdfe1309d79bb78a90"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel_id"],
+          "properties": {
+            "channel_id": {
+              "type": "string",
+              "description": "Channel to list bookmarks in"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__BOOKMARKS_ADD",
+    "description": "Add bookmark to a channel",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BOOKMARKS_ADD",
+      "canonical_tool_description_hash": "a91e5d57be61be95da8aefd6b97808ec7d9334cec15cc0f810040ce3fcfd68f2",
+      "canonical_tool_input_schema_hash": "c73840e7996b4c927eb6afa9c3048f582f2e1258b676cc1f1dba7ffadcaeab61"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel_id", "title", "type"],
+          "properties": {
+            "link": {
+              "type": "string",
+              "description": "Link to bookmark"
+            },
+            "type": {
+              "type": "string",
+              "default": "link",
+              "description": "Type of the bookmark (currently only 'link' is supported)"
+            },
+            "emoji": {
+              "type": "string",
+              "description": "Emoji tag to apply to the link"
+            },
+            "title": {
+              "type": "string",
+              "description": "Title for the bookmark"
+            },
+            "entity_id": {
+              "type": "string",
+              "description": "ID of the entity being bookmarked. Only applies to message and file types"
+            },
+            "parent_id": {
+              "type": "string",
+              "description": "ID of this bookmark's parent"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "Channel to add bookmark in"
+            },
+            "access_level": {
+              "enum": ["read", "write"],
+              "type": "string",
+              "description": "The level that we are setting the file's permission to"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__BOOKMARKS_EDIT",
+    "description": "Edit bookmark in a Slack channel",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BOOKMARKS_EDIT",
+      "canonical_tool_description_hash": "fa01f3d25d493e9bf947fdee7df68c9d3f16fa1e733579d702416d91070a7a03",
+      "canonical_tool_input_schema_hash": "ad10caaa58156de7d5d4b37d7511d9b4efa6ee66009fd6d1d7c837cda8ed0a07"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["bookmark_id", "channel_id"],
+          "properties": {
+            "link": {
+              "type": "string",
+              "description": "Link to bookmark"
+            },
+            "emoji": {
+              "type": "string",
+              "description": "Emoji tag to apply to the link"
+            },
+            "title": {
+              "type": "string",
+              "description": "Title for the bookmark"
+            },
+            "channel_id": {
+              "type": "string",
+              "description": "Channel to update bookmark in"
+            },
+            "bookmark_id": {
+              "type": "string",
+              "description": "Bookmark to update"
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__BOOKMARKS_REMOVE",
+    "description": "Remove bookmark from the channel",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "BOOKMARKS_REMOVE",
+      "canonical_tool_description_hash": "bbf7a923faeeb28d6f4ebd118d2e80e693b429d88bc8b060ddbd665fd90e0acf",
+      "canonical_tool_input_schema_hash": "34784d48c525acf466a8076a8da4b77f05563c4b267a04a8a0443fd47f0be6b3"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["bookmark_id", "channel_id"],
+          "properties": {
+            "channel_id": {
+              "type": "string",
+              "description": "Channel to remove bookmark from"
+            },
+            "bookmark_id": {
+              "type": "string",
+              "description": "Bookmark to remove"
+            },
+            "quip_section_id": {
+              "type": "string",
+              "description": "Quip section ID to unbookmark"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__PINS_LIST",
+    "description": "Lists items pinned to a channel",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PINS_LIST",
+      "canonical_tool_description_hash": "b999ca448d4619cad434a9aaa8d5b708b322ed238b74cb84c4324fb0b075aa70",
+      "canonical_tool_input_schema_hash": "9d7386b997508148c245f5e50b890a174b8cee9ba5df37e7e3959edf0c97ab48"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["channel"],
+          "properties": {
+            "channel": {
+              "type": "string",
+              "description": "Channel ID to get pinned items for (e.g., C1234567890)"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__PINS_ADD",
+    "description": "Pins an item to a channel",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PINS_ADD",
+      "canonical_tool_description_hash": "e8eaf5e13bb9ca3490b74c64632c36ceb872169bae5af707ed55f54e5863bfc4",
+      "canonical_tool_input_schema_hash": "e3b32cc065979a5e7397e9a1256b1eb2d66c2ad4badf8027df44a219b6f18958"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel"],
+          "properties": {
+            "channel": {
+              "type": "string",
+              "description": "Channel ID to pin the message to"
+            },
+            "timestamp": {
+              "type": "string",
+              "description": "Timestamp of the message to pin"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__PINS_REMOVE",
+    "description": "Un-pins an item from a channel",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PINS_REMOVE",
+      "canonical_tool_description_hash": "c9f5fe93fd876ab846e826fce4f1d86d6ec817be146452e540a86c0ca90058d8",
+      "canonical_tool_input_schema_hash": "9487ccd038c76712c62411d5825e81cfc00af6706b8b21dec20cc669616e5842"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel"],
+          "properties": {
+            "channel": {
+              "type": "string",
+              "description": "Channel where the item is pinned to"
+            },
+            "timestamp": {
+              "type": "string",
+              "description": "Timestamp of the message to un-pin"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__REACTIONS_LIST",
+    "description": "Lists reactions made by a user",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REACTIONS_LIST",
+      "canonical_tool_description_hash": "f5b85defa1eed14f7a9f75045ef382a7bacf37b4b3490228524a8f0ccb1b5a62",
+      "canonical_tool_input_schema_hash": "e82e7004dcd1a39e0e06aa5f306b28f0cedc4e674932ad55684cbdd6f0a5d0d2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "full": {
+              "type": "boolean",
+              "description": "If true always return the complete reaction list"
+            },
+            "page": {
+              "type": "integer",
+              "default": 1,
+              "description": "Page number of results to return"
+            },
+            "user": {
+              "type": "string",
+              "description": "Show reactions made by this user. Defaults to the authed user"
+            },
+            "count": {
+              "type": "integer",
+              "default": 100,
+              "description": "Number of items to return per page"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 0,
+              "description": "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the list hasn't been reached"
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Parameter for pagination. Set cursor equal to the next_cursor attribute returned by the previous request's response_metadata"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__REACTIONS_GET",
+    "description": "Gets reactions for an item (file, file comment, channel message, group message, or direct message)",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REACTIONS_GET",
+      "canonical_tool_description_hash": "7c526e2530772cbf5a6e8d9f4d9e5458a2403200675b8d2cc1f2e65b352c7719",
+      "canonical_tool_input_schema_hash": "3771ee417f876b47ad15c7441f449dd708be407f7df0233ef23ea3d85df3d180"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "file": {
+              "type": "string",
+              "description": "File to get reactions for"
+            },
+            "full": {
+              "type": "boolean",
+              "description": "If true always return the complete reaction list"
+            },
+            "channel": {
+              "type": "string",
+              "description": "Channel where the message to get reactions for was posted"
+            },
+            "timestamp": {
+              "type": "string",
+              "description": "Timestamp of the message to get reactions for"
+            },
+            "file_comment": {
+              "type": "string",
+              "description": "File comment to get reactions for"
+            }
+          },
+          "description": "Query parameters for the HTTP request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__REACTIONS_ADD",
+    "description": "Adds a reaction (emoji) to a message in a Slack channel",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REACTIONS_ADD",
+      "canonical_tool_description_hash": "a95911c50a9909726017506ceb94fbeb985d6978326d27028961b47d7c8a7ea4",
+      "canonical_tool_input_schema_hash": "071825128b15744d6c26404a7ecf9ed882f110939586aede6990c70d8ba60473"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["channel", "name", "timestamp"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Reaction (emoji) name, can include skin tone modifiers like 'thumbsup::skin-tone-3'"
+            },
+            "channel": {
+              "type": "string",
+              "description": "Channel where the message to add reaction to was posted"
+            },
+            "timestamp": {
+              "type": "string",
+              "description": "Timestamp of the message to add reaction to"
+            }
+          },
+          "description": "Parameters for adding a reaction",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__REACTIONS_REMOVE",
+    "description": "Removes a reaction (emoji) from an item (file, file comment, channel message, group message, or direct message)",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REACTIONS_REMOVE",
+      "canonical_tool_description_hash": "7b0c7a67d1b6464754bc104d18bd502aa6e49c36994ea3616fce2b9c000357be",
+      "canonical_tool_input_schema_hash": "1b22db7283ac8420a85446454ea6b6d00e09ff350509fabdc6a84defaf7f40b0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "file": {
+              "type": "string",
+              "description": "File to remove reaction from"
+            },
+            "name": {
+              "type": "string",
+              "description": "Reaction (emoji) name"
+            },
+            "channel": {
+              "type": "string",
+              "description": "Channel where the message to remove reaction from was posted"
+            },
+            "timestamp": {
+              "type": "string",
+              "description": "Timestamp of the message to remove reaction from"
+            },
+            "file_comment": {
+              "type": "string",
+              "description": "File comment to remove reaction from"
+            }
+          },
+          "description": "Body parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__REMINDERS_LIST",
+    "description": "Lists all reminders created by or for a given user",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REMINDERS_LIST",
+      "canonical_tool_description_hash": "5a7276d1e213012e3130dcbcdf5b3b976028137918714b9471abde0889328cc8",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__REMINDERS_INFO",
+    "description": "Gets information about a reminder",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REMINDERS_INFO",
+      "canonical_tool_description_hash": "a67b240be94a369bc232eaa0a8cb7909fedc79e9dccf203261d24279904cb77d",
+      "canonical_tool_input_schema_hash": "dae82e40eea9686d204bbfd1cbe10b9ed05fbec33e04204b41af6eaa294dbc6d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["reminder"],
+          "properties": {
+            "reminder": {
+              "type": "string",
+              "description": "The ID of the reminder"
+            }
+          },
+          "description": "Query parameters for the HTTP request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__SEARCH_ALL",
+    "description": "Searches for messages and files matching a query",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_ALL",
+      "canonical_tool_description_hash": "f1222f88634d7ed458e13c7ea3277e3d27b217fb38b57138cb108f87b47ade83",
+      "canonical_tool_input_schema_hash": "a49d419d7b30b76293f6b93a933896fd94d78f5fc1878d3d37c898ca6d6b32a1"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["query"],
+          "properties": {
+            "page": {
+              "type": "integer",
+              "default": 1,
+              "description": "Page number of results to return"
+            },
+            "sort": {
+              "enum": ["score", "timestamp"],
+              "type": "string",
+              "default": "score",
+              "description": "Return matches sorted by either score or timestamp"
+            },
+            "count": {
+              "type": "integer",
+              "default": 20,
+              "description": "Number of items to return per page"
+            },
+            "query": {
+              "type": "string",
+              "description": "Search query. May contains booleans, etc."
+            },
+            "sort_dir": {
+              "enum": ["asc", "desc"],
+              "type": "string",
+              "default": "desc",
+              "description": "Change sort direction to ascending (asc) or descending (desc)"
+            },
+            "highlight": {
+              "type": "boolean",
+              "default": false,
+              "description": "Pass a value of true to enable query highlight markers"
+            }
+          },
+          "description": "Query parameters for the HTTP request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__SEARCH_FILES",
+    "description": "Searches for files matching a query in Slack",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_FILES",
+      "canonical_tool_description_hash": "c1d2d9f54ccafb9fd7611156dfe0053ec696c37c0fb986626d6389f2feb051f9",
+      "canonical_tool_input_schema_hash": "c50b341ac11c2d00be12c6fbc707f851ab54098f31721b1c128b90e047ca8d75"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["query"],
+          "properties": {
+            "page": {
+              "type": "integer",
+              "default": 1,
+              "description": "Page number of results to return"
+            },
+            "sort": {
+              "enum": ["score", "timestamp"],
+              "type": "string",
+              "default": "score",
+              "description": "Return matches sorted by either score or timestamp"
+            },
+            "count": {
+              "type": "integer",
+              "default": 20,
+              "description": "Number of items to return per page"
+            },
+            "query": {
+              "type": "string",
+              "description": "Search query to find matching files"
+            },
+            "sort_dir": {
+              "enum": ["asc", "desc"],
+              "type": "string",
+              "default": "desc",
+              "description": "Change sort direction to ascending (asc) or descending (desc)"
+            },
+            "highlight": {
+              "type": "boolean",
+              "description": "Pass a value of true to enable query highlight markers"
+            }
+          },
+          "description": "Query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SLACK__SEARCH_MESSAGES",
+    "description": "Searches for messages matching a query",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_MESSAGES",
+      "canonical_tool_description_hash": "b05d65ed15421a259d0a4d5f23416db713a6c196efb617bb97f2763394aa7949",
+      "canonical_tool_input_schema_hash": "36fd087eb3f9de32808f3c3ce2a8de1924cbe822e21d7dc88d2aa8927998a39b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["query"],
+          "properties": {
+            "page": {
+              "type": "integer",
+              "default": 1,
+              "description": "Page number of results to return"
+            },
+            "sort": {
+              "enum": ["score", "timestamp"],
+              "type": "string",
+              "default": "score",
+              "description": "Return matches sorted by either score or timestamp"
+            },
+            "count": {
+              "type": "integer",
+              "default": 20,
+              "description": "Number of items to return per page"
+            },
+            "query": {
+              "type": "string",
+              "description": "Search query"
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Use this when getting results with cursormark pagination. For first call send `*` for subsequent calls, send the value of `next_cursor` returned in the previous call's results"
+            },
+            "sort_dir": {
+              "enum": ["asc", "desc"],
+              "type": "string",
+              "default": "desc",
+              "description": "Change sort direction to ascending (asc) or descending (desc)"
+            },
+            "highlight": {
+              "type": "boolean",
+              "description": "Pass a value of true to enable query highlight markers"
+            }
+          },
+          "description": "Query parameters for the request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/steel/tools.json
+++ b/backend/mcp_servers/steel/tools.json
@@ -1,0 +1,481 @@
+[
+  {
+    "name": "STEEL__RELEASE_SESSION",
+    "description": "Releases a specific session by ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RELEASE_SESSION",
+      "canonical_tool_description_hash": "96120a5fde81ef5fa68aee0280e2be864d040486b88f91fc03314e148feb3d26",
+      "canonical_tool_input_schema_hash": "c9cada70f44e69b19762b749f3c03621ef4409573089a27f05bb448ed8cd2a93"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the session to release"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "STEEL__GET_SESSION_LIVE_DETAILS",
+    "description": "Returns the live state of the session, including pages, tabs, and browser state.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SESSION_LIVE_DETAILS",
+      "canonical_tool_description_hash": "a2856f7be214fb48a2d8e673f3b156c03d2df00c7e9d6fbda1fab4610638c06d",
+      "canonical_tool_input_schema_hash": "912fe7836afd4bbf96e49fd00acb3293673917f212b7227fb1684a0bc7bc6f96"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the session to get live details for"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "STEEL__GET_SESSION_DETAILS",
+    "description": "Retrieves details of a specific session by ID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SESSION_DETAILS",
+      "canonical_tool_description_hash": "9dcd20f273da99302ccaed70502f37aa76a418d94c4eed6b81ddc63553d4b6ad",
+      "canonical_tool_input_schema_hash": "9ef8cf7009fd7c83a11cb8e3879384c88e2e7361a93c561b0698280601467315"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the session to retrieve"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "STEEL__GET_SESSION_CONTEXT",
+    "description": "Fetches the context data of a specific session.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SESSION_CONTEXT",
+      "canonical_tool_description_hash": "ce62b6ee68e9e0c0f4e88393c18fe60e7ecd094bceb93f7611693ed28b090638",
+      "canonical_tool_input_schema_hash": "9708ece5526ebae47b4c09f7c8f97fef150e8369dee724e5a70b9297dd6d6add"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the session to fetch context for"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "STEEL__GET_SESSION_EVENTS",
+    "description": "Get the recorded session events in the RRWeb format.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SESSION_EVENTS",
+      "canonical_tool_description_hash": "f99eeeff531388acbb9ebfb60b9d98c2d33633fb5e6bc6b56aaea92d36bebb06",
+      "canonical_tool_input_schema_hash": "3e0ff6df76b045d24157f56d336eebc6411957314d563bedba7fc8409371a8e8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the session to get recorded events for"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "STEEL__SCRAPE_WEBPAGE",
+    "description": "Extracts content from a specified URL. Returns the page content in various formats along with optional screenshot and PDF.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SCRAPE_WEBPAGE",
+      "canonical_tool_description_hash": "c89cf7847a07e13d32c3b95b5f484deeed5c00c4546fe041107b04a9b07631a8",
+      "canonical_tool_input_schema_hash": "b49feb2bc92b6decb6cc19c447a4c83c57ab44e7e7d0def068dfb276f210e189"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["url"],
+          "properties": {
+            "pdf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include a PDF of the page in the response"
+            },
+            "url": {
+              "type": "string",
+              "description": "URL of the webpage to scrape"
+            },
+            "delay": {
+              "type": "number",
+              "default": 0,
+              "description": "Delay before scraping (in milliseconds)"
+            },
+            "format": {
+              "type": "array",
+              "items": {
+                "enum": ["html", "cleaned_html", "markdown", "readability"],
+                "type": "string"
+              },
+              "description": "Desired format(s) for the scraped content. Default is 'html'."
+            },
+            "useProxy": {
+              "type": "boolean",
+              "default": false,
+              "description": "Use a Steel-provided residential proxy for the scrape"
+            },
+            "screenshot": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include a screenshot in the response"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "STEEL__CAPTURE_SCREENSHOT",
+    "description": "Captures a screenshot of a specified webpage.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CAPTURE_SCREENSHOT",
+      "canonical_tool_description_hash": "211f51d2dcebd6dfd4fba02327b1809a969d21cad012f5b545e4689193ce23fd",
+      "canonical_tool_input_schema_hash": "73a0afb35e7d58d8f3e6f642abc8dfe237a7a5426aebe4d17dbdd10b85e34221"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL of the webpage to capture"
+            },
+            "delay": {
+              "type": "number",
+              "default": 0,
+              "description": "Delay before capturing the screenshot (in milliseconds)"
+            },
+            "fullPage": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to capture the full scrollable page or just the viewport"
+            },
+            "useProxy": {
+              "type": "boolean",
+              "default": false,
+              "description": "Use a Steel-provided residential proxy for the request"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "STEEL__CONVERT_TO_PDF",
+    "description": "Generates a PDF from a specified webpage.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CONVERT_TO_PDF",
+      "canonical_tool_description_hash": "aab48e124c6ca37f136e53ae5724da3a973cb01b765bd94322448cb867c2a5c3",
+      "canonical_tool_input_schema_hash": "b6170031b000580d9c8f1f40c48037c12dbd6b2206ae89c1a33b5193d0936a66"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL of the webpage to convert to PDF"
+            },
+            "delay": {
+              "type": "number",
+              "default": 0,
+              "description": "Delay before generating the PDF (in milliseconds)"
+            },
+            "useProxy": {
+              "type": "boolean",
+              "default": false,
+              "description": "Use a Steel-provided residential proxy for the request"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "STEEL__LIST_SESSIONS",
+    "description": "Fetches all active sessions for the current organization.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_SESSIONS",
+      "canonical_tool_description_hash": "a2d3db4c3ca128f3c39c5856c772a2efce702812e46936ca96d6f112c3dbf396",
+      "canonical_tool_input_schema_hash": "d32b48be2dd7c0d1edf4f7a9c1061476776b8d2ca5cf0a76e2a347bd557de121"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "limit": {
+              "type": "integer",
+              "default": 50,
+              "description": "Number of sessions to return. Default is 50."
+            },
+            "status": {
+              "enum": ["live", "released", "failed"],
+              "type": "string",
+              "description": "Filter sessions by current status"
+            },
+            "cursorId": {
+              "type": "string",
+              "description": "Cursor ID for pagination"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "STEEL__CREATE_SESSION",
+    "description": "Creates a new session with the provided configuration.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_SESSION",
+      "canonical_tool_description_hash": "6747dc95f7fa8077b25290c37ad181714151e7eeb2d3093f3eb7c8e6df6a81a1",
+      "canonical_tool_input_schema_hash": "6777b1f5c70c0af06980316d5c38d7464c2dbed862c915fc4ee50788619861d4"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["dimensions"],
+          "properties": {
+            "timeout": {
+              "type": "integer",
+              "default": 300000,
+              "description": "Session timeout duration in milliseconds. Default is 300000 (5 minutes)."
+            },
+            "blockAds": {
+              "type": "boolean",
+              "default": false,
+              "description": "Block ads in the browser session. Default is false."
+            },
+            "proxyUrl": {
+              "type": "string",
+              "description": "Custom proxy URL for the browser session. Overrides useProxy, disabling Steel-provided proxies in favor of your specified proxy. Format: http(s)://username:password@hostname:port"
+            },
+            "useProxy": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable Steel-provided residential proxy usage for the browser session. Default is false, which routes requests through datacenter proxies."
+            },
+            "sessionId": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Optional custom UUID for the session"
+            },
+            "userAgent": {
+              "type": "string",
+              "description": "Custom user agent string for the browser session"
+            },
+            "dimensions": {
+              "type": "object",
+              "required": ["width", "height"],
+              "properties": {
+                "width": {
+                  "type": "integer",
+                  "description": "Width of the session"
+                },
+                "height": {
+                  "type": "integer",
+                  "description": "Height of the session"
+                }
+              },
+              "description": "Viewport and browser window dimensions for the session",
+              "additionalProperties": false
+            },
+            "isSelenium": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable Selenium mode for the browser session (default is false). Use this when you plan to connect to the browser session via Selenium."
+            },
+            "concurrency": {
+              "type": "integer",
+              "default": 1,
+              "description": "Number of sessions to create concurrently (check your plan limit)"
+            },
+            "solveCaptcha": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable automatic captcha solving. Default is false."
+            },
+            "sessionContext": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "cookies": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["name", "value", "domain"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Name of the cookie"
+                      },
+                      "path": {
+                        "type": "string",
+                        "default": "/",
+                        "description": "Path the cookie is valid for"
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "Value of the cookie"
+                      },
+                      "domain": {
+                        "type": "string",
+                        "description": "Domain the cookie belongs to"
+                      },
+                      "secure": {
+                        "type": "boolean",
+                        "description": "Whether the cookie requires HTTPS"
+                      },
+                      "expires": {
+                        "type": "number",
+                        "description": "Unix timestamp when the cookie expires"
+                      },
+                      "httpOnly": {
+                        "type": "boolean",
+                        "description": "Whether the cookie is HTTP only"
+                      },
+                      "sameSite": {
+                        "enum": ["Strict", "Lax", "None"],
+                        "type": "string",
+                        "description": "SameSite attribute of the cookie"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "description": "Cookies to initialize in the session"
+                },
+                "localStorage": {
+                  "type": "object",
+                  "required": [],
+                  "properties": {},
+                  "description": "Domain-specific localStorage items to initialize in the session",
+                  "additionalProperties": true
+                }
+              },
+              "description": "Session context data to be used in the created session. Sessions will start with an empty context by default.",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "STEEL__RELEASE_ALL_SESSIONS",
+    "description": "Releases all active sessions for the current organization.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RELEASE_ALL_SESSIONS",
+      "canonical_tool_description_hash": "953af39c46735e853565257666754be1bcd3d80f9ec005b72bffacf9df6691e2",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/supabase/tools.json
+++ b/backend/mcp_servers/supabase/tools.json
@@ -1,0 +1,1019 @@
+[
+  {
+    "name": "SUPABASE__CREATE_ORGANIZATION",
+    "description": "Create an organization",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_ORGANIZATION",
+      "canonical_tool_description_hash": "5e98756943a8ac8c216f1826156d2406be7b747276ca10c643de2553653de056",
+      "canonical_tool_input_schema_hash": "0725b8a9f211943120d27fe1a1042449688b76f7ed6bf4c302369319bd84180c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Organization name"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__LIST_PROJECTS",
+    "description": "List all projects",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_PROJECTS",
+      "canonical_tool_description_hash": "c5ee6da68ed44e33e7f6b714bd9528a0f5302566d86cb91abf466ac5990ad041",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__GET_PROJECT",
+    "description": "Get a project",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PROJECT",
+      "canonical_tool_description_hash": "caa70a1ce169902ed0568a986eca74a956bbab7d9e875d55c5ce457f81e9de00",
+      "canonical_tool_input_schema_hash": "a1865e874834dd943362d88daa0e32e743a1babf3098eab21022c26d23d31fed"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__CREATE_SSO_PROVIDER",
+    "description": "Creates a new SSO provider.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_SSO_PROVIDER",
+      "canonical_tool_description_hash": "72358dd9a116ef1915b6565512707edac39795b7e36c79ae46b178f673032a26",
+      "canonical_tool_input_schema_hash": "4d812e7aca9fa7fcc613a75c7e0a1f6213080e55c09d879f3427a44c1100d241"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "enum": ["saml"],
+              "type": "string",
+              "description": "Type of SSO provider"
+            },
+            "domains": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Domains"
+            },
+            "metadata_url": {
+              "type": "string",
+              "description": "Metadata URL"
+            },
+            "metadata_xml": {
+              "type": "string",
+              "description": "Metadata XML"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__REMOVE_SSO_PROVIDER",
+    "description": "Removes an SSO provider by its UUID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REMOVE_SSO_PROVIDER",
+      "canonical_tool_description_hash": "07b1182bb256b733efa559cb1c94c8305721c6887c03870d27586595d9e7e170",
+      "canonical_tool_input_schema_hash": "fd8aecad07ff49dfbc9e1ac34be3786975111bd59974da00cb5c545e68e91363"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref", "provider_id"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            },
+            "provider_id": {
+              "type": "string",
+              "description": "Provider ID"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__GET_SSO_PROVIDER",
+    "description": "Gets an SSO provider by its UUID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SSO_PROVIDER",
+      "canonical_tool_description_hash": "9047a719fb137c8ce0b599b663d25c5daa939ccbbdb4d07fdbec95ec41b62cf4",
+      "canonical_tool_input_schema_hash": "fd8aecad07ff49dfbc9e1ac34be3786975111bd59974da00cb5c545e68e91363"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref", "provider_id"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            },
+            "provider_id": {
+              "type": "string",
+              "description": "Provider ID"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__GET_AUTH_CONFIG",
+    "description": "Gets project's auth config.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_AUTH_CONFIG",
+      "canonical_tool_description_hash": "5e56758ec98ec0cddd76f61befdb983004e7179fedfb32b8a00ff39033e7fe42",
+      "canonical_tool_input_schema_hash": "a1865e874834dd943362d88daa0e32e743a1babf3098eab21022c26d23d31fed"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__LIST_SSO_PROVIDERS",
+    "description": "Lists all SSO providers.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_SSO_PROVIDERS",
+      "canonical_tool_description_hash": "f0409e717fc28debd62444cb902eac02a8655e5f2ab98f2ec328cb269876e31b",
+      "canonical_tool_input_schema_hash": "a1865e874834dd943362d88daa0e32e743a1babf3098eab21022c26d23d31fed"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__DISABLE_READONLY_MODE",
+    "description": "Disables project's readonly mode for the next 15 minutes.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DISABLE_READONLY_MODE",
+      "canonical_tool_description_hash": "18a543b6113196f7d7e75263ac1b861a7e1ebce9612f1626266eece8430a6cd4",
+      "canonical_tool_input_schema_hash": "a1865e874834dd943362d88daa0e32e743a1babf3098eab21022c26d23d31fed"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__GENERATE_TYPESCRIPT_TYPES",
+    "description": "Generates TypeScript types of your schema for use with supabase-js.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GENERATE_TYPESCRIPT_TYPES",
+      "canonical_tool_description_hash": "2e3b0408fe79061e96d3dbd8ddab8daf106455a456f413a3f2efd77818ba8be6",
+      "canonical_tool_input_schema_hash": "e4fdc58ab7dde8605683b6b524568e61f062f508bbce762881495d8f703e88af"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "included_schemas": {
+              "type": "string",
+              "description": "Included schemas"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__LIST_ORGANIZATIONS",
+    "description": "List all organizations",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_ORGANIZATIONS",
+      "canonical_tool_description_hash": "e7bea96af126fa717728b9795a6208c6ab38fd0b0c0e4358be89d66e8ddb02ce",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__LIST_ORGANIZATION_MEMBERS",
+    "description": "List members of an organization",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_ORGANIZATION_MEMBERS",
+      "canonical_tool_description_hash": "064bede8ebe7361b35d67bddad22229ff02ce585aa1590f23defd7c0954c0d0f",
+      "canonical_tool_input_schema_hash": "f72204cc3a3a7469a073da3bf45b6c461df762b4d609e2ea4adfc933b05f921f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["slug"],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "Organization slug"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__GET_ORGANIZATION",
+    "description": "Gets information about the organization",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ORGANIZATION",
+      "canonical_tool_description_hash": "1ebf7b652e40cefe856af1da0796a51e9d459165f261d3d1fdfe3dc6b5dd7a32",
+      "canonical_tool_input_schema_hash": "f72204cc3a3a7469a073da3bf45b6c461df762b4d609e2ea4adfc933b05f921f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["slug"],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "Organization slug"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__CREATE_PROJECT",
+    "description": "Create a project",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_PROJECT",
+      "canonical_tool_description_hash": "4492abb1312dc70f329026038ed03a4ecf48a49db9abb90728350d36c073510b",
+      "canonical_tool_input_schema_hash": "d4be2ff1f46ca52c3402510c8832c6d22e15e8c4b29dd0be0bc84ef92161588a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["db_pass", "name", "organization_id", "region"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Project name"
+            },
+            "region": {
+              "enum": [
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2",
+                "ap-east-1",
+                "ap-southeast-1",
+                "ap-northeast-1",
+                "ap-northeast-2",
+                "ap-southeast-2",
+                "eu-west-1",
+                "eu-west-2",
+                "eu-west-3",
+                "eu-north-1",
+                "eu-central-1",
+                "eu-central-2",
+                "ca-central-1",
+                "ap-south-1",
+                "sa-east-1"
+              ],
+              "type": "string",
+              "description": "Region"
+            },
+            "db_pass": {
+              "type": "string",
+              "description": "Database password"
+            },
+            "template_url": {
+              "type": "string",
+              "description": "Template URL"
+            },
+            "organization_id": {
+              "type": "string",
+              "description": "Organization ID"
+            },
+            "desired_instance_size": {
+              "enum": [
+                "micro",
+                "small",
+                "medium",
+                "large",
+                "xlarge",
+                "2xlarge",
+                "4xlarge",
+                "8xlarge",
+                "12xlarge",
+                "16xlarge"
+              ],
+              "type": "string",
+              "description": "Desired instance size"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__DELETE_PROJECT",
+    "description": "Deletes the given project",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_PROJECT",
+      "canonical_tool_description_hash": "80e77f258e6b7c6c935893a13d88de72ae5a869057dc0a714e4f9f2f381cf15b",
+      "canonical_tool_input_schema_hash": "a1865e874834dd943362d88daa0e32e743a1babf3098eab21022c26d23d31fed"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__RESTORE_PROJECT",
+    "description": "Restores the given project",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RESTORE_PROJECT",
+      "canonical_tool_description_hash": "0504b79488805374b3becfcf5b63038f7aac6d6cdaf60cf464d62c1bf6936a67",
+      "canonical_tool_input_schema_hash": "a1865e874834dd943362d88daa0e32e743a1babf3098eab21022c26d23d31fed"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__PAUSE_PROJECT",
+    "description": "Pauses the given project",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PAUSE_PROJECT",
+      "canonical_tool_description_hash": "c641507803df83b9a9ea3d455feb878efdcfb10c05954f5679448f2a95793dae",
+      "canonical_tool_input_schema_hash": "a1865e874834dd943362d88daa0e32e743a1babf3098eab21022c26d23d31fed"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__CANCEL_PROJECT_RESTORATION",
+    "description": "Cancels the given project restoration",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CANCEL_PROJECT_RESTORATION",
+      "canonical_tool_description_hash": "c3343a8e9633c8281e8ced9f67088178934a5b0c84161cbd4265183b3691bbdd",
+      "canonical_tool_input_schema_hash": "a1865e874834dd943362d88daa0e32e743a1babf3098eab21022c26d23d31fed"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__GET_PROJECT_HEALTH_STATUS",
+    "description": "Gets project's service health status",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PROJECT_HEALTH_STATUS",
+      "canonical_tool_description_hash": "d21b07ac37e5d4ac09729c48a1bba5aec4a37b842f7e855f4d09ded22d98a1a3",
+      "canonical_tool_input_schema_hash": "7f2d5bdfc4214b05f5dd66af2e8a7eadb3ea9eec12f47d03470fec17956cc3d1"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "query"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": ["services"],
+          "properties": {
+            "services": {
+              "type": "string",
+              "description": "Comma-separated list of services to check health for (e.g., 'auth,db,pooler,realtime,rest,storage')"
+            },
+            "timeout_ms": {
+              "type": "integer",
+              "description": "Timeout in milliseconds for the health check"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__GET_PROJECT_API_KEYS",
+    "description": "Get project api keys",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_PROJECT_API_KEYS",
+      "canonical_tool_description_hash": "887219fc4c127bb0e0b7a03f21b3009b34547155c2635aadcb4a19f2512fc3af",
+      "canonical_tool_input_schema_hash": "357997c8e22ff4576a4ce6fbe7e2b4798079e3d45eba1f56a306e689875b74cb"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "reveal": {
+              "type": "boolean",
+              "description": "Whether to reveal the API keys"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__RUN_SQL_QUERY",
+    "description": "[Beta] Run sql query",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RUN_SQL_QUERY",
+      "canonical_tool_description_hash": "346b1f772b30c875d026d27ecbbeca167a5b3da1e3c7f2ce28d1fb880ecd2c77",
+      "canonical_tool_input_schema_hash": "35a5795753437b4444c36f5747d8c34808cbda1acd8cebdf6c53476893f598a9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["query"],
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "SQL query to execute"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__LIST_ALL_EDGE_FUNCTIONS",
+    "description": "List all edge functions",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_ALL_EDGE_FUNCTIONS",
+      "canonical_tool_description_hash": "49417698905544c5ebc15556a7a789a86dd7b4544f8a9a5b72571c667ec0c69e",
+      "canonical_tool_input_schema_hash": "a1865e874834dd943362d88daa0e32e743a1babf3098eab21022c26d23d31fed"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__CREATE_EDGE_FUNCTION",
+    "description": "Create an edge function (deprecated - use deploy endpoint)",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_EDGE_FUNCTION",
+      "canonical_tool_description_hash": "b02cd25454ca5e9157f6c598b3e2d0a831f6c609264dbee20fa2b4193203732f",
+      "canonical_tool_input_schema_hash": "ab7816a93f604d8d1e4e68c46ff6d81490bd820e95f468e15bc8c045c1a82645"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["slug", "name", "body"],
+          "properties": {
+            "body": {
+              "type": "string",
+              "description": "Function code body"
+            },
+            "name": {
+              "type": "string",
+              "description": "Function name"
+            },
+            "slug": {
+              "type": "string",
+              "description": "Function slug"
+            },
+            "verify_jwt": {
+              "type": "boolean",
+              "description": "Verify JWT"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Function name"
+            },
+            "slug": {
+              "type": "string",
+              "description": "Function slug"
+            },
+            "import_map": {
+              "type": "boolean",
+              "description": "Import map enabled"
+            },
+            "verify_jwt": {
+              "type": "boolean",
+              "description": "Verify JWT"
+            },
+            "entrypoint_path": {
+              "type": "string",
+              "description": "Entrypoint path"
+            },
+            "import_map_path": {
+              "type": "string",
+              "description": "Import map path"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__DELETE_EDGE_FUNCTION",
+    "description": "Delete an edge function",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_EDGE_FUNCTION",
+      "canonical_tool_description_hash": "021cfbf7b0dc0c2ef809f8c597c29b69f1d1a5de5a3f1c99b14159c838b6eada",
+      "canonical_tool_input_schema_hash": "ba6835f37c25d9b08b0cfe95e8b5ffde35ed429b4ad8c34abf812e6f2083e2d9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref", "function_slug"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            },
+            "function_slug": {
+              "type": "string",
+              "description": "Function slug"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__GET_EDGE_FUNCTION",
+    "description": "Get an edge function",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_EDGE_FUNCTION",
+      "canonical_tool_description_hash": "fcc24d179b8698385491fe77ceaf7d17b07da5e59fbc72b27605da04b5c30c4d",
+      "canonical_tool_input_schema_hash": "ba6835f37c25d9b08b0cfe95e8b5ffde35ed429b4ad8c34abf812e6f2083e2d9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref", "function_slug"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            },
+            "function_slug": {
+              "type": "string",
+              "description": "Function slug"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__UPDATE_EDGE_FUNCTION",
+    "description": "Update an edge function",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_EDGE_FUNCTION",
+      "canonical_tool_description_hash": "d0ad7211ae913a0bd8a049ad2b311d78a67e49b299209b06ba3263d4bdac0d9d",
+      "canonical_tool_input_schema_hash": "0b7ec4af0dd0b6a8b67a7ebca404ff10f53270590e4eb79de7f4ba76af09c7e7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "body": {
+              "type": "string",
+              "description": "Function code body"
+            },
+            "name": {
+              "type": "string",
+              "description": "Function name"
+            },
+            "verify_jwt": {
+              "type": "boolean",
+              "description": "Verify JWT"
+            }
+          },
+          "description": "body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["ref", "function_slug"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            },
+            "function_slug": {
+              "type": "string",
+              "description": "Function slug"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Function name"
+            },
+            "import_map": {
+              "type": "boolean",
+              "description": "Import map enabled"
+            },
+            "verify_jwt": {
+              "type": "boolean",
+              "description": "Verify JWT"
+            },
+            "entrypoint_path": {
+              "type": "string",
+              "description": "Entrypoint path"
+            },
+            "import_map_path": {
+              "type": "string",
+              "description": "Import map path"
+            }
+          },
+          "description": "query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SUPABASE__GET_EDGE_FUNCTION_BODY",
+    "description": "Get an edge function body",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_EDGE_FUNCTION_BODY",
+      "canonical_tool_description_hash": "4ea34d8baeabaf85ad09b36532c0633a9150273505fa37d67174856113ea8161",
+      "canonical_tool_input_schema_hash": "ba6835f37c25d9b08b0cfe95e8b5ffde35ed429b4ad8c34abf812e6f2083e2d9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["ref", "function_slug"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "Project ref"
+            },
+            "function_slug": {
+              "type": "string",
+              "description": "Function slug"
+            }
+          },
+          "description": "path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/typefully/tools.json
+++ b/backend/mcp_servers/typefully/tools.json
@@ -1,0 +1,175 @@
+[
+  {
+    "name": "TYPEFULLY__CREATE_DRAFT",
+    "description": "Create a draft given some plain-text content",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_DRAFT",
+      "canonical_tool_description_hash": "f5cee4627b184cf558ce48dc6ea8e091b296128b698b639fb7a8097f2ddb17b8",
+      "canonical_tool_input_schema_hash": "998fbe3d8b0e48990a92a5a236067609ff5cca6d4e6e8f3e2d79ee0588969aee"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["content"],
+          "properties": {
+            "share": {
+              "type": "boolean",
+              "description": "If true, returned payload will include a share_url"
+            },
+            "content": {
+              "type": "string",
+              "description": "Content of the draft. You can split into multiple tweets by adding 4 consecutive newlines between tweets in the content."
+            },
+            "threadify": {
+              "type": "boolean",
+              "description": "Content will be automatically split into multiple tweets"
+            },
+            "schedule-date": {
+              "type": "string",
+              "description": "Can either be an ISO formatted date (e.g.: 2022-06-13T11:13:31.662Z) or 'next-free-slot'"
+            },
+            "auto_plug_enabled": {
+              "type": "boolean",
+              "description": "If true, the post will have an AutoPlug enabled, according to the one set on Typefully for the account"
+            },
+            "auto_retweet_enabled": {
+              "type": "boolean",
+              "description": "If true, the post will have an AutoRT enabled, according to the one set on Typefully for the account"
+            }
+          },
+          "description": "Draft content and options",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "TYPEFULLY__GET_RECENTLY_PUBLISHED_DRAFTS",
+    "description": "Get a list of all the most recently published drafts in Typefully",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_RECENTLY_PUBLISHED_DRAFTS",
+      "canonical_tool_description_hash": "a199eecc79c8503460a31d0070dbc8450d3aba273454a819e81aa6bf5c5791ef",
+      "canonical_tool_input_schema_hash": "07530d0a70dfacf52826512a5d98b9818f3ec6f9d649c1b13f5dca2e5466c35f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "content_filter": {
+              "enum": ["threads", "tweets"],
+              "type": "string",
+              "description": "Filters the list of drafts to only include tweets or threads"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "TYPEFULLY__GET_LATEST_NOTIFICATIONS",
+    "description": "Get the latest notifications from Typefully",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_LATEST_NOTIFICATIONS",
+      "canonical_tool_description_hash": "8483e8f12c6fe6c7e256e0b88ac7b5be6ff6dfba0ca530dfb4fdcdb9fd15f84f",
+      "canonical_tool_input_schema_hash": "2bc44200a436c8e627c05e3638211d834f6c5db7e528e785963f07ec9b01deb9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "kind": {
+              "enum": ["inbox", "activity"],
+              "type": "string",
+              "description": "Filter notifications based on whether they are inbox notifications (e.g. comments, replies) or activity events (e.g. tweet published)"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "TYPEFULLY__MARK_NOTIFICATIONS_READ",
+    "description": "Mark all notifications as read",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "MARK_NOTIFICATIONS_READ",
+      "canonical_tool_description_hash": "6d82efd5f9d1ca3a690b7839f156d0abf6ceb81dac377f5cc632a099c59f9bab",
+      "canonical_tool_input_schema_hash": "def2f477aedadfadd0e5d8d2bc5a22a418b3feeecdd265fc400fa05cd795c675"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "kind": {
+              "enum": ["inbox", "activity"],
+              "type": "string",
+              "description": "Specifies whether to mark inbox notifications (e.g. comments, replies) or activities (e.g. publishing events) as read"
+            },
+            "username": {
+              "type": "string",
+              "description": "The username of the account. If given, it will only mark read notifications for that specific account"
+            }
+          },
+          "description": "Options for marking notifications as read",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "TYPEFULLY__GET_RECENTLY_SCHEDULED_DRAFTS",
+    "description": "Get a list of all the most recently scheduled drafts in Typefully",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_RECENTLY_SCHEDULED_DRAFTS",
+      "canonical_tool_description_hash": "cef5a26daf5d86a57a5b0bb5b16dd0d1d88d0694b2ff8a8caee5e695a5a44b0d",
+      "canonical_tool_input_schema_hash": "07530d0a70dfacf52826512a5d98b9818f3ec6f9d649c1b13f5dca2e5466c35f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "content_filter": {
+              "enum": ["threads", "tweets"],
+              "type": "string",
+              "description": "Filters the list of drafts to only include tweets or threads"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/ultra_msg/tools.json
+++ b/backend/mcp_servers/ultra_msg/tools.json
@@ -1,0 +1,187 @@
+[
+  {
+    "name": "ULTRA_MSG__GET_ALL_GROUPS",
+    "description": "Retrieves all WhatsApp groups associated with the UltraMsg instance, including group ID, name, description, and participants.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_ALL_GROUPS",
+      "canonical_tool_description_hash": "a1734a36a92b62ab3e28f65b10d3b7a8f378899614461e2a27a7f7f4cae02585",
+      "canonical_tool_input_schema_hash": "8677c9d9fd6d5cc38cc4eb97df76ada1a733847beae90489c3b2a43ada9e4f7c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the UltraMsg instance."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ULTRA_MSG__GET_GROUP_IDS",
+    "description": "Retrieves a list of all WhatsApp group IDs associated with the specified UltraMsg instance.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_GROUP_IDS",
+      "canonical_tool_description_hash": "d19897ed12092d9f35c9722163027111cc6a340613949f1af2ba8fb7b0298ac7",
+      "canonical_tool_input_schema_hash": "8677c9d9fd6d5cc38cc4eb97df76ada1a733847beae90489c3b2a43ada9e4f7c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the UltraMsg instance."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ULTRA_MSG__SEND_CHAT_MESSAGE",
+    "description": "Sends a text message to a phone number or group via UltraMsg WhatsApp API. The message body supports UTF-8 or UTF-16 encoding with emojis. Maximum length is 4096 characters.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEND_CHAT_MESSAGE",
+      "canonical_tool_description_hash": "a72ca409ca16bb43b6d1f43ebc75c2270e2cb9c0473ff3ff00e572f04d777918",
+      "canonical_tool_input_schema_hash": "95633101460a15508d6851dbaea208a14daa4f3703385902a98c49e1334f905f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["to", "body"],
+          "properties": {
+            "to": {
+              "type": "string",
+              "description": "Recipient's phone number in international format (e.g., +14155552671) or chat ID for contact or group (e.g., [email\u00a0protected] or [email\u00a0protected])."
+            },
+            "body": {
+              "type": "string",
+              "description": "The text message content. Supports UTF-8 or UTF-16 encoding with emojis. Maximum length is 4096 characters."
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the UltraMsg instance."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ULTRA_MSG__GET_MESSAGES_BY_STATUS",
+    "description": "Retrieves a list of messages for a given UltraMsg instance, filtered by message status such as 'sent', 'unsent', 'queue', 'invalid', or 'all'.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_MESSAGES_BY_STATUS",
+      "canonical_tool_description_hash": "d7a7704163f38d52acc2975856ec655af45f498f5f24fbf6b05c7a3b83099772",
+      "canonical_tool_input_schema_hash": "3a43713ccc207fda9c0388a9be611f93a6e53768915cb9e9fdf34989af007f25"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the UltraMsg instance."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "page": {
+              "type": "integer",
+              "description": "Page number for pagination."
+            },
+            "sort": {
+              "type": "string",
+              "description": "Sort order of the results. 'asc' for ascending, 'desc' for descending."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Number of results per page (max 100)."
+            },
+            "status": {
+              "type": "string",
+              "description": "Filter messages by status. Valid values: 'sent', 'queue', 'unsent', 'invalid', or 'all'."
+            }
+          },
+          "description": "Query parameters for filtering and pagination",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ULTRA_MSG__GET_CONTACTS",
+    "description": "Retrieves the list of contacts associated with the specified UltraMsg instance.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_CONTACTS",
+      "canonical_tool_description_hash": "5d6835f2e070303b5fefc6ab6562e5d6ef8151f2cc963095abc3f1922f90182e",
+      "canonical_tool_input_schema_hash": "8677c9d9fd6d5cc38cc4eb97df76ada1a733847beae90489c3b2a43ada9e4f7c"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["instance_id"],
+          "properties": {
+            "instance_id": {
+              "type": "string",
+              "description": "The ID of the UltraMsg instance."
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/vercel/tools.json
+++ b/backend/mcp_servers/vercel/tools.json
@@ -1,0 +1,1342 @@
+[
+  {
+    "name": "VERCEL__GET_URL_TO_INSTALL_VERCEL_APP_IN_GITHUB",
+    "description": "Installs the Vercel app in a GitHub repository. It will return a URL that user can follow to install the Vercel app in their GitHub repository.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_URL_TO_INSTALL_VERCEL_APP_IN_GITHUB",
+      "canonical_tool_description_hash": "0467a8a3d6e059a8c0982365b46a923fc712702963cb7630cd1f97b3550d53ca",
+      "canonical_tool_input_schema_hash": "d746974fa9afd5e951f76f9af38954b0ad7f436f2120dc974da65e5ee39f856f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__CREATE_PROJECT",
+    "description": "Creates a new project on Vercel.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_PROJECT",
+      "canonical_tool_description_hash": "764477a45c7eee14ca61091d91ecc2f9ec0926e91bc272f4afe17e7a85a306bb",
+      "canonical_tool_input_schema_hash": "67335fa5576af43ea9a66223ac176603148d9e506dc08922e6541e85a724c825"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The desired name for the project"
+            },
+            "framework": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "blitzjs",
+                    "nextjs",
+                    "gatsby",
+                    "remix",
+                    "react-router",
+                    "astro",
+                    "hexo",
+                    "eleventy",
+                    "docusaurus-2",
+                    "docusaurus",
+                    "preact",
+                    "solidstart-1",
+                    "solidstart",
+                    "dojo",
+                    "ember",
+                    "vue",
+                    "scully",
+                    "ionic-angular",
+                    "angular",
+                    "polymer",
+                    "svelte",
+                    "sveltekit",
+                    "sveltekit-1",
+                    "ionic-react",
+                    "create-react-app",
+                    "gridsome",
+                    "umijs",
+                    "sapper",
+                    "saber",
+                    "stencil",
+                    "nuxtjs",
+                    "redwoodjs",
+                    "hugo",
+                    "jekyll",
+                    "brunch",
+                    "middleman",
+                    "zola",
+                    "hydrogen",
+                    "vite",
+                    "vitepress",
+                    "vuepress",
+                    "parcel",
+                    "fasthtml",
+                    "sanity-v3",
+                    "sanity",
+                    "storybook"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The framework that is being used for this project. When null is used no framework is selected"
+            },
+            "gitRepository": {
+              "type": "object",
+              "required": ["repo", "type"],
+              "properties": {
+                "repo": {
+                  "type": "string",
+                  "description": "The name of the git repository."
+                },
+                "type": {
+                  "enum": ["github", "gitlab", "bitbucket"],
+                  "type": "string",
+                  "default": "github",
+                  "description": "The Git Provider of the repository"
+                }
+              },
+              "description": "The Git Repository that will be connected to the project. When this is defined, any pushes to the specified connected Git Repository will be automatically deployed. The Vercel app must be installed first to use this feature.",
+              "additionalProperties": false
+            },
+            "rootDirectory": {
+              "type": "string",
+              "description": "The name of a directory or relative path to the source code of your project. When null is used it will default to the project root. Maximum length: 256."
+            },
+            "environmentVariables": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "visible": ["key", "target", "value", "gitBranch", "type"],
+                "required": ["key", "target", "value", "type"],
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "description": "Name of the ENV variable"
+                  },
+                  "type": {
+                    "enum": ["system", "secret", "encrypted", "plain", "sensitive"],
+                    "type": "string",
+                    "description": "Type of the ENV variable"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "Value for the ENV variable"
+                  },
+                  "target": {
+                    "enum": ["production", "preview", "development"],
+                    "type": "string",
+                    "description": "Deployment Target or Targets in which the ENV variable will be used"
+                  },
+                  "gitBranch": {
+                    "type": "string",
+                    "description": "If defined, the git branch of the environment variable (must have target=preview). Maximum length: 250."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "Environment variables to be applied to the project"
+            }
+          },
+          "description": "Request body parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__UPDATE_PROJECT",
+    "description": "Updates an existing project on Vercel using either its name or id.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "UPDATE_PROJECT",
+      "canonical_tool_description_hash": "c8f428ba2c32f784693d72254c0b44f54b1fbd8ef50c13fce0e6c42904b17618",
+      "canonical_tool_input_schema_hash": "e3d84829ece45f3aef7e07dcff2b3c888e50a36a1782d29907807107c9458ea9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The desired name for the project. Maximum length: 100."
+            },
+            "framework": {
+              "enum": [
+                "blitzjs",
+                "nextjs",
+                "gatsby",
+                "remix",
+                "react-router",
+                "astro",
+                "hexo",
+                "eleventy",
+                "docusaurus-2",
+                "docusaurus",
+                "preact",
+                "solidstart-1",
+                "solidstart",
+                "dojo",
+                "ember",
+                "vue",
+                "scully",
+                "ionic-angular",
+                "angular",
+                "polymer",
+                "svelte",
+                "sveltekit",
+                "sveltekit-1",
+                "ionic-react",
+                "create-react-app",
+                "gridsome",
+                "umijs",
+                "sapper",
+                "saber",
+                "stencil",
+                "nuxtjs",
+                "redwoodjs",
+                "hugo",
+                "jekyll",
+                "brunch",
+                "middleman",
+                "zola",
+                "hydrogen",
+                "vite",
+                "vitepress",
+                "vuepress",
+                "parcel",
+                "fasthtml",
+                "sanity-v3",
+                "sanity",
+                "storybook",
+                null
+              ],
+              "type": "string",
+              "description": "The framework that is being used for this project. When null is used no framework is selected"
+            },
+            "devCommand": {
+              "type": "string",
+              "description": "The dev command for this project. When null is used this value will be automatically detected. Maximum length: 256."
+            },
+            "buildCommand": {
+              "type": "string",
+              "description": "The build command for this project. When null is used this value will be automatically detected. Maximum length: 256."
+            },
+            "rootDirectory": {
+              "type": "string",
+              "description": "The name of a directory or relative path to the source code of your project. When null is used it will default to the project root. Maximum length: 256."
+            },
+            "installCommand": {
+              "type": "string",
+              "description": "The install command for this project. When null is used this value will be automatically detected. Maximum length: 256."
+            }
+          },
+          "description": "Request body parameters for updating the project",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["idOrName"],
+          "properties": {
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__LIST_PROJECTS",
+    "description": "Lists all projects for the authenticated user.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_PROJECTS",
+      "canonical_tool_description_hash": "8b92af721339af03b6c88876346f4aace42166ff41bb84f1912c4cb9f7dbc5c2",
+      "canonical_tool_input_schema_hash": "26521a167cd0fd758c68b89715b5b63a7fecca7fd702a0e015846c946564f7e0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "repo": {
+              "type": "string",
+              "description": "Filter results to only include projects belonging to the specified repository."
+            },
+            "slug": {
+              "type": "string",
+              "description": "The team slug to perform the request on behalf of a specific team."
+            },
+            "limit": {
+              "type": "string",
+              "description": "Limits the number of projects returned in the response."
+            },
+            "repoId": {
+              "type": "string",
+              "description": "Filter results by the unique Repository ID."
+            },
+            "search": {
+              "type": "string",
+              "description": "Search for projects by their name. Maximum length: 100 characters."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            },
+            "repoUrl": {
+              "type": "string",
+              "description": "Filter results by the full Repository URL."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__FIND_PROJECT_BY_ID_OR_NAME",
+    "description": "Get the information for a specific project by passing either the project id or name in the URL.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "FIND_PROJECT_BY_ID_OR_NAME",
+      "canonical_tool_description_hash": "9286924e76834e9c3dd619607777e88500fb27bed9984c9294fb27e5ca4e1fbb",
+      "canonical_tool_input_schema_hash": "54dce37ee0a91062bc3519ee0f41e17447a54601583203981f7a288773e43403"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["idOrName"],
+          "properties": {
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__DELETE_PROJECT",
+    "description": "Deletes a specific project by its id or name on Vercel.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DELETE_PROJECT",
+      "canonical_tool_description_hash": "3eec5a1efbc9d3549672ed8a5c3b6c5542c5b2eb6ebce9b858062bee02a68ea8",
+      "canonical_tool_input_schema_hash": "54dce37ee0a91062bc3519ee0f41e17447a54601583203981f7a288773e43403"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["idOrName"],
+          "properties": {
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__DEPLOY",
+    "description": "Creates a new deployment on Vercel. A vercel project must be created first.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DEPLOY",
+      "canonical_tool_description_hash": "47924a3b6e17d9a09dddf51a1688fe796506d5998b65295eb7f6be9d2b1cfba9",
+      "canonical_tool_input_schema_hash": "59ec11e4cd0dd87cd4bb48541e9ba581f2560ca8790c66f148d1b43691d3409b"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name", "gitSource", "project"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "A string with the project name used in the deployment URL."
+            },
+            "target": {
+              "type": "string",
+              "description": "Either not defined, 'staging', 'production', or a custom environment identifier. If omitted, the target will be preview."
+            },
+            "project": {
+              "type": "string",
+              "description": "The target project identifier in which the deployment will be created. Overrides name if defined."
+            },
+            "gitSource": {
+              "type": "object",
+              "required": ["org", "ref", "repo", "type"],
+              "properties": {
+                "org": {
+                  "type": "string",
+                  "description": "The organization/user of the repo."
+                },
+                "ref": {
+                  "type": "string",
+                  "description": "The branch or ref to deploy."
+                },
+                "sha": {
+                  "type": "string",
+                  "description": "The commit SHA to deploy."
+                },
+                "repo": {
+                  "type": "string",
+                  "description": "The repository name."
+                },
+                "type": {
+                  "enum": ["github"],
+                  "type": "string",
+                  "description": "The Git provider type. Only 'github' is supported."
+                }
+              },
+              "description": "Defines the Git Repository source to be deployed. Required for git deployments.",
+              "additionalProperties": false
+            },
+            "deploymentId": {
+              "type": "string",
+              "description": "A deployment id for an existing deployment to redeploy."
+            },
+            "withLatestCommit": {
+              "type": "boolean",
+              "description": "When true and deploymentId is passed in, the sha from the previous deployment's gitSource is removed forcing the latest commit to be used."
+            },
+            "customEnvironmentSlugOrId": {
+              "type": "string",
+              "description": "Deploy to a custom environment, which will override the default environment."
+            }
+          },
+          "description": "Request body parameters for deployment creation.",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            },
+            "forceNew": {
+              "enum": ["0", "1"],
+              "type": "string",
+              "description": "Forces a new deployment even if there is a previous similar deployment."
+            },
+            "skipAutoDetectionConfirmation": {
+              "enum": ["0", "1"],
+              "type": "string",
+              "description": "Allows to skip framework detection so the API would not fail to ask for confirmation."
+            }
+          },
+          "description": "Optional query parameters for the http request.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__LIST_DEPLOYMENTS",
+    "description": "List deployments under the authenticated user or team. If a deployment hasn't finished uploading (is incomplete), the url property will have a value of null.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "LIST_DEPLOYMENTS",
+      "canonical_tool_description_hash": "f6e056cf09ac0ca3256de0cdc5cc8c47ed2e5c305189b405fb5702eaef8021b5",
+      "canonical_tool_input_schema_hash": "5a25084e56a9e455be38566b02f210e693d7718a993f87e7561bd6db59334ab7"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "app": {
+              "type": "string",
+              "description": "Name of the deployment."
+            },
+            "sha": {
+              "type": "string",
+              "description": "Filter deployments based on the SHA"
+            },
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum number of deployments to list from a request."
+            },
+            "since": {
+              "type": "number",
+              "description": "Get Deployments created after this JavaScript timestamp."
+            },
+            "state": {
+              "type": "string",
+              "description": "Filter deployments based on their state (BUILDING, ERROR, INITIALIZING, QUEUED, READY, CANCELED)"
+            },
+            "until": {
+              "type": "number",
+              "description": "Get Deployments created before this JavaScript timestamp."
+            },
+            "users": {
+              "type": "string",
+              "description": "Filter out deployments based on users who have created the deployment."
+            },
+            "branch": {
+              "type": "string",
+              "description": "Filter deployments based on the branch name"
+            },
+            "target": {
+              "type": "string",
+              "description": "Filter deployments based on the environment."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            },
+            "projectId": {
+              "type": "string",
+              "description": "Filter deployments from the given ID or name."
+            },
+            "rollbackCandidate": {
+              "type": "boolean",
+              "description": "Filter deployments based on their rollback candidacy"
+            }
+          },
+          "description": "Optional query parameters for filtering deployments",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__GET_DEPLOYMENT",
+    "description": "Retrieves information for a deployment either by supplying its ID (id property) or Hostname (url property). Additional details will be included when the authenticated user or team is an owner of the deployment.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DEPLOYMENT",
+      "canonical_tool_description_hash": "34006d624d7c16012f4c76245a8bdfb8845f7bccb5d689c9966752ce2abdf0d7",
+      "canonical_tool_input_schema_hash": "30deb4e4aa006f83eeddf670985a2b607d20f2d951e7ed6bbdfcf11814484066"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["idOrUrl"],
+          "properties": {
+            "idOrUrl": {
+              "type": "string",
+              "description": "The unique identifier or hostname of the deployment."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            },
+            "withGitRepoInfo": {
+              "type": "string",
+              "description": "Whether to add in gitRepo information."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__GET_DEPLOYMENT_EVENTS",
+    "description": "Get the build logs of a deployment by deployment ID and build ID. It can work as an infinite stream of logs or as a JSON endpoint depending on the input parameters.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_DEPLOYMENT_EVENTS",
+      "canonical_tool_description_hash": "c3741032bcdf0d4b5d436254fd69ab64b04ce9f9ad5b242720de3058d4d4e245",
+      "canonical_tool_input_schema_hash": "f2119df941a4eab4bc497e4844e56b476de4a34a65c7a3edeb0e6354a16f85c2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["idOrUrl"],
+          "properties": {
+            "idOrUrl": {
+              "type": "string",
+              "description": "The unique identifier or hostname of the deployment."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Deployment build ID."
+            },
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum number of events to return. Provide -1 to return all available logs."
+            },
+            "since": {
+              "type": "number",
+              "description": "Timestamp for when build logs should be pulled from."
+            },
+            "until": {
+              "type": "number",
+              "description": "Timestamp for when the build logs should be pulled up until."
+            },
+            "builds": {
+              "enum": [0, 1],
+              "type": "number",
+              "description": "Whether to include build information in the response."
+            },
+            "follow": {
+              "enum": [0, 1],
+              "type": "number",
+              "description": "When enabled, this endpoint will return live events as they happen."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            },
+            "delimiter": {
+              "enum": [0, 1],
+              "type": "number",
+              "description": "Whether to include delimiter in the response."
+            },
+            "direction": {
+              "enum": ["backward", "forward"],
+              "type": "string",
+              "default": "forward",
+              "description": "Order of the returned events based on the timestamp."
+            },
+            "statusCode": {
+              "type": "number",
+              "description": "HTTP status code range to filter events by."
+            }
+          },
+          "description": "Optional query parameters for filtering and controlling event output",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__ADD_DOMAIN_TO_PROJECT",
+    "description": "Adds a domain to a Vercel project by project id or name.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ADD_DOMAIN_TO_PROJECT",
+      "canonical_tool_description_hash": "aed432faddbed666c64b63b3fdd65a1b3db2b9a8fd7732c4d83e30ccec28d245",
+      "canonical_tool_input_schema_hash": "122e97547690321715ca110c0145cce192d2793e9fae91a6ece412b88eb15b18"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The project domain name."
+            }
+          },
+          "description": "Request body parameters for adding a domain to a project.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["idOrName"],
+          "properties": {
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__RETRIEVE_PROJECT_DOMAINS",
+    "description": "Retrieves the domains associated with a Vercel project by project id or name. Supports filtering by production, target, gitBranch, redirects, verified, limit, teamId, and slug.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RETRIEVE_PROJECT_DOMAINS",
+      "canonical_tool_description_hash": "8827e85172d0ea0223ad0ab560888cdda54f2dd3d794e06490d46aa98a087af8",
+      "canonical_tool_input_schema_hash": "6e1b5ddd50b9a4f164a17f8fd69159f543cbadff93a659725d2cb62478c602bd"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["idOrName"],
+          "properties": {
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum number of domains to list from a request (max 100)."
+            },
+            "target": {
+              "enum": ["production", "preview"],
+              "type": "string",
+              "description": "Filters on the target of the domain."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            },
+            "verified": {
+              "enum": ["true", "false"],
+              "type": "string",
+              "description": "Filters domains based on their verification status."
+            },
+            "gitBranch": {
+              "type": "string",
+              "description": "Filters domains based on specific branch."
+            },
+            "redirects": {
+              "enum": ["true", "false"],
+              "type": "string",
+              "description": "Includes or excludes redirect project domains."
+            },
+            "production": {
+              "enum": ["true", "false"],
+              "type": "string",
+              "description": "Filters only production domains when set to true."
+            }
+          },
+          "description": "Optional query parameters for filtering domains.",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__GET_A_PROJECT_DOMAIN",
+    "description": "Gets a project domain by project id or name and domain name.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_A_PROJECT_DOMAIN",
+      "canonical_tool_description_hash": "7ec1be0a6a620183d4afb91c2b0418b8bf27760ddadbd1af403e2793ca9a356e",
+      "canonical_tool_input_schema_hash": "04795e0b9172f623c06f6007272c0b8d02a96916e70aba87a07056b655941315"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["idOrName", "domain"],
+          "properties": {
+            "domain": {
+              "type": "string",
+              "description": "The project domain name."
+            },
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__REMOVE_DOMAIN_FROM_PROJECT",
+    "description": "Removes a domain from a Vercel project by project id or name and domain name. Optionally removes all redirects to the domain.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REMOVE_DOMAIN_FROM_PROJECT",
+      "canonical_tool_description_hash": "e6e3ea46481aedaff68fb8112f6c40a3e8fe18bff35bd0e706c835beb27af80a",
+      "canonical_tool_input_schema_hash": "79dede22d1868766fff96fead4ffe59b1d2e2f592bd1917deec5dd879412ec83"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "removeRedirects": {
+              "type": "boolean",
+              "description": "Whether to remove all domains from this project that redirect to the domain being removed."
+            }
+          },
+          "description": "Optional body parameters for removing a domain from a project.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["idOrName", "domain"],
+          "properties": {
+            "domain": {
+              "type": "string",
+              "description": "The project domain name."
+            },
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__CREATE_ENVIRONMENT_VARIABLES",
+    "description": "Create one or more environment variables for a project by passing its key, value, type and target and by specifying the project by either passing the project id or name in the URL. If you include upsert=true as a query parameter, a new environment variable will not be created if it already exists but, the existing variable's value will be updated.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "CREATE_ENVIRONMENT_VARIABLES",
+      "canonical_tool_description_hash": "9c2a71244e7c4e8f13bccf3a15e54d0c6866f96a5613c3e815b35ae714d79497",
+      "canonical_tool_input_schema_hash": "101e4a35f0d278a06d39fd2b7eee06c5607ac0940e9f6aa50b1b448fa039f58f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": ["key", "value", "type", "target"],
+          "properties": {
+            "key": {
+              "type": "string",
+              "description": "Name of the ENV variable."
+            },
+            "type": {
+              "enum": ["system", "secret", "encrypted", "plain", "sensitive"],
+              "type": "string",
+              "description": "Type of the ENV variable."
+            },
+            "value": {
+              "type": "string",
+              "description": "Value for the ENV variable."
+            },
+            "target": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "available options: production, preview, development"
+              },
+              "description": "Deployment Target or Targets in which the ENV variable will be used."
+            }
+          },
+          "description": "Request body parameters for creating environment variables.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["idOrName"],
+          "properties": {
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            },
+            "upsert": {
+              "type": "string",
+              "description": "Allow override of environment variable if it already exists."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__EDIT_ENVIRONMENT_VARIABLE",
+    "description": "Edit a specific environment variable for a given project by passing the environment variable identifier and either passing the project id or name in the URL.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "EDIT_ENVIRONMENT_VARIABLE",
+      "canonical_tool_description_hash": "fc59bd0188e06373498df2920e9ba951a3729dbf5a220ea716f516f7383887b3",
+      "canonical_tool_input_schema_hash": "f6d4740a3207d29b12f50d01e1deb116fad2733b841a596c249f14e553500489"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path", "body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "key": {
+              "type": "string",
+              "description": "The name of the environment variable."
+            },
+            "type": {
+              "enum": ["plain", "sensitive"],
+              "type": "string",
+              "description": "The type of environment variable."
+            },
+            "value": {
+              "type": "string",
+              "description": "The value of the environment variable."
+            },
+            "target": {
+              "type": "array",
+              "items": {
+                "enum": ["production", "preview", "development"],
+                "type": "string"
+              },
+              "description": "The target environment of the environment variable."
+            },
+            "comment": {
+              "type": "string",
+              "description": "A comment to add context on what this env var is for. Maximum length: 500."
+            },
+            "gitBranch": {
+              "type": "string",
+              "description": "If defined, the git branch of the environment variable (must have target=preview). Maximum length: 250."
+            },
+            "customEnvironmentIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The custom environments that the environment variable should be synced to."
+            }
+          },
+          "description": "Request body parameters for editing an environment variable.",
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "required": ["idOrName", "id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique environment variable identifier."
+            },
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__REMOVE_ENVIRONMENT_VARIABLE",
+    "description": "Delete a specific environment variable for a given project by passing the environment variable identifier and either passing the project id or name in the URL.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "REMOVE_ENVIRONMENT_VARIABLE",
+      "canonical_tool_description_hash": "7d4d192b090163748a18f849e41ffa83baf791e0db19cc4aca84a2b001127a00",
+      "canonical_tool_input_schema_hash": "5d90cd0b1ab7b5fb008cd4aeae17720430a04dc87a07b8fb755701732c3ccdbc"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["idOrName", "id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique environment variable identifier."
+            },
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            },
+            "customEnvironmentId": {
+              "type": "string",
+              "description": "The unique custom environment identifier within the project."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__RETRIEVE_ENVIRONMENT_VARIABLES",
+    "description": "Retrieve the environment variables for a given project by passing either the project id or name in the URL.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RETRIEVE_ENVIRONMENT_VARIABLES",
+      "canonical_tool_description_hash": "ac12459c1c96790beb633425f72c5687832baa639492463ac7c4eca0e5b64467",
+      "canonical_tool_input_schema_hash": "9ebe5dd5f4afbaf6b2df95690cd0beefa0eaaacafc90482c7c2ee8fa7b79358f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["idOrName"],
+          "properties": {
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "source": {
+              "type": "string",
+              "description": "The source that is calling the endpoint."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            },
+            "decrypt": {
+              "enum": ["true", "false"],
+              "type": "string",
+              "description": "If true, the environment variable value will be decrypted. (deprecated)"
+            },
+            "gitBranch": {
+              "type": "string",
+              "description": "If defined, the git branch of the environment variable to filter the results (must have target=preview). Maximum length: 250."
+            },
+            "customEnvironmentId": {
+              "type": "string",
+              "description": "The unique custom environment identifier within the project."
+            },
+            "customEnvironmentSlug": {
+              "type": "string",
+              "description": "The custom environment slug (name) within the project."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "VERCEL__RETRIEVE_DECRYPTED_ENVIRONMENT_VARIABLE",
+    "description": "Retrieve the decrypted value of an environment variable for a given project.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RETRIEVE_DECRYPTED_ENVIRONMENT_VARIABLE",
+      "canonical_tool_description_hash": "0ff1d43062c567ffc1a7fddd2be9537b62fff2c5a6a9bd41e8f0e5fd1122ff71",
+      "canonical_tool_input_schema_hash": "71e985e1687a0063a369c66597a0c4b4506d31981e5b3fc5876b91bfcce2948d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["idOrName", "id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The unique ID for the environment variable to get the decrypted value."
+            },
+            "idOrName": {
+              "type": "string",
+              "description": "The unique project identifier or the project name."
+            }
+          },
+          "description": "Path parameters for the http request",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "slug": {
+              "type": "string",
+              "description": "The Team slug to perform the request on behalf of."
+            },
+            "teamId": {
+              "type": "string",
+              "description": "The Team identifier to perform the request on behalf of."
+            }
+          },
+          "description": "Optional query parameters for the http request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/x/tools.json
+++ b/backend/mcp_servers/x/tools.json
@@ -1,0 +1,914 @@
+[
+  {
+    "name": "X__GET_POST_BY_ID",
+    "description": "Retrieve a specific post by its ID. Returns detailed post information including metrics and context.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_POST_BY_ID",
+      "canonical_tool_description_hash": "ca2575510c8c795f8ccc93c88a980f66b046bed5234aa6ed1312c50ab7ce855a",
+      "canonical_tool_input_schema_hash": "2cb542d7d10d55d58d0d7554fd793dfce4e603a4bef0ccae5117a88b9c56b755"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the post to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username,verified",
+              "description": "Comma-separated list of user fields to include"
+            },
+            "tweet.fields": {
+              "type": "string",
+              "default": "id,text,author_id,created_at,public_metrics,context_annotations",
+              "description": "Comma-separated list of tweet fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_POSTS_BY_IDS",
+    "description": "Retrieve multiple posts by their IDs. Returns detailed information for up to 100 posts.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_POSTS_BY_IDS",
+      "canonical_tool_description_hash": "2e431886998d2f58865376573da7503ab4055233ddd8b5b45f8025e804ac2854",
+      "canonical_tool_input_schema_hash": "d573d5582c3b38384facf798624ebe876bb9c02ac2945adc42379525e20fa46e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["ids"],
+          "properties": {
+            "ids": {
+              "type": "string",
+              "description": "Comma-separated list of post IDs (up to 100)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username",
+              "description": "Comma-separated list of user fields to include"
+            },
+            "tweet.fields": {
+              "type": "string",
+              "default": "id,text,author_id,created_at,public_metrics",
+              "description": "Comma-separated list of tweet fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__SEARCH_POSTS",
+    "description": "Search for posts published in the last 7 days using a query. Returns matching posts with comprehensive metadata.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_POSTS",
+      "canonical_tool_description_hash": "aae49c961ab425bdbddfb0230633d72271d65aa150a46bbd2e2c757a7ffa0881",
+      "canonical_tool_input_schema_hash": "5ac02149fcf1529d8cd866156c8e9e01b7024d446e0f35404a60493ffd0b23f8"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["query"],
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "Search query string. Supports boolean operators, hashtags, mentions, and advanced search syntax."
+            },
+            "max_results": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 100,
+              "minimum": 10,
+              "description": "Maximum number of results to return (10-100, default: 10)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username",
+              "description": "Comma-separated list of user fields to include"
+            },
+            "tweet.fields": {
+              "type": "string",
+              "default": "id,text,author_id,created_at,public_metrics",
+              "description": "Comma-separated list of tweet fields to include"
+            }
+          },
+          "description": "Query parameters for the search",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_USER_POSTS",
+    "description": "Get posts from a specific user's timeline. Returns the user's recent posts with engagement metrics.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_USER_POSTS",
+      "canonical_tool_description_hash": "0f70d310a46166f299504c4bda992d0b60f247ac06c765013894d8cd31694a9e",
+      "canonical_tool_input_schema_hash": "7190756ea36ce660d99743d9850ffd03d146c703cfc9436b40dde5b2d797f1ad"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the user whose posts to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "max_results": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 100,
+              "minimum": 5,
+              "description": "Maximum number of posts to return (5-100, default: 10)"
+            },
+            "tweet.fields": {
+              "type": "string",
+              "default": "id,text,created_at,public_metrics,context_annotations",
+              "description": "Comma-separated list of tweet fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_POST_RETWEETS",
+    "description": "Get users who have retweeted a specific post. Returns user information for those who retweeted.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_POST_RETWEETS",
+      "canonical_tool_description_hash": "d941566cc6d51d955dcc0e787297c5f9c2af10cbdd803674a424a4b75d72a7d2",
+      "canonical_tool_input_schema_hash": "6b68561f701fff00866adc310718ae0a341f983e70eb561bb41c9c47278e59e9"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the post to get retweets for"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "max_results": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Maximum number of users to return (1-100, default: 100)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username,public_metrics",
+              "description": "Comma-separated list of user fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_USER_BY_ID",
+    "description": "Retrieve user information by user ID. Returns detailed user profile data including metrics and verification status.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_USER_BY_ID",
+      "canonical_tool_description_hash": "65b65462dd6846d00314e8d49276d3ff793e23ef5f738718b2f598ab449f8758",
+      "canonical_tool_input_schema_hash": "942f0ea41830f13ae9c3113be27087eb5e0d63ff1ca87d47214a8edb4972bdee"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the user to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username,description,public_metrics,verified,created_at",
+              "description": "Comma-separated list of user fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_USERS_BY_IDS",
+    "description": "Retrieve multiple users by their IDs. Returns detailed user profile data for up to 100 users.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_USERS_BY_IDS",
+      "canonical_tool_description_hash": "b12afcb057bd70e22d4dbbb8cc4e7606a71260c079d6691b8b858256642a21ec",
+      "canonical_tool_input_schema_hash": "bfc2f9d5aa5c4f05a3282240766abd9802f44811ea8087b18968deb80684be58"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["ids"],
+          "properties": {
+            "ids": {
+              "type": "string",
+              "description": "Comma-separated list of user IDs (up to 100)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username,description,public_metrics,verified",
+              "description": "Comma-separated list of user fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_USER_BY_USERNAME",
+    "description": "Retrieve user information by username. Returns detailed user profile data including metrics and verification status.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_USER_BY_USERNAME",
+      "canonical_tool_description_hash": "6a102171a94c26dc03d300760349f91e5a13497c5a68b93fa70b38e78d4b5ed8",
+      "canonical_tool_input_schema_hash": "2d0bc1abfda9e51a3b2f61e4fb692292af15ecd39459b085ecb4aafb9d73c35a"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["username"],
+          "properties": {
+            "username": {
+              "type": "string",
+              "description": "The username (handle) of the user to retrieve, without the @ symbol"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username,description,public_metrics,verified,created_at",
+              "description": "Comma-separated list of user fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_USERS_BY_USERNAMES",
+    "description": "Retrieve multiple users by their usernames. Returns detailed user profile data for up to 100 users.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_USERS_BY_USERNAMES",
+      "canonical_tool_description_hash": "a25b4ac0803fca9544e25f2a76c9fc9bbb9ae618595e2d1f0687e80827422f68",
+      "canonical_tool_input_schema_hash": "882acea35fee4236a64ada268085c2f4cb6282fdcbffd13334b1d19416a354c2"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["usernames"],
+          "properties": {
+            "usernames": {
+              "type": "string",
+              "description": "Comma-separated list of usernames (up to 100, without @ symbol)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username,description,public_metrics,verified",
+              "description": "Comma-separated list of user fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_LIST_BY_ID",
+    "description": "Retrieve detailed information about a specific list by its ID. Returns list metadata and settings.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_LIST_BY_ID",
+      "canonical_tool_description_hash": "241fbd1bf6c7c97776e329196599816a08292790f5d48095113c258108ca6bfb",
+      "canonical_tool_input_schema_hash": "07775e14d755ddccb5076f522376bd2a1a619bce16454db1b29fa47d374a03b5"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the list to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "list.fields": {
+              "type": "string",
+              "default": "id,name,description,member_count,private,owner_id",
+              "description": "Comma-separated list of list fields to include"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username",
+              "description": "Comma-separated list of user fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_USER_OWNED_LISTS",
+    "description": "Get lists owned by a specific user. Returns list information for lists they created.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_USER_OWNED_LISTS",
+      "canonical_tool_description_hash": "ba31d37e6acff40b7f0929530be392aa9f838b268e95baeccb8152b3ec06b246",
+      "canonical_tool_input_schema_hash": "132090f89c9836076e1aba48713793cb3cbe41c743b7c17ad9ff8c2175becc99"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the user whose owned lists to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "list.fields": {
+              "type": "string",
+              "default": "id,name,description,member_count,private",
+              "description": "Comma-separated list of list fields to include"
+            },
+            "max_results": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Maximum number of lists to return (1-100, default: 100)"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_LIST_POSTS",
+    "description": "Get posts from a specific list. Returns recent posts from list members.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_LIST_POSTS",
+      "canonical_tool_description_hash": "9d58144f524cc1bbe50224dca1aa94229d7f59e0fc57556af7cd558d89ba87aa",
+      "canonical_tool_input_schema_hash": "fafc5ad0b33bf0d7c6095df9cf42e5cbad2a03eaad8cf516989dd8921233679f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the list whose posts to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "max_results": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 100,
+              "minimum": 5,
+              "description": "Maximum number of posts to return (5-100, default: 100)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username",
+              "description": "Comma-separated list of user fields to include"
+            },
+            "tweet.fields": {
+              "type": "string",
+              "default": "id,text,author_id,created_at,public_metrics",
+              "description": "Comma-separated list of tweet fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_LIST_MEMBERS",
+    "description": "Get members of a specific list. Returns user information for list members.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_LIST_MEMBERS",
+      "canonical_tool_description_hash": "318ba5f28ed1239ed799ebda84c9c12b52b7c352440f05c53c68c3019ae0f964",
+      "canonical_tool_input_schema_hash": "f6973acace1bb9cccf98f48a259afdd713ff5e0eb1709f0ad8ea63af1fb50088"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the list whose members to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "max_results": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Maximum number of members to return (1-100, default: 100)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username,description,public_metrics",
+              "description": "Comma-separated list of user fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_USER_LIST_MEMBERSHIPS",
+    "description": "Get lists that a specific user is a member of. Returns list information for their memberships.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_USER_LIST_MEMBERSHIPS",
+      "canonical_tool_description_hash": "d6b5dcf91c1cb40f0619f4c18614c10aa798b1127c6da0288e62c3919573283f",
+      "canonical_tool_input_schema_hash": "886cbc0251b971f5ca436bde3019347f6d428b1aae56464aad70a3ec6279f88d"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the user whose list memberships to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "list.fields": {
+              "type": "string",
+              "default": "id,name,description,member_count,private,owner_id",
+              "description": "Comma-separated list of list fields to include"
+            },
+            "max_results": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Maximum number of lists to return (1-100, default: 100)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username",
+              "description": "Comma-separated list of user fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_USER_FOLLOWED_LISTS",
+    "description": "Get lists that a specific user follows. Returns list information for lists they follow.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_USER_FOLLOWED_LISTS",
+      "canonical_tool_description_hash": "f23f8801eabc6e923fd75fc3b1874852b0924148ceea278739ee7ef0d9e12471",
+      "canonical_tool_input_schema_hash": "bfb2dd27e1b717ce53f943309f3bc0e649e3c306709eb907873da3bbba53738e"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the user whose followed lists to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "list.fields": {
+              "type": "string",
+              "default": "id,name,description,member_count,private,owner_id",
+              "description": "Comma-separated list of list fields to include"
+            },
+            "max_results": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Maximum number of lists to return (1-100, default: 100)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username",
+              "description": "Comma-separated list of user fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_SPACE_BY_ID",
+    "description": "Retrieve detailed information about a specific Space by its ID. Returns Space metadata and settings.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SPACE_BY_ID",
+      "canonical_tool_description_hash": "927d533fac9ffc9eea338ca457739e4bd0dc6cc5c44acaccc2bd1eb335be8d41",
+      "canonical_tool_input_schema_hash": "08273caddea7b13c2b4b0702ab4f8e8249051c751b396d855d27b95c09681a97"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the Space to retrieve"
+            }
+          },
+          "description": "Path parameters",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username",
+              "description": "Comma-separated list of user fields to include"
+            },
+            "space.fields": {
+              "type": "string",
+              "default": "id,state,created_at,title,host_ids,speaker_ids,participant_count",
+              "description": "Comma-separated list of Space fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_SPACES_BY_IDS",
+    "description": "Retrieve multiple Spaces by their IDs. Returns detailed information for up to 100 Spaces.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SPACES_BY_IDS",
+      "canonical_tool_description_hash": "e14d70c57fd88aa18594dc105f0e8906280b1633ea7fe3fe8a54b140abe1e83d",
+      "canonical_tool_input_schema_hash": "0b3e47c31b5b4a113223b77c250c8eda62a69ab0608072a8bb1c00d120b51880"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["ids"],
+          "properties": {
+            "ids": {
+              "type": "string",
+              "description": "Comma-separated list of Space IDs (up to 100)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username",
+              "description": "Comma-separated list of user fields to include"
+            },
+            "space.fields": {
+              "type": "string",
+              "default": "id,state,created_at,title,host_ids,participant_count",
+              "description": "Comma-separated list of Space fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__GET_SPACES_BY_CREATOR_IDS",
+    "description": "Get Spaces created by specific users. Returns Space information for Spaces they created.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_SPACES_BY_CREATOR_IDS",
+      "canonical_tool_description_hash": "daaf918e79b3906dea983b9d92c0ba40868289b30369a9db39ec4fbf5c8c7e90",
+      "canonical_tool_input_schema_hash": "42bdee974df1908f2bd935c8d551ff9e5968985dd83e0391c7c1e5f0056337c5"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["user_ids"],
+          "properties": {
+            "user_ids": {
+              "type": "string",
+              "description": "Comma-separated list of user IDs whose created Spaces to retrieve (up to 100)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username",
+              "description": "Comma-separated list of user fields to include"
+            },
+            "space.fields": {
+              "type": "string",
+              "default": "id,state,created_at,title,host_ids,participant_count",
+              "description": "Comma-separated list of Space fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__SEARCH_SPACES",
+    "description": "Search for live or scheduled Spaces matching specified search terms. Returns matching Spaces.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH_SPACES",
+      "canonical_tool_description_hash": "47a20fe46ca5b301c7300af5fc1781ba5660468157608c39e003d422aa6faf02",
+      "canonical_tool_input_schema_hash": "8e0bbe320181724720d797cf0bff890c0f2463c0312db76963b763352d96e955"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["query"],
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "Search query for Spaces"
+            },
+            "max_results": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Maximum number of Spaces to return (1-100, default: 10)"
+            },
+            "user.fields": {
+              "type": "string",
+              "default": "id,name,username",
+              "description": "Comma-separated list of user fields to include"
+            },
+            "space.fields": {
+              "type": "string",
+              "default": "id,state,created_at,title,host_ids,participant_count",
+              "description": "Comma-separated list of Space fields to include"
+            }
+          },
+          "description": "Query parameters",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__PUBLISH_POST",
+    "description": "Creates and publishes a text post on X.com with optional poll support. For basic text posts, only provide the 'text' field. To create a poll, include both 'text' and 'poll' fields. The poll field should only be included when creating a poll with valid options (2-4 options) and duration.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "PUBLISH_POST",
+      "canonical_tool_description_hash": "f66b57d7ba5b31d3b2946d97be39ed8b95eeac307af15d57f7551079c43af252",
+      "canonical_tool_input_schema_hash": "c83c6f950ff2e22afe77fce7ec5519a716d603e4856e7afeba495b4b5ff3a799"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["body"],
+      "properties": {
+        "body": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "poll": {
+              "type": "object",
+              "required": [],
+              "properties": {
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 4,
+                  "minItems": 2,
+                  "description": "Poll options (2-4 options required)"
+                },
+                "duration_minutes": {
+                  "type": "integer",
+                  "maximum": 10080,
+                  "minimum": 5,
+                  "description": "Poll duration in minutes (5 minutes to 7 days)"
+                }
+              },
+              "description": "Poll options for a Tweet with a poll. IMPORTANT: Only include this object if you want to create a poll. If not creating a poll, completely omit this field from the request. This is mutually exclusive from Media, Quote Tweet Id, and Card URI.",
+              "additionalProperties": false
+            },
+            "text": {
+              "type": "string",
+              "description": "The content of the Tweet."
+            }
+          },
+          "description": "Request body for creating a post",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/youtube/tools.json
+++ b/backend/mcp_servers/youtube/tools.json
@@ -1,0 +1,332 @@
+[
+  {
+    "name": "YOUTUBE__SEARCH",
+    "description": "Search for YouTube resources including videos, channels, and playlists using various criteria. Quota impact: 100 units per call.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "SEARCH",
+      "canonical_tool_description_hash": "0b122cccfde450c2ef8feb5f742796700612684ec81463ec1116f70cdace965d",
+      "canonical_tool_input_schema_hash": "06ac6411f2ddde63ea9130183b2e72227fc5ff706023c294551bcb3dc59ac731"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "q": {
+              "type": "string",
+              "description": "The q parameter specifies the query term to search for. Your request can also use the Boolean NOT (-) and OR (|) operators to exclude videos or to find videos that are associated with one of several search terms."
+            },
+            "type": {
+              "enum": [
+                "video",
+                "channel",
+                "playlist",
+                "video,channel",
+                "video,playlist",
+                "channel,playlist",
+                "video,channel,playlist"
+              ],
+              "type": "string",
+              "default": "video,channel,playlist",
+              "description": "The type parameter restricts a search query to only retrieve a particular type of resource."
+            },
+            "order": {
+              "enum": ["date", "rating", "relevance", "title", "videoCount", "viewCount"],
+              "type": "string",
+              "default": "relevance",
+              "description": "The order parameter specifies the method that will be used to order resources in the API response. date \u2013 Resources are sorted in reverse chronological order based on the date they were created. rating \u2013 Resources are sorted from highest to lowest rating. relevance \u2013 Resources are sorted based on their relevance to the search query. This is the default value for this parameter. title \u2013 Resources are sorted alphabetically by title. videoCount \u2013 Channels are sorted in descending order of their number of uploaded videos. viewCount \u2013 Resources are sorted from highest to lowest number of views."
+            },
+            "forMine": {
+              "type": "boolean",
+              "description": "This parameter can only be used in a properly authorized request. The forMine parameter restricts the search to only retrieve videos owned by the authenticated user. If set to true, the request must also set the type parameter value to video and cannot use certain video parameters."
+            },
+            "location": {
+              "type": "string",
+              "description": "The location parameter restricts a search to videos that have a geographical location specified in their metadata. The value is a string that specifies geographic coordinates in the format latitude,longitude (e.g., 37.42307,-122.08427). If you specify a value for this parameter, you must also set the locationRadius parameter."
+            },
+            "channelId": {
+              "type": "string",
+              "description": "The channelId parameter indicates that the API response should only contain resources created by the channel."
+            },
+            "eventType": {
+              "enum": ["completed", "live", "upcoming"],
+              "type": "string",
+              "description": "The eventType parameter restricts a search to broadcast events. If you specify a value for this parameter, you must also set the type parameter's value to video."
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "The pageToken parameter identifies a specific page in the result set that should be returned."
+            },
+            "videoType": {
+              "enum": ["any", "episode", "movie"],
+              "type": "string",
+              "default": "any",
+              "description": "The videoType parameter lets you restrict a search to a particular type of videos. If you specify a value for this parameter, you must also set the type parameter's value to video."
+            },
+            "maxResults": {
+              "type": "integer",
+              "default": 5,
+              "maximum": 50,
+              "minimum": 0,
+              "description": "The maxResults parameter specifies the maximum number of items that should be returned in the result set."
+            },
+            "regionCode": {
+              "type": "string",
+              "default": "US",
+              "description": "The regionCode parameter instructs the API to return search results for videos that can be viewed in the specified country. The parameter value is an ISO 3166-1 alpha-2 country code."
+            },
+            "safeSearch": {
+              "enum": ["moderate", "none", "strict"],
+              "type": "string",
+              "default": "moderate",
+              "description": "The safeSearch parameter indicates whether the search results should include restricted content as well as standard content."
+            },
+            "channelType": {
+              "enum": ["any", "show"],
+              "type": "string",
+              "default": "any",
+              "description": "The channelType parameter lets you restrict a search to a particular type of channel."
+            },
+            "forDeveloper": {
+              "type": "boolean",
+              "description": "This parameter can only be used in a properly authorized request. The forDeveloper parameter restricts the search to only retrieve videos uploaded via the developer's application or website. The API server uses the request's authorization credentials to identify the developer."
+            },
+            "videoCaption": {
+              "enum": ["any", "closedCaption", "none"],
+              "type": "string",
+              "default": "any",
+              "description": "The videoCaption parameter indicates whether the API should filter video search results based on whether they have captions. If you specify a value for this parameter, you must also set the type parameter's value to video."
+            },
+            "videoLicense": {
+              "enum": ["any", "creativeCommon", "youtube"],
+              "type": "string",
+              "default": "any",
+              "description": "The videoLicense parameter filters search results to only include videos with a particular license. If you specify a value for this parameter, you must also set the type parameter's value to video."
+            },
+            "videoDuration": {
+              "enum": ["any", "long", "medium", "short"],
+              "type": "string",
+              "default": "any",
+              "description": "The videoDuration parameter filters video search results based on their duration. If you specify a value for this parameter, you must also set the type parameter's value to video."
+            },
+            "locationRadius": {
+              "type": "string",
+              "description": "The locationRadius parameter specifies the geographic area to search within for videos. The value must be a floating point number followed by a measurement unit (e.g., 5km). Valid measurement units are m, km, ft, and mi. The API does not support locationRadius values larger than 1000 kilometers."
+            },
+            "publishedAfter": {
+              "type": "string",
+              "description": "The publishedAfter parameter indicates that the API response should only contain resources created at or after the specified time (RFC 3339 format, e.g., 1970-01-01T00:00:00Z)."
+            },
+            "videoDimension": {
+              "enum": ["2d", "3d", "any"],
+              "type": "string",
+              "default": "any",
+              "description": "The videoDimension parameter lets you restrict a search to only retrieve 2D or 3D videos. If you specify a value for this parameter, you must also set the type parameter's value to video."
+            },
+            "forContentOwner": {
+              "type": "boolean",
+              "description": "This parameter can only be used in a properly authorized request, and it is intended exclusively for YouTube content partners. The forContentOwner parameter restricts the search to only retrieve videos owned by the content owner identified by the onBehalfOfContentOwner parameter. If set to true, the request must also include the onBehalfOfContentOwner parameter, be associated with a content owner account, set the type parameter value to video, and cannot use certain video parameters."
+            },
+            "publishedBefore": {
+              "type": "string",
+              "description": "The publishedBefore parameter indicates that the API response should only contain resources created before or at the specified time (RFC 3339 format, e.g., 2025-12-31T23:59:59Z)."
+            },
+            "videoCategoryId": {
+              "type": "string",
+              "description": "The videoCategoryId parameter filters video search results based on their category. Use YOUTUBE__GET_VIDEO_CATEGORIES to get the list of available categories."
+            },
+            "videoDefinition": {
+              "enum": ["any", "high", "standard"],
+              "type": "string",
+              "default": "any",
+              "description": "The videoDefinition parameter lets you restrict a search to only include either high definition (HD) or standard definition (SD) videos. HD videos are available for playback in at least 720p, though higher resolutions, like 1080p, might also be available."
+            },
+            "videoEmbeddable": {
+              "enum": ["any", "true"],
+              "type": "string",
+              "default": "any",
+              "description": "The videoEmbeddable parameter lets you to restrict a search to only videos that can be embedded into a webpage. If you specify a value for this parameter, you must also set the type parameter's value to video."
+            },
+            "videoSyndicated": {
+              "enum": ["any", "true"],
+              "type": "string",
+              "default": "any",
+              "description": "The videoSyndicated parameter lets you to restrict a search to only videos that can be played outside youtube.com. If you specify a value for this parameter, you must also set the type parameter's value to video."
+            },
+            "relevanceLanguage": {
+              "type": "string",
+              "description": "The relevanceLanguage parameter instructs the API to return search results that are most relevant to the specified language. The parameter value is typically an ISO 639-1 two-letter language code. However, you should use the values zh-Hans for simplified Chinese and zh-Hant for traditional Chinese."
+            }
+          },
+          "description": "Query parameters for the YouTube search request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "YOUTUBE__GET_VIDEO_DETAILS",
+    "description": "Get detailed information about specific YouTube videos by ID. Quota impact: 1 unit per call.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_VIDEO_DETAILS",
+      "canonical_tool_description_hash": "e1c586cbb4ba82fa2710a56d5535dc55b8e86e4afd6b1f331ee8856f26b01555",
+      "canonical_tool_input_schema_hash": "fdcb8aff5f6dcde11c3c6cfe231895fd062d14665af6da546b528bf320f62758"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "hl": {
+              "type": "string",
+              "default": "en_US",
+              "description": "The hl parameter instructs the API to retrieve localized resource metadata for a specific application language that the YouTube website supports."
+            },
+            "id": {
+              "type": "string",
+              "description": "The id parameter specifies a comma-separated list of YouTube video IDs."
+            },
+            "chart": {
+              "enum": ["mostPopular"],
+              "type": "string",
+              "default": "mostPopular",
+              "description": "The chart parameter identifies the chart that you want to retrieve."
+            },
+            "maxWidth": {
+              "type": "integer",
+              "maximum": 8192,
+              "minimum": 72,
+              "description": "The maxWidth parameter specifies the maximum width of the embedded player returned in the player.embedHtml property."
+            },
+            "myRating": {
+              "enum": ["like", "dislike"],
+              "type": "string",
+              "description": "This parameter can only be used in a properly authorized request. Set this parameter's value to like or dislike to instruct the API to only return videos liked or disliked by the authenticated user."
+            },
+            "maxHeight": {
+              "type": "integer",
+              "maximum": 8192,
+              "minimum": 72,
+              "description": "The maxHeight parameter specifies the maximum height of the embedded player returned in the player.embedHtml property."
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "The pageToken parameter identifies a specific page in the result set that should be returned."
+            },
+            "maxResults": {
+              "type": "integer",
+              "default": 5,
+              "maximum": 50,
+              "minimum": 1,
+              "description": "The maxResults parameter specifies the maximum number of items that should be returned in the result set. Only supported with myRating parameter."
+            },
+            "regionCode": {
+              "type": "string",
+              "description": "The regionCode parameter instructs the API to select a video chart available in the specified region. This parameter can only be used in conjunction with the chart parameter. ISO 3166-1 alpha-2 country code."
+            },
+            "videoCategoryId": {
+              "type": "string",
+              "default": "0",
+              "description": "The videoCategoryId parameter identifies the video category for which the chart should be retrieved. This parameter can only be used in conjunction with the chart parameter."
+            },
+            "onBehalfOfContentOwner": {
+              "type": "string",
+              "description": "This parameter can only be used in a properly authorized request. Note: This parameter is intended exclusively for YouTube content partners."
+            }
+          },
+          "description": "Query parameters for the YouTube video details request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "YOUTUBE__RATE_VIDEO",
+    "description": "Add a like or dislike rating to a video or remove a rating from a video.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "RATE_VIDEO",
+      "canonical_tool_description_hash": "00bfc8b9d4da75d6f6393e3f2e0fc2573d54d17e57e866219662873969b457f3",
+      "canonical_tool_input_schema_hash": "24f6a13c4a5785247650df51c839fa4ff92bca73b7c106363eebfadd04cb4047"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["id", "rating"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The id parameter specifies the YouTube video ID of the video that is being rated or having its rating removed."
+            },
+            "rating": {
+              "enum": ["like", "dislike", "none"],
+              "type": "string",
+              "default": "like",
+              "description": "Specifies the rating to record."
+            }
+          },
+          "description": "Query parameters for the YouTube video rating request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "YOUTUBE__GET_VIDEO_CATEGORIES",
+    "description": "Retrieve a list of video categories that can be associated with YouTube videos. Quota impact: 1 unit per call.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GET_VIDEO_CATEGORIES",
+      "canonical_tool_description_hash": "928246c029138628dcc351607df419a0a532af20a65c0da937aed3a515cf8c8a",
+      "canonical_tool_input_schema_hash": "3ea364842b11c0572ee2e3d63fa1e1524f749b64451e2e8f22cae4b8d7e83399"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["part"],
+          "properties": {
+            "hl": {
+              "type": "string",
+              "default": "en_US",
+              "description": "The hl parameter specifies the language that should be used for text values in the API response."
+            },
+            "id": {
+              "type": "string",
+              "description": "The id parameter specifies a comma-separated list of video category IDs for the resources that you are retrieving. This parameter cannot be used with the regionCode parameter."
+            },
+            "part": {
+              "enum": ["snippet"],
+              "type": "string",
+              "default": "snippet",
+              "description": "The part parameter specifies the videoCategory resource properties that the API response will include."
+            },
+            "regionCode": {
+              "type": "string",
+              "description": "The regionCode parameter instructs the API to return the list of video categories available in the specified country. The parameter value is an ISO 3166-1 alpha-2 country code. This parameter cannot be used with the id parameter."
+            }
+          },
+          "description": "Query parameters for the YouTube video categories request",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/backend/mcp_servers/zenrows/tools.json
+++ b/backend/mcp_servers/zenrows/tools.json
@@ -1,0 +1,167 @@
+[
+  {
+    "name": "ZENROWS__DISCOVER_AMAZON_PRODUCTS",
+    "description": "Navigate through Amazon search results or category pages to collect product information such as titles, prices, and URLs using ZenRows Amazon Discovery API.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "DISCOVER_AMAZON_PRODUCTS",
+      "canonical_tool_description_hash": "e919097cc4542a7e4e3fdff242b0586d4d5baabc8c37ddec1c3caaf084a86ee2",
+      "canonical_tool_input_schema_hash": "4523a85a03bd66c15384929dfb36ec55c48f563e1ac7c4b92f91c00bfb07d38f"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["search_term"],
+          "properties": {
+            "search_term": {
+              "type": "string",
+              "pattern": "^[\\w\\s\\+]+$",
+              "description": "The search term for Amazon products (e.g., 'Echo Dot')"
+            }
+          },
+          "description": "Path parameters for Amazon discovery",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "tld": {
+              "type": "string",
+              "default": ".com",
+              "description": "Amazon top-level domain (e.g., '.com', '.de', '.it')"
+            },
+            "country": {
+              "type": "string",
+              "default": "us",
+              "description": "Country code for Amazon site (e.g., 'us', 'es')"
+            }
+          },
+          "description": "Query parameters for discovering Amazon product information",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ZENROWS__GOOGLE_SEARCH_RESULTS",
+    "description": "Extract search results from a Google search query using ZenRows Google Search Results API. Returns structured JSON data containing titles, URLs, and snippets.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "GOOGLE_SEARCH_RESULTS",
+      "canonical_tool_description_hash": "2e53142d2a28ce56734417113fe3f0f3ab740698b9a300783b2dddb0602f6547",
+      "canonical_tool_input_schema_hash": "5fd8b42a8956201cfc3cd7314d7d59e7a1da53c79a45a508e2a64d4fbacf1671"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["url"],
+          "properties": {
+            "tld": {
+              "type": "string",
+              "default": ".com",
+              "description": "Google top-level domain (e.g., '.com', '.ca', '.co.uk')"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "The full Google search URL (e.g., 'https://www.google.com/search?q=web+scraping')"
+            },
+            "country": {
+              "type": "string",
+              "description": "Country code for the Google search (e.g., 'us', 'es')"
+            }
+          },
+          "description": "Query parameters for retrieving Google search results",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ZENROWS__ZILLOW_PROPERTY_DATA",
+    "description": "Retrieve detailed property information for a specified Zillow property using ZenRows Zillow Property Data API. Returns structured data including address, price, and specifications based on the provided ZPID.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ZILLOW_PROPERTY_DATA",
+      "canonical_tool_description_hash": "a5c7077aec84dc0bfadd58b3c98aec775630aacdc45c41d7feb88be98255ee0f",
+      "canonical_tool_input_schema_hash": "67a3bd05fcc1cdb062a2d109eb177725b639a5974d67a93475d66d538ea316e5"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "object",
+          "required": ["zpid"],
+          "properties": {
+            "zpid": {
+              "type": "string",
+              "pattern": "^[0-9]{7,10}$",
+              "description": "The Zillow Property ID (ZPID) for the property, a 7-10 digit number (e.g., '2081512050')"
+            }
+          },
+          "description": "Path parameters for retrieving Zillow property information",
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URL of the Zillow property page (e.g., 'https://www.zillow.com/homedetails/2081512050_zpid')"
+            },
+            "country": {
+              "type": "string",
+              "default": "us",
+              "description": "Country code for the Zillow site (e.g., 'us')"
+            }
+          },
+          "description": "Query parameters for retrieving Zillow property information",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "ZENROWS__ZILLOW_DISCOVERY",
+    "description": "Retrieve property listings from Zillow search results using ZenRows Zillow Discovery API. Returns structured data based on the provided search URL.",
+    "tags": [],
+    "tool_metadata": {
+      "canonical_tool_name": "ZILLOW_DISCOVERY",
+      "canonical_tool_description_hash": "3a7ee1d8b26c05b883f0c97e10a8285ae188a52245efd13d681d6dc0ad5fa7df",
+      "canonical_tool_input_schema_hash": "cd74ae6e36e8469e6c5f6d2ecccb9a32256dd21202a8762e2ef7668cc7c8aaf0"
+    },
+    "input_schema": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "object",
+          "required": ["url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URL-encoded Zillow search URL (e.g., 'https://www.zillow.com/ks/?searchQueryState=%7B%7D')"
+            }
+          },
+          "description": "Query parameters for retrieving Zillow search results",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+]


### PR DESCRIPTION
### 📝 Description
- generate tools.json files for mcp servers (that are backed by virtual mcp servers)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added generated tools.json files for virtual MCP servers to standardize tool metadata and input schemas across many integrations. Also expanded Gmail and major Google/Microsoft tools for broader coverage.

- **New Features**
  - Added tools.json for 50+ integrations (e.g., Airtable, Brave Search, Baidu Map, Figma, Browserbase, Cal.com, Calendly, Dexscreener, Dify, Feishu).
  - Comprehensive Google and Microsoft coverage (Calendar, Sheets, Docs, Meet, Tasks; Microsoft Calendar, OneDrive).
  - Updated Gmail tools.json with message operations and improved SEND_EMAIL schema formatting.
  - Standardized metadata (canonical_tool_name and description/input_schema hashes) for consistency and deduping.
  - Clear input_schema structures (path/query/body) with validations to improve tool reliability.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a large set of new tool integrations across many services (Gmail, Google Calendar/Docs/Sheets/Maps/Meet/Tasks, Microsoft Calendar/OneDrive/Outlook/Teams, Figma, ElevenLabs, Airtable, Coda, Calendly, Cal.com, Discord, Brave Search, arXiv, and many more).

* **Chores**
  * Added a pre-commit hook to auto-format JSON files.

* **Bug Fixes**
  * Emit user-facing warnings when MCP server configuration or account is missing during auth retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->