### PR TITLE
Enhance header component with documentation link

### DIFF
--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -10,7 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 // import { GoBell } from "react-icons/go";
-import { BsQuestionCircle, BsDiscord } from "react-icons/bs";
+import { BsQuestionCircle, BsDiscord, BsBook } from "react-icons/bs";
 import { Separator } from "@/components/ui/separator";
 import { BreadcrumbLinks } from "./BreadcrumbLinks";
 import { usePathname } from "next/navigation";
@@ -55,6 +55,17 @@ export const Header = () => {
             <Button variant="outline" className="h-9 px-2">
               <BsDiscord />
               <span>Discord</span>
+            </Button>
+          </a>
+
+          <a
+            href="https://gate22-docs.aci.dev/introduction/overview"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button variant="outline" className="h-9 px-2">
+              <BsBook />
+              <span>Docs</span>
             </Button>
           </a>
 


### PR DESCRIPTION
### 🏷️ Ticket

https://github.com/aipotheosis-labs/gate22/issues/138

### 📝 Description

- Added a new button in the header component that links to the documentation page.
- Imported the BsBook icon from react-icons for visual representation of the Docs button.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
