### PR TITLE
feat: rate limiting mcp server tools refreshing

### DIFF
--- a/backend/aci/control_plane/exceptions.py
+++ b/backend/aci/control_plane/exceptions.py
@@ -262,3 +262,16 @@ class MCPToolsNormalizationError(ControlPlaneException):
             message=message,
             error_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
+
+
+class MCPToolsRefreshTooFrequent(ControlPlaneException):
+    """
+    Exception raised when an MCP tools refresh is too frequent
+    """
+
+    def __init__(self, message: str | None = None):
+        super().__init__(
+            title="MCP tools refresh too frequent",
+            message=message,
+            error_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        )


### PR DESCRIPTION
### 📝 Description
Applying a 1 minute rate limit on refetching mcp server tools

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a 1-minute rate limit to the MCP server tools refresh endpoint to prevent rapid re-syncs and reduce load. Requests within the window now return 429.

- **New Features**
  - Blocks refreshes if last_synced_at is within 1 minute of now.
  - Adds MCPToolsRefreshTooFrequent exception for clearer errors.
  - Returns 403 when attempting to refresh a public MCP server.
  - Tests cover rate limit behavior and org/public access.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to MCP tools refresh: repeated requests within one minute now return 429 with a clear message.
  * Blocked manual refresh for public MCP servers, returning 403 to indicate insufficient scope.
  * Improved error feedback for overly frequent refresh attempts.

* **Tests**
  * Added tests covering org scope restrictions, rate-limiting (429), and successful refresh behavior, ensuring correct responses and single invocation when allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->