### PR TITLE
unify container port to 8000

### DIFF
--- a/backend/Dockerfile.mcp
+++ b/backend/Dockerfile.mcp
@@ -17,4 +17,4 @@ COPY ./aci/__init__.py /workdir/aci/__init__.py
 # remove unecessary or sensitive files (.env files are skipped by default specified in .dockerignore)
 RUN rm -rf /workdir/aci/mcp/tests
 
-CMD ["uvicorn", "aci.mcp.main:app", "--proxy-headers", "--forwarded-allow-ips=*", "--host", "0.0.0.0", "--port", "8001", "--no-access-log"]
+CMD ["uvicorn", "aci.mcp.main:app", "--proxy-headers", "--forwarded-allow-ips=*", "--host", "0.0.0.0", "--port", "8000", "--no-access-log"]

--- a/backend/Dockerfile.virtual_mcp
+++ b/backend/Dockerfile.virtual_mcp
@@ -17,4 +17,4 @@ COPY ./aci/__init__.py /workdir/aci/__init__.py
 # remove unecessary or sensitive files (.env files are skipped by default specified in .dockerignore)
 RUN rm -rf /workdir/aci/virtual_mcp/tests
 
-CMD ["uvicorn", "aci.virtual_mcp.main:app", "--proxy-headers", "--forwarded-allow-ips=*", "--host", "0.0.0.0", "--port", "8002", "--no-access-log"]
+CMD ["uvicorn", "aci.virtual_mcp.main:app", "--proxy-headers", "--forwarded-allow-ips=*", "--host", "0.0.0.0", "--port", "8000", "--no-access-log"]

--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -69,8 +69,8 @@ services:
       - ./aci/mcp:/workdir/aci/mcp
       - ./aci/common:/workdir/aci/common
     ports:
-      - "8001:8001"
-    command: uvicorn aci.mcp.main:app --reload --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 8001 --no-access-log
+      - "8001:8000"
+    command: uvicorn aci.mcp.main:app --reload --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 8000 --no-access-log
     depends_on:
       db:
         condition: service_healthy
@@ -91,8 +91,8 @@ services:
       - ./aci/virtual_mcp:/workdir/aci/virtual_mcp
       - ./aci/common:/workdir/aci/common
     ports:
-      - "8002:8002"
-    command: uvicorn aci.virtual_mcp.main:app --reload --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 8002 --no-access-log
+      - "8002:8000"
+    command: uvicorn aci.virtual_mcp.main:app --reload --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 8000 --no-access-log
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
### 📝 Description
- All services now running on 8000 in container. We just expose different localhost port for each.
- AWS fargate tasks and ALB target groups should change accordingly
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized all backend containers to listen on port 8000. docker-compose now maps mcp to 8001->8000 and virtual_mcp to 8002->8000; no app behavior change.

- **Migration**
  - Update Fargate task definitions: set containerPort to 8000 for both services.
  - Update ALB target groups: change target port to 8000; listeners can remain unchanged.
  - Move any health checks off 8001/8002 to 8000.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - None

- Chores
  - Standardized MCP backend and virtual MCP containers to listen on port 8000.
  - Updated Docker configuration and compose setup to map host ports: 8001→8000 (MCP) and 8002→8000 (Virtual MCP).
  - External ports remain unchanged; existing connections to 8001 and 8002 continue to work without modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->