### PR TITLE
Fix UI bug action button overlaping text

### DIFF
--- a/frontend/src/app/(dashboard)/available-mcp-servers/page.tsx
+++ b/frontend/src/app/(dashboard)/available-mcp-servers/page.tsx
@@ -264,7 +264,7 @@ export default function AvailableMCPServersPage() {
                     </div>
 
                     {/* Header content */}
-                    <CardHeader className="pb-3">
+                    <CardHeader className="block pb-3">
                       <div className="mb-2 flex items-start gap-3">
                         {config.mcp_server?.logo && (
                           <div className="flex size-10 shrink-0 items-center justify-center">
@@ -278,7 +278,7 @@ export default function AvailableMCPServersPage() {
                             />
                           </div>
                         )}
-                        <div className="min-w-0 flex-1 pr-12">
+                        <div className="min-w-0 flex-1 pr-28">
                           <CardTitle className="truncate text-base font-semibold">
                             {config.name}
                           </CardTitle>


### PR DESCRIPTION
### 🏷️ Ticket
#147 


### 📝 Description

I set the Card display to `block` so that the text remains within the bounds of the card and changed the `padding-right` in order to have a good-looking truncation, where the button does not overlap the server name.

### 📸 Screenshots
Before:
<img width="1710" height="1073" alt="Screenshot 2025-10-08 at 17 48 16" src="https://github.com/user-attachments/assets/12a5e581-b1df-4b87-8e86-447eda841b9b" />

After:
<img width="1710" height="1073" alt="Screenshot 2025-10-08 at 17 58 08" src="https://github.com/user-attachments/assets/717ecf6d-71fa-42b9-ad16-2aa9dd9d7cec" />


### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [x] I have linked this PR to an issue or a ticket (required)
- [x] All checks on CI passed
