### PR TITLE
add virtual mcp to cicd deployment

### DIFF
--- a/.github/workflows/backend-deployment.yml
+++ b/.github/workflows/backend-deployment.yml
@@ -17,6 +17,15 @@ jobs:
       image_tag: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha }}
       dockerfile: Dockerfile.control_plane
 
+  build-virtual-mcp:
+    name: Build Virtual MCP
+    uses: ./.github/workflows/ecs-build-image.yml
+    secrets: inherit
+    with:
+      ecr_repository_url: ${{ vars.CICD_ECR_REPOSITORY_URL_VIRTUAL_MCP }}
+      image_tag: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha }}
+      dockerfile: Dockerfile.virtual_mcp
+
   build-mcp:
     name: Build MCP
     uses: ./.github/workflows/ecs-build-image.yml
@@ -37,7 +46,7 @@ jobs:
 
   db-migration:
     name: Database Migration
-    needs: [build-control-plane, build-mcp, build-migration] # Make sure all images are prepared before running migrations
+    needs: [build-control-plane, build-virtual-mcp, build-mcp, build-migration] # Make sure all images are prepared before running migrations
     uses: ./.github/workflows/ecs-db-migration.yml
     secrets: inherit
     with:
@@ -57,6 +66,18 @@ jobs:
       ecs_service: ${{ vars.CICD_ECS_SERVICE_CONTROL_PLANE }}
       ecs_cluster: ${{ vars.CICD_ECS_CLUSTER }}
       ecr_repository_url: ${{ vars.CICD_ECR_REPOSITORY_URL_CONTROL_PLANE }}
+      image_tag: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha }}
+
+  deploy-virtual-mcp:
+    name: Deploy Virtual MCP
+    needs: [build-virtual-mcp, db-migration]
+    uses: ./.github/workflows/ecs-deploy-service.yml
+    secrets: inherit
+    with:
+      ecs_task_definition: ${{ vars.CICD_ECS_TASK_DEFINITION_VIRTUAL_MCP }}
+      ecs_service: ${{ vars.CICD_ECS_SERVICE_VIRTUAL_MCP }}
+      ecs_cluster: ${{ vars.CICD_ECS_CLUSTER }}
+      ecr_repository_url: ${{ vars.CICD_ECR_REPOSITORY_URL_VIRTUAL_MCP }}
       image_tag: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha }}
 
   deploy-mcp:


### PR DESCRIPTION
### 📝 Description
- as title
- added repo variables for CICD_ECS_TASK_DEFINITION_VIRTUAL_MCP, CICD_ECS_SERVICE_VIRTUAL_MCP, CICD_ECR_REPOSITORY_URL_VIRTUAL_MCP
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added Virtual MCP to the CI/CD pipeline so it builds, runs migrations, and deploys to ECS alongside existing services. This brings consistent image tagging and automated deployments for Virtual MCP.

- **New Features**
  - Added build-virtual-mcp job using Dockerfile.virtual_mcp and CICD_ECR_REPOSITORY_URL_VIRTUAL_MCP.
  - Added deploy-virtual-mcp job with CICD_ECS_TASK_DEFINITION_VIRTUAL_MCP and CICD_ECS_SERVICE_VIRTUAL_MCP; depends on db-migration.
  - Updated db-migration job to wait for the Virtual MCP build.
  - Introduced repo variables: CICD_ECS_TASK_DEFINITION_VIRTUAL_MCP, CICD_ECS_SERVICE_VIRTUAL_MCP, CICD_ECR_REPOSITORY_URL_VIRTUAL_MCP.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced build and deploy steps for the Virtual MCP service in the backend deployment pipeline.
  * Ensured database migrations depend on the Virtual MCP image build, reducing migration/deploy race conditions.
  * Automated Virtual MCP rollout using the same deployment pattern as existing services for consistency.
  * Improved release reliability and traceability for the Virtual MCP service through standardized CI/CD workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->