### PR TITLE
add main readme and template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: 🐛 Bug Report
+description: Report a bug or issue in the MCP Gateway.
+title: "[Your Bug Report Title Here]"
+type: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure the issue is clear, reproducible, and easy to act on. (Feel free to ask in [Discussions](https://github.com/aipotheosis-labs/mcp-gateway/discussions) first if unsure)
+
+  - type: checkboxes
+    id: pre-requisites
+    attributes:
+      label: "Required Pre-requisites"
+      description: "Please make sure you've completed the following steps before submitting. Thank you! 🙏"
+      options:
+        - label: "I have read the [Documentation](https://www.aci.dev/docs)"
+          required: true
+        - label: "I have searched the [Issue Tracker](https://github.com/aipotheosis-labs/mcp-gateway/issues) and [Discussions](https://github.com/aipotheosis-labs/mcp-gateway/discussions) that this hasn't been reported yet."
+          required: true
+        - label: "Consider asking in [Discussions](https://github.com/aipotheosis-labs/mcp-gateway/discussions) first"
+          required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: "Please provide a clear and concise description of the bug or issue, the expected behavior, the actual behavior, and steps to reproduce the issue. Thank you! 🙏"
+      placeholder: |
+        Description:
+
+        Expected behavior:
+
+        Actual behavior:
+
+        Steps to reproduce:
+
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: >-
+        Add any other context about the problem here. Screenshots, logs, etc may also be helpful.
+
+        If you know or suspect the reason for this bug, paste the code lines and suggest modifications.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: 💡 Feature Request
+description: Request a new feature or enhancement in the MCP Gateway.
+title: "[Your Feature Request Title Here]"
+type: feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure the feature request is clear, reproducible, and easy to act on. (Feel free to ask in [Discussions](https://github.com/aipotheosis-labs/mcp-gateway/discussions) first if unsure)
+
+  - type: checkboxes
+    id: pre-requisites
+    attributes:
+      label: "Required Pre-requisites"
+      description: "Please make sure you've completed the following steps before submitting. Thank you!"
+      options:
+        - label: "I have read the [Documentation](https://www.aci.dev/docs)"
+          required: true
+        - label: "I have searched the [Issue Tracker](https://github.com/aipotheosis-labs/mcp-gateway/issues) and [Discussions](https://github.com/aipotheosis-labs/mcp-gateway/discussions) that this hasn't been reported yet."
+          required: true
+        - label: "Consider asking in [Discussions](https://github.com/aipotheosis-labs/mcp-gateway/discussions) first"
+          required: false
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: "Motivation"
+      description: "Please provide a clear and concise description of the feature request, the motivation for the feature, and any additional context that would be helpful. Thank you! 🙏"
+      placeholder: |
+        Motivation:
+
+        Additional context:
+
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: "Proposed Solution"
+      description: "Please provide a description of the proposed solution."
+      placeholder: |
+        Proposed solution:
+
+        Additional context:
+
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
-# MCP Gateway
+<p align="center">
+  <img src="frontend/public/aci-dev-full-logo-light-bg.svg" alt="ACI.dev Logo" width="100%">
+</p>
+
+# {PLACEHOLDER: product name}: Open-Source {PLACEHOLDER: tagline}
+
+
+
+<p align="center">
+  <a href="https://aci.dev/docs"><img src="https://img.shields.io/badge/Documentation-34a1bf" alt="Documentation"></a>
+  <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
+  <a href="https://discord.com/invite/UU2XAnfHJh"><img src="https://img.shields.io/discord/1349424813550342275?logo=discord&label=Discord&color=7289DA" alt="Discord"></a>
+  <a href="https://x.com/AipoLabs"><img src="https://img.shields.io/twitter/follow/AipoLabs?style=social" alt="Twitter Follow"></a>
+</p>
+
+
+{PLACEHOLDER: intro & example usecase & description}
+
+
+
+![ACI.dev Architecture]{PLACEHOLDER: architecture or product diagram}
+
+<p align="center">
+  Join us on <a href="https://discord.com/invite/UU2XAnfHJh">Discord</a> to help shape the future of AI governance.<br/><br/>
+  🌟 <strong>Star ACI.dev to stay updated on new releases!</strong><br/><br/>
+  <a href="https://github.com/aipotheosis-labs/mcp-gateway/stargazers">
+    <img src="https://img.shields.io/github/stars/aipotheosis-labs/mcp-gateway?style=social" alt="GitHub Stars">
+  </a>
+</p>
+
+## 📺 Demo Video
+{PLACEHOLDER: demo video}
+
+## ✨ Key Features
+
+- **{PLACEHOLDER: feature 1}**: {PLACEHOLDER: feature 1 description}
+- **{PLACEHOLDER: feature 2}**: {PLACEHOLDER: feature 2 description}
+- **{PLACEHOLDER: feature 3}**: {PLACEHOLDER: feature 3 description}
+
+
+## 💡 Why Use {PLACEHOLDER: product name}?
+
+{PLACEHOLDER: one line reason}
+
+- **{PLACEHOLDER: reason 1}**: {PLACEHOLDER: reason 1 description}
+- **{PLACEHOLDER: reason 2}**: {PLACEHOLDER: reason 2 description}
+- **{PLACEHOLDER: feature 3}**: {PLACEHOLDER: feature 3 description}
+
+
+## 🧰 Common Use Cases
+
+- **{PLACEHOLDER: use case 1}**: {PLACEHOLDER: use case 1 description}
+- **{PLACEHOLDER: use case 2}**: {PLACEHOLDER: use case 2 description}
+
+## 🔗 Quick Links
+
+- **Cloud Version:** [gateway.aci.dev](https://gateway.aci.dev/)
+- **Documentation:** [aci.dev/docs](https://www.aci.dev/docs)
+- **Blog:** [aci.dev/blog](https://www.aci.dev/blog)
+- **Community:** [Discord](https://discord.com/invite/UU2XAnfHJh) | [Twitter/X](https://x.com/AipoLabs) | [LinkedIn](https://www.linkedin.com/company/aci-dev-by-aipolabs/posts/?feedView=all)
+
+## 💻 Getting Started: Local Development
+
+To run the full {PLACEHOLDER: product name} platform (backend server and frontend portal) locally, follow the individual README files for each component:
+
+- **Backend:** [backend/README.md](backend/README.md)
+- **Frontend:** [frontend/README.md](frontend/README.md)
+
+## 👋 Contributing
+
+We welcome contributions! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for more information.


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Introduce a main README scaffold and GitHub issue templates to improve onboarding and standardize bug/feature submissions. This helps contributors file clear issues and gives users a starting point for docs, links, and local setup.

- **New Features**
  - Added GitHub issue templates: bug_report.yml and feature_request.yml with prerequisites, structured fields, and links to docs/discussions.
  - Rewrote root README with a product placeholder, badges, quick links, demo section, features/use cases outline, local dev pointers (backend/frontend), and contributing link.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added structured GitHub issue templates for bug reports and feature requests, including required checklists and guided fields to improve clarity and reproducibility.
  * Revamped README to a template-driven layout with branding placeholders, badges, quick links, and expanded Getting Started guidance, plus sections for architecture and demo resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->