### PR TITLE
Feat/update delete mcp servers

### DIFF
--- a/backend/aci/cli/README.md
+++ b/backend/aci/cli/README.md
@@ -5,17 +5,17 @@
 ### Upsert an MCP Server
 
 ```bash
-docker compose exec runner python -m aci.cli upsert-mcp-server --mcp-server-file ./mcp_servers/notion/server.json --secrets-file ./mcp_servers/notion/.secrets.json
+docker compose exec runner python -m aci.cli mcp upsert-server --server-file ./mcp_servers/notion/server.json
 
-docker compose exec runner python -m aci.cli upsert-mcp-server --mcp-server-file ./mcp_servers/notion/server.json --secrets-file ./mcp_servers/notion/.secrets.json --skip-dry-run
+docker compose exec runner python -m aci.cli mcp upsert-server --server-file ./mcp_servers/notion/server.json --skip-dry-run
 ```
 
 ### Upsert MCP Tools
 
 ```bash
-docker compose exec runner python -m aci.cli upsert-mcp-tools --mcp-tools-file ./mcp_servers/notion/tools.json
+docker compose exec runner python -m aci.cli mcp upsert-tools --tools-file ./mcp_servers/notion/tools.json
 
-docker compose exec runner python -m aci.cli upsert-mcp-tools --mcp-tools-file ./mcp_servers/notion/tools.json --skip-dry-run
+docker compose exec runner python -m aci.cli mcp upsert-tools --tools-file ./mcp_servers/notion/tools.json --skip-dry-run
 ```
 
 #### Create a mock organization, teams and users setting

--- a/backend/aci/common/db/crud/mcp_servers.py
+++ b/backend/aci/common/db/crud/mcp_servers.py
@@ -101,6 +101,14 @@ def update_mcp_server(
     return mcp_server
 
 
+def delete_mcp_server(
+    db_session: Session,
+    mcp_server_id: UUID,
+) -> None:
+    mcp_server = get_mcp_server_by_id(db_session, mcp_server_id, throw_error_if_not_found=True)
+    db_session.delete(mcp_server)
+
+
 def list_mcp_servers(
     db_session: Session,
     organization_id: UUID | None = None,

--- a/backend/aci/common/schemas/mcp_server.py
+++ b/backend/aci/common/schemas/mcp_server.py
@@ -26,6 +26,15 @@ class MCPServerPartialUpdateRequest(BaseModel):
     logo: str | None = Field(default=None)
     categories: list[str] | None = Field(default=None)
 
+    @model_validator(mode="after")
+    def reject_explicit_none(self) -> "MCPServerPartialUpdateRequest":
+        non_nullable_fields = ["description", "logo", "categories"]
+
+        for field in non_nullable_fields:
+            if field in self.model_fields_set and getattr(self, field) is None:
+                raise ValueError(f"{field} cannot be set to null")
+        return self
+
 
 class MCPServerPartialUpdate(BaseModel):
     """

--- a/backend/aci/common/schemas/mcp_server.py
+++ b/backend/aci/common/schemas/mcp_server.py
@@ -17,6 +17,16 @@ class MCPServerMetadata(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class MCPServerPartialUpdateRequest(BaseModel):
+    """Used for API schema validation"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    description: str | None = Field(default=None)
+    logo: str | None = Field(default=None)
+    categories: list[str] | None = Field(default=None)
+
+
 class MCPServerPartialUpdate(BaseModel):
     """
     Used for Partial Updating data to the database.

--- a/backend/aci/control_plane/exceptions.py
+++ b/backend/aci/control_plane/exceptions.py
@@ -308,3 +308,14 @@ class InvalidInvitationTokenError(ControlPlaneException):
             message=message,
             error_code=status.HTTP_400_BAD_REQUEST,
         )
+
+
+class MCPServerNotFoundError(ControlPlaneException):
+    """Raised when an MCP server is not found."""
+
+    def __init__(self, message: str | None = None):
+        super().__init__(
+            title="MCP server not found",
+            message=message,
+            error_code=status.HTTP_404_NOT_FOUND,
+        )

--- a/backend/aci/control_plane/routes/mcp_servers.py
+++ b/backend/aci/control_plane/routes/mcp_servers.py
@@ -270,6 +270,8 @@ async def update_mcp_server(
     mcp_server = crud.mcp_servers.update_mcp_server(
         context.db_session,
         mcp_server,
+        # Here the `body` is validated by the `MCPServerPartialUpdateRequest` model, should not
+        # contain non-nullable fields set to None
         MCPServerPartialUpdate.model_validate(body.model_dump(exclude_unset=True)),
         mcp_server_embedding,
     )

--- a/backend/aci/control_plane/routes/mcp_servers.py
+++ b/backend/aci/control_plane/routes/mcp_servers.py
@@ -252,8 +252,12 @@ async def update_mcp_server(
             MCPServerEmbeddingFields(
                 name=mcp_server.name,
                 url=mcp_server.url,
-                description=body.description or mcp_server.description,
-                categories=body.categories or mcp_server.categories,
+                description=body.description
+                if body.description is not None
+                else mcp_server.description,
+                categories=body.categories
+                if body.categories is not None
+                else mcp_server.categories,
             ),
         )
     else:

--- a/backend/aci/control_plane/routes/mcp_servers.py
+++ b/backend/aci/control_plane/routes/mcp_servers.py
@@ -293,6 +293,10 @@ async def delete_mcp_server(
     )
 
     crud.mcp_servers.delete_mcp_server(context.db_session, mcp_server_id)
+
+    # TODO: Remove all Orphan records related to this MCP server
+    # (MCP server configurations, Connected Accounts, MCPServerBundle)
+
     context.db_session.commit()
 
 

--- a/backend/aci/control_plane/tests/routes/mcp_servers/test_mcp_servers.py
+++ b/backend/aci/control_plane/tests/routes/mcp_servers/test_mcp_servers.py
@@ -429,6 +429,18 @@ def test_delete_mcp_server(
             ),
             False,
         ),
+        (
+            MCPServerPartialUpdateRequest(
+                description="",
+            ),
+            True,
+        ),
+        (
+            MCPServerPartialUpdateRequest(
+                categories=[],
+            ),
+            True,
+        ),
         (MCPServerPartialUpdateRequest(), False),
     ],
 )

--- a/frontend/src/app/(dashboard)/mcp-servers/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/mcp-servers/[id]/page.tsx
@@ -226,7 +226,7 @@ export default function MCPServerDetailPage() {
         <div className="flex items-center gap-2">
           <PermissionGuard permission={PERMISSIONS.MCP_CONFIGURATION_CREATE}>
             <Button onClick={() => setIsConfigModalOpen(true)}>
-              <Plus className="h-4 w-4 mr-2" />
+              <Plus className="mr-2 h-4 w-4" />
               Configure Server
             </Button>
           </PermissionGuard>
@@ -240,12 +240,12 @@ export default function MCPServerDetailPage() {
               >
                 {updateMutation.isPending ? (
                   <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                     Updating...
                   </>
                 ) : (
                   <>
-                    <Edit className="h-4 w-4 mr-2" />
+                    <Edit className="mr-2 h-4 w-4" />
                     Edit
                   </>
                 )}
@@ -262,12 +262,12 @@ export default function MCPServerDetailPage() {
               >
                 {deleteMutation.isPending ? (
                   <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                     Deleting...
                   </>
                 ) : (
                   <>
-                    <Trash2 className="h-4 w-4 mr-2" />
+                    <Trash2 className="mr-2 h-4 w-4" />
                     Delete
                   </>
                 )}

--- a/frontend/src/features/mcp/api/mcp.service.ts
+++ b/frontend/src/features/mcp/api/mcp.service.ts
@@ -63,6 +63,11 @@ export const mcpService = {
       const api = createAuthenticatedRequest(token);
       return api.post<ToolsSyncResult>(`${API_ENDPOINTS.SERVERS}/${serverId}/refresh-tools`, {});
     },
+
+    delete: async (token: string, serverId: string): Promise<void> => {
+      const api = createAuthenticatedRequest(token);
+      return api.delete(`${API_ENDPOINTS.SERVERS}/${serverId}`);
+    },
   },
 
   // MCP Server Configurations endpoints (requires auth)

--- a/frontend/src/features/mcp/api/mcp.service.ts
+++ b/frontend/src/features/mcp/api/mcp.service.ts
@@ -70,10 +70,7 @@ export const mcpService = {
       data: { description?: string; logo?: string },
     ): Promise<MCPServerPublic> => {
       const api = createAuthenticatedRequest(token);
-      return api.patch<MCPServerPublic>(
-        `${API_ENDPOINTS.SERVERS}/${serverId}`,
-        data,
-      );
+      return api.patch<MCPServerPublic>(`${API_ENDPOINTS.SERVERS}/${serverId}`, data);
     },
 
     delete: async (token: string, serverId: string): Promise<void> => {

--- a/frontend/src/features/mcp/api/mcp.service.ts
+++ b/frontend/src/features/mcp/api/mcp.service.ts
@@ -64,6 +64,18 @@ export const mcpService = {
       return api.post<ToolsSyncResult>(`${API_ENDPOINTS.SERVERS}/${serverId}/refresh-tools`, {});
     },
 
+    update: async (
+      token: string,
+      serverId: string,
+      data: { description?: string; logo?: string },
+    ): Promise<MCPServerPublic> => {
+      const api = createAuthenticatedRequest(token);
+      return api.patch<MCPServerPublic>(
+        `${API_ENDPOINTS.SERVERS}/${serverId}`,
+        data,
+      );
+    },
+
     delete: async (token: string, serverId: string): Promise<void> => {
       const api = createAuthenticatedRequest(token);
       return api.delete(`${API_ENDPOINTS.SERVERS}/${serverId}`);

--- a/frontend/src/features/mcp/components/delete-server-dialog.tsx
+++ b/frontend/src/features/mcp/components/delete-server-dialog.tsx
@@ -49,15 +49,12 @@ export function DeleteServerDialog({
       <AlertDialogContent className="max-w-md">
         <AlertDialogHeader>
           <AlertDialogTitle>
-            Are you sure you want to delete &ldquo;{serverName}&rdquo; MCP
-            server?
+            Are you sure you want to delete &ldquo;{serverName}&rdquo; MCP server?
           </AlertDialogTitle>
-          <AlertDialogDescription>
-            This action cannot be undone.
-          </AlertDialogDescription>
+          <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
         </AlertDialogHeader>
         <div className="space-y-4 py-2">
-          <div className="text-sm text-muted-foreground space-y-1">
+          <div className="space-y-1 text-sm text-muted-foreground">
             <p>• All server configurations will be deleted</p>
             <p>• Connected accounts will be removed</p>
             <p>• Server will be removed from all bundles</p>
@@ -67,7 +64,7 @@ export function DeleteServerDialog({
           <div className="space-y-2">
             <p className="text-sm text-muted-foreground">
               To confirm, type{" "}
-              <span className="inline-flex items-center px-2 py-0.5 rounded-md bg-muted font-mono text-xs font-medium text-foreground">
+              <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 font-mono text-xs font-medium text-foreground">
                 {expectedDeleteText}
               </span>{" "}
               below:
@@ -93,7 +90,7 @@ export function DeleteServerDialog({
           >
             {isPending ? (
               <>
-                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 Deleting...
               </>
             ) : (

--- a/frontend/src/features/mcp/components/delete-server-dialog.tsx
+++ b/frontend/src/features/mcp/components/delete-server-dialog.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+
+interface DeleteServerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  serverName: string;
+  onConfirm: () => void | Promise<void>;
+  isPending?: boolean;
+}
+
+export function DeleteServerDialog({
+  open,
+  onOpenChange,
+  serverName,
+  onConfirm,
+  isPending = false,
+}: DeleteServerDialogProps) {
+  const [deleteConfirmText, setDeleteConfirmText] = useState("");
+  const expectedDeleteText = `delete ${serverName}`;
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      setDeleteConfirmText("");
+    }
+    onOpenChange(newOpen);
+  };
+
+  const handleConfirm = async () => {
+    await onConfirm();
+    setDeleteConfirmText("");
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent className="max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Are you sure you want to delete &ldquo;{serverName}&rdquo; MCP
+            server?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="text-sm text-muted-foreground space-y-1">
+            <p>• All server configurations will be deleted</p>
+            <p>• Connected accounts will be removed</p>
+            <p>• Server will be removed from all bundles</p>
+            <p>• Teams will lose access to this server</p>
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              To confirm, type{" "}
+              <span className="inline-flex items-center px-2 py-0.5 rounded-md bg-muted font-mono text-xs font-medium text-foreground">
+                {expectedDeleteText}
+              </span>{" "}
+              below:
+            </p>
+            <Input
+              value={deleteConfirmText}
+              onChange={(e) => setDeleteConfirmText(e.target.value)}
+              placeholder=""
+              className="font-mono shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              autoComplete="off"
+              disabled={isPending}
+              aria-disabled={isPending}
+            />
+          </div>
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={deleteConfirmText !== expectedDeleteText || isPending}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            aria-busy={isPending}
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              "Delete"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/features/mcp/components/update-server-dialog.tsx
+++ b/frontend/src/features/mcp/components/update-server-dialog.tsx
@@ -20,10 +20,7 @@ interface UpdateServerDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   server: MCPServerPublic;
-  onConfirm: (data: {
-    description?: string;
-    logo?: string;
-  }) => void | Promise<void>;
+  onConfirm: (data: { description?: string; logo?: string }) => void | Promise<void>;
   isPending?: boolean;
 }
 
@@ -85,8 +82,7 @@ export function UpdateServerDialog({
     }
   };
 
-  const hasChanges =
-    description !== (server.description ?? "") || logo !== (server.logo ?? "");
+  const hasChanges = description !== (server.description ?? "") || logo !== (server.logo ?? "");
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -94,9 +90,7 @@ export function UpdateServerDialog({
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Update &ldquo;{server.name}&rdquo;</DialogTitle>
-            <DialogDescription>
-              Update the server description and logo URL.
-            </DialogDescription>
+            <DialogDescription>Update the server description and logo URL.</DialogDescription>
           </DialogHeader>
 
           <div className="space-y-4 py-4">
@@ -134,14 +128,10 @@ export function UpdateServerDialog({
             >
               Cancel
             </Button>
-            <Button
-              type="submit"
-              disabled={!hasChanges || isPending}
-              aria-busy={isPending}
-            >
+            <Button type="submit" disabled={!hasChanges || isPending} aria-busy={isPending}>
               {isPending ? (
                 <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   Updating...
                 </>
               ) : (

--- a/frontend/src/features/mcp/components/update-server-dialog.tsx
+++ b/frontend/src/features/mcp/components/update-server-dialog.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { MCPServerPublic } from "../types/mcp.types";
+
+interface UpdateServerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  server: MCPServerPublic;
+  onConfirm: (data: {
+    description?: string;
+    logo?: string;
+  }) => void | Promise<void>;
+  isPending?: boolean;
+}
+
+export function UpdateServerDialog({
+  open,
+  onOpenChange,
+  server,
+  onConfirm,
+  isPending = false,
+}: UpdateServerDialogProps) {
+  const [description, setDescription] = useState("");
+  const [logo, setLogo] = useState("");
+
+  // Initialize form with current server data when dialog opens
+  useEffect(() => {
+    if (open && server) {
+      setDescription(server.description || "");
+      setLogo(server.logo || "");
+    }
+  }, [open, server]);
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      // Reset form when closing
+      setDescription(server?.description || "");
+      setLogo(server?.logo || "");
+    }
+    onOpenChange(newOpen);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // Only include fields that have changed
+    const updateData: { description?: string; logo?: string } = {};
+
+    if (description !== server.description) {
+      updateData.description = description;
+    }
+
+    if (logo !== server.logo) {
+      updateData.logo = logo;
+    }
+
+    // Only proceed if there are changes
+    if (Object.keys(updateData).length > 0) {
+      await onConfirm(updateData);
+    } else {
+      // Close dialog if no changes
+      onOpenChange(false);
+    }
+  };
+
+  const hasChanges = description !== server.description || logo !== server.logo;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Update &ldquo;{server.name}&rdquo;</DialogTitle>
+            <DialogDescription>
+              Update the server description and logo URL.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Enter server description..."
+                disabled={isPending}
+                className="min-h-[80px]"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="logo">Logo URL</Label>
+              <Input
+                id="logo"
+                type="url"
+                value={logo}
+                onChange={(e) => setLogo(e.target.value)}
+                placeholder="https://example.com/logo.png"
+                disabled={isPending}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!hasChanges || isPending}
+              aria-busy={isPending}
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Updating...
+                </>
+              ) : (
+                "Update Server"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/mcp/components/update-server-dialog.tsx
+++ b/frontend/src/features/mcp/components/update-server-dialog.tsx
@@ -40,8 +40,8 @@ export function UpdateServerDialog({
   // Initialize form with current server data when dialog opens
   useEffect(() => {
     if (open && server) {
-      setDescription(server.description || "");
-      setLogo(server.logo || "");
+      setDescription(server.description ?? "");
+      setLogo(server.logo ?? "");
     }
   }, [open, server]);
 
@@ -61,7 +61,15 @@ export function UpdateServerDialog({
     const updateData: { description?: string; logo?: string } = {};
 
     if (description !== server.description) {
-      updateData.description = description;
+      const originalDescription = server.description ?? "";
+      const originalLogo = server.logo ?? "";
+
+      if (description !== originalDescription) {
+        updateData.description = description;
+      }
+      if (logo !== originalLogo) {
+        updateData.logo = logo;
+      }
     }
 
     if (logo !== server.logo) {
@@ -77,7 +85,8 @@ export function UpdateServerDialog({
     }
   };
 
-  const hasChanges = description !== server.description || logo !== server.logo;
+  const hasChanges =
+    description !== (server.description ?? "") || logo !== (server.logo ?? "");
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/frontend/src/features/mcp/hooks/use-mcp-servers.ts
+++ b/frontend/src/features/mcp/hooks/use-mcp-servers.ts
@@ -187,6 +187,40 @@ export function useMCPTool(toolName: string) {
   });
 }
 
+// Hook to update an MCP server with permission check
+export function useUpdateMCPServer() {
+  const { accessToken, checkPermission } = useMetaInfo();
+  const queryClient = useQueryClient();
+
+  const canUpdate = checkPermission(PERMISSIONS.CUSTOM_MCP_SERVER_UPDATE);
+
+  return useMutation({
+    mutationFn: ({
+      serverId,
+      data,
+    }: {
+      serverId: string;
+      data: { description?: string; logo?: string };
+    }) => {
+      if (!canUpdate) {
+        throw new Error("You do not have permission to update MCP servers");
+      }
+      return mcpService.servers.update(accessToken!, serverId, data);
+    },
+    onSuccess: (updatedServer, { serverId }) => {
+      // Update the specific server in the cache
+      queryClient.setQueryData(
+        mcpQueryKeys.servers.detail(serverId),
+        updatedServer,
+      );
+      // Also invalidate the servers list to refresh it
+      queryClient.invalidateQueries({
+        queryKey: mcpQueryKeys.servers.all,
+      });
+    },
+  });
+}
+
 // Hook to delete an MCP server with permission check
 export function useDeleteMCPServer() {
   const { accessToken, checkPermission } = useMetaInfo();

--- a/frontend/src/features/mcp/hooks/use-mcp-servers.ts
+++ b/frontend/src/features/mcp/hooks/use-mcp-servers.ts
@@ -186,3 +186,26 @@ export function useMCPTool(toolName: string) {
     enabled: !!accessToken && !!toolName,
   });
 }
+
+// Hook to delete an MCP server with permission check
+export function useDeleteMCPServer() {
+  const { accessToken, checkPermission } = useMetaInfo();
+  const queryClient = useQueryClient();
+
+  const canDelete = checkPermission(PERMISSIONS.CUSTOM_MCP_SERVER_DELETE);
+
+  return useMutation({
+    mutationFn: (serverId: string) => {
+      if (!canDelete) {
+        throw new Error("You do not have permission to delete MCP servers");
+      }
+      return mcpService.servers.delete(accessToken!, serverId);
+    },
+    onSuccess: () => {
+      // Invalidate servers list to refetch
+      queryClient.invalidateQueries({
+        queryKey: mcpQueryKeys.servers.all,
+      });
+    },
+  });
+}

--- a/frontend/src/features/mcp/hooks/use-mcp-servers.ts
+++ b/frontend/src/features/mcp/hooks/use-mcp-servers.ts
@@ -209,10 +209,7 @@ export function useUpdateMCPServer() {
     },
     onSuccess: (updatedServer, { serverId }) => {
       // Update the specific server in the cache
-      queryClient.setQueryData(
-        mcpQueryKeys.servers.detail(serverId),
-        updatedServer,
-      );
+      queryClient.setQueryData(mcpQueryKeys.servers.detail(serverId), updatedServer);
       // Also invalidate the servers list to refresh it
       queryClient.invalidateQueries({
         queryKey: mcpQueryKeys.servers.all,

--- a/frontend/src/lib/rbac/permissions.ts
+++ b/frontend/src/lib/rbac/permissions.ts
@@ -4,6 +4,8 @@ export const PERMISSIONS = {
 
   CUSTOM_MCP_SERVER_CREATE: "custom_mcp_server:create",
   CUSTOM_MCP_SERVER_SYNC: "custom_mcp_server:sync_tools",
+  CUSTOM_MCP_SERVER_DELETE: "custom_mcp_server:delete",
+  CUSTOM_MCP_SERVER_UPDATE: "custom_mcp_server:update",
 
   // MCP Configuration permissions
   MCP_CONFIGURATION_PAGE_VIEW: "mcp_configuration:page_view",
@@ -34,6 +36,8 @@ export const ROLE_PERMISSIONS: Record<string, readonly Permission[]> = {
 
     PERMISSIONS.CUSTOM_MCP_SERVER_CREATE,
     PERMISSIONS.CUSTOM_MCP_SERVER_SYNC,
+    PERMISSIONS.CUSTOM_MCP_SERVER_DELETE,
+    PERMISSIONS.CUSTOM_MCP_SERVER_UPDATE,
 
     // MCP Configuration - Admins can view, create and delete configurations
     PERMISSIONS.MCP_CONFIGURATION_PAGE_VIEW,


### PR DESCRIPTION
### 🏷️ Ticket
https://www.notion.so/Custom-MCP-Server-Update-and-Remove-Custom-MCP-Server-2748378d6a478009bbf3dc42f5924ede?v=c135b6e7f76243819caf99a83e291380&source=copy_link

### 📝 Description
- Allow admin to update and delete Custom MCP Servers

<img width="1297" height="473" alt="Screenshot 2025-09-29 at 13 26 05" src="https://github.com/user-attachments/assets/fcd646bb-b4ad-4971-b38b-5d7b2ddb3393" />
<img width="845" height="533" alt="Screenshot 2025-09-29 at 13 26 08" src="https://github.com/user-attachments/assets/1dfc236d-59d4-406e-ab73-0f6a474ebd10" />
<img width="981" height="673" alt="Screenshot 2025-09-29 at 13 26 11" src="https://github.com/user-attachments/assets/ee5d6a85-1fbe-4ede-b339-adf9869ffea3" />


<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds admin-only update and delete actions for Custom MCP Servers across backend and UI. Embeddings are regenerated when relevant fields change, and access control is enforced.

- **New Features**
  - Backend: PATCH and DELETE /mcp-servers/{id} with org-admin checks; public servers cannot be modified.
  - Embedding regeneration when description or categories change; transactional updates and deletes.
  - Frontend: Edit and Delete buttons with dialogs, permission guards, and React Query cache updates.
  - RBAC: Added custom_mcp_server:update and custom_mcp_server:delete permissions.
  - Tests cover access control and update flows; CLI README updated to new mcp subcommands.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update and delete custom MCP servers from the dashboard via confirm/update dialogs, loading states, and success/error toasts; actions gated by ownership and admin permissions.

* **API**
  * Added server PATCH and DELETE endpoints; partial updates supported and embeddings regenerated when relevant.

* **Permissions**
  * New admin permissions to control MCP server update and delete actions.

* **Documentation**
  * CLI command and flag renames for MCP upsert flows.

* **Tests**
  * Expanded coverage for update/delete flows, permission checks, and embedding regeneration.

* **Errors**
  * New explicit "MCP server not found" 404 error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->