### PR TITLE
bug: remove trailing space from supabase server.json file; make virtu…

### DIFF
--- a/backend/aci/virtual_mcp/routes/mcp.py
+++ b/backend/aci/virtual_mcp/routes/mcp.py
@@ -158,7 +158,8 @@ def _parse_auth_token(x_virtual_mcp_auth_token: str) -> VirtualMCPAuthTokenData:
         token="1234567890"
     )
     """
-    token_data = x_virtual_mcp_auth_token.split(" ")
+    # Strip leading/trailing whitespace and split by any amount of whitespace
+    token_data = x_virtual_mcp_auth_token.strip().split()
     if len(token_data) != 3 and len(token_data) != 4:
         raise InvalidAuthTokenError()
 

--- a/backend/mcp_servers/supabase/server.json
+++ b/backend/mcp_servers/supabase/server.json
@@ -10,7 +10,7 @@
       "type": "api_key",
       "location": "header",
       "name": "Authorization",
-      "prefix": "Bearer "
+      "prefix": "Bearer"
     }
   ],
   "server_metadata": {


### PR DESCRIPTION
### 📝 Description
- fix supabase server.json typo
- making MS - VMS auth parsing more robust
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed a trailing space in Supabase server.json and made Virtual MCP auth token parsing handle extra whitespace. Prevents malformed headers and avoids auth failures.

- **Bug Fixes**
  - Supabase server.json: set Authorization prefix to "Bearer" (no trailing space).
  - Virtual MCP: strip and split auth token by any whitespace for more robust parsing.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication token handling to gracefully accept extra spaces or tabs in tokens, reducing login and request failures.
  * Corrected Authorization header formatting to use the proper Bearer scheme, improving compatibility with external services and preventing unauthorized errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->