### PR TITLE
backend readme

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,5 +1,41 @@
 # MCP Gateway Backend
 
+[![Backend Checks](https://github.com/aipotheosis-labs/mcp-gateway/actions/workflows/backend-checks.yml/badge.svg)](https://github.com/aipotheosis-labs/mcp-gateway/actions/workflows/backend-checks.yml)
+[![Backend Deployment](https://github.com/aipotheosis-labs/mcp-gateway/actions/workflows/backend-deployment.yml/badge.svg)](https://github.com/aipotheosis-labs/mcp-gateway/actions/workflows/backend-deployment.yml)
+[![Build Image](https://github.com/aipotheosis-labs/mcp-gateway/actions/workflows/ecs-build-image.yml/badge.svg)](https://github.com/aipotheosis-labs/mcp-gateway/actions/workflows/ecs-build-image.yml)
+[![Database Migration](https://github.com/aipotheosis-labs/mcp-gateway/actions/workflows/ecs-db-migration.yml/badge.svg)](https://github.com/aipotheosis-labs/mcp-gateway/actions/workflows/ecs-db-migration.yml)
+[![Deploy Service](https://github.com/aipotheosis-labs/mcp-gateway/actions/workflows/ecs-deploy-service.yml/badge.svg)](https://github.com/aipotheosis-labs/mcp-gateway/actions/workflows/ecs-deploy-service.yml)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+## Overview
+
+- [Code Structure](#code-structure)
+- [Development Setup](#development-setup)
+   - [Prerequisites](#prerequisites)
+   - [Code Style](#code-style)
+   - [IDE Configuration](#ide-configuration)
+   - [Getting Started](#getting-started)
+   - [Running Tests](#running-tests)
+- [Database Management](#database-management)
+   - [Working with Migrations](#working-with-migrations)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+## Code Structure
+
+The backend consists of several main components:
+
+- **ACI**: The root package for the MCP Gateway.
+  - **Alembic**: Database migrations
+  - **CLI**: Command-line interface for local development, admin operations, etc.
+  - **Common**: Shared code and utilities used across components
+  - **Control Plane**: The Service powering the core operations of the gateway
+  - **MCP**: The Service for hosting Remote MCP Servers
+  - **Virtual MCP**: The Service for hosting Virtual MCP Servers
+- **MCP Server**: MCP servers indexed by the MCP Gateway
+- **Virtual MCP Server**: Virtual MCP servers hosted by **Virtual MCP** service
+
 ## Development Setup
 
 ### Prerequisites
@@ -18,19 +54,7 @@ We follow strict code quality standards:
 
 ### IDE Configuration
 
-For VS Code users, configure Ruff formatter:
-
-```json
-{
-  "[python]": {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "charliermarsh.ruff",
-    "editor.codeActionsOnSave": {
-      "source.organizeImports.ruff": "always"
-    }
-  }
-}
-```
+For VS Code or VS Code compatible IDEs, use [`.vscode`](../.vscode) folder for configuration.
 
 ### Getting Started
 
@@ -62,8 +86,14 @@ For VS Code users, configure Ruff formatter:
 
    Most sensitive variables and dummy values are already defined in `.env.example`, so you only need to set the following env vars in `.env.local`:
 
-   - `CONTROL_PLANE_OPENAI_API_KEY`: Use your own OpenAI API key
-   - `CLI_OPENAI_API_KEY`: Use your own OpenAI API key (can be the same as `CONTROL_PLANE_OPENAI_API_KEY`)
+   - `CONTROL_PLANE_OPENAI_API_KEY`
+   - `MCP_OPENAI_API_KEY`
+   - `CLI_OPENAI_API_KEY`
+
+   You might need to set AWS related variables if you want to test relevant features
+   - `AWS_ACCESS_KEY_ID`
+   - `AWS_SECRET_ACCESS_KEY`
+   - `AWS_DEFAULT_REGION`
 
 1. Start services with Docker Compose:
 
@@ -74,22 +104,45 @@ For VS Code users, configure Ruff formatter:
    This will start:
 
    - `control-plane`: Backend API service
+   - `mcp`: MCP service
+   - `virtual-mcp`: Virtual MCP service
    - `runner`: Container for running commands like pytest, cli commands or scripts
+   - `test-runner`: Container for running pytest
+   - `db`: PostgreSQL database for local development
+   - `test-db`: PostgreSQL database for running pytest
 
-1. Seed the database with sample data:
+1. Seed the database with cli commands:
 
-   ```bash
-   docker compose exec runner ./scripts/seed_db.sh
-   ```
+   - Insert mcp servers and tools
 
-1. (Optional) Connect to the database using a GUI client (e.g., `DBeaver`)
+      ```bash
+      for server_dir in ./mcp_servers/*/; do
+        server_file="${server_dir}server.json"
+        tools_file="${server_dir}tools.json"
+        dotenv run python -m aci.cli mcp upsert-server --server-file "$server_file"
+        dotenv run python -m aci.cli mcp upsert-tools --tools-file "$tools_file"
+      done
+      ```
+
+   - Insert virtual mcp servers and tools
+
+      ```bash
+      for server_dir in ./virtual_mcp_servers/*/; do
+        server_file="${server_dir}server.json"
+        tools_file="${server_dir}tools.json"
+        dotenv run python -m aci.cli virtual-mcp upsert-server --server-file "$server_file"
+        dotenv run python -m aci.cli virtual-mcp upsert-tools --tools-file "$tools_file"
+      done
+      ```
+
+1. (Optional) Connect to the database using a GUI client (e.g., `Beekeeper Studio`)
 
    - Parameters for the db connection can be found in the `.env.local` file you created in step 4.
 
 1. Access the API documentation at:
 
    ```bash
-   http://localhost:8000/v1/control-plane-docs
+   http://localhost:8000/v1/control-plane/docs
    ```
 
 ### Running Tests
@@ -136,3 +189,11 @@ When making changes to database models:
    ```bash
    docker compose exec runner alembic downgrade -1
    ```
+
+## Contributing
+
+Please refer to the [Contributing Guide](../CONTRIBUTING.md) for details on making contributions to this project.
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](../LICENSE) file for details.


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Revamped the backend README to make setup and development clearer. Adds CI badges, code structure overview, CLI-based seeding, updated env vars, expanded Docker services, the new API docs URL, and links to contributing and license.

- **Migration**
  - Replace seed_db.sh with CLI commands to upsert MCP and Virtual MCP servers and tools.
  - Add MCP_OPENAI_API_KEY (and optional AWS_* vars) to .env.local.
  - Use the new API docs URL: http://localhost:8000/v1/control-plane/docs.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revamped README with badges and a clear Overview plus navigable sections.
  * Expanded Code Structure descriptions for major components.
  * Overhauled Development Setup: updated prerequisites, IDE guidance, env vars, and service startup steps.
  * Replaced legacy seeding with CLI-based data seeding for MCP and Virtual MCP.
  * Switched database tooling guidance to Beekeeper Studio.
  * Updated API docs URL path.
  * Added instructions for running tests via container.
  * Introduced Contributing and License sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->