### PR TITLE
fix: hotfix backend base path

### DIFF
--- a/frontend/src/features/settings/api/subscription.ts
+++ b/frontend/src/features/settings/api/subscription.ts
@@ -7,6 +7,7 @@ import {
   ChangeSubscriptionResponse,
   Plan,
 } from "../types/subscription.types";
+import { CONTROL_PLANE_PATH } from "@/config/api.constants";
 
 export const subscriptionApi = {
   getSubscriptionStatus: async (
@@ -15,7 +16,7 @@ export const subscriptionApi = {
   ): Promise<SubscriptionStatus> => {
     const api = createAuthenticatedRequest(token);
     return api.get<SubscriptionStatus>(
-      `/subscriptions/organizations/${organizationId}/subscription-status`,
+      `${CONTROL_PLANE_PATH}/subscriptions/organizations/${organizationId}/subscription-status`,
     );
   },
 
@@ -26,7 +27,7 @@ export const subscriptionApi = {
   ): Promise<ChangeSubscriptionResponse> => {
     const api = createAuthenticatedRequest(token);
     return api.post<ChangeSubscriptionResponse>(
-      `/subscriptions/organizations/${organizationId}/change-subscription`,
+      `${CONTROL_PLANE_PATH}/subscriptions/organizations/${organizationId}/change-subscription`,
       data,
     );
   },
@@ -38,7 +39,7 @@ export const subscriptionApi = {
   ): Promise<ChangeSubscriptionResponse> => {
     const api = createAuthenticatedRequest(token);
     return api.post<ChangeSubscriptionResponse>(
-      `/subscriptions/organizations/${organizationId}/subscription-seat-change`,
+      `${CONTROL_PLANE_PATH}/subscriptions/organizations/${organizationId}/subscription-seat-change`,
       data,
     );
   },
@@ -50,18 +51,20 @@ export const subscriptionApi = {
   ): Promise<ChangeSubscriptionResponse> => {
     const api = createAuthenticatedRequest(token);
     return api.post<ChangeSubscriptionResponse>(
-      `/subscriptions/organizations/${organizationId}/subscription-plan-change`,
+      `${CONTROL_PLANE_PATH}/subscriptions/organizations/${organizationId}/subscription-plan-change`,
       data,
     );
   },
 
   getPlans: async (token?: string): Promise<Plan[]> => {
     const api = createAuthenticatedRequest(token);
-    return api.get<Plan[]>("/subscriptions/plans");
+    return api.get<Plan[]>(`${CONTROL_PLANE_PATH}/subscriptions/plans`);
   },
 
   cancelSubscription: async (organizationId: string, token?: string): Promise<void> => {
     const api = createAuthenticatedRequest(token);
-    return api.post<void>(`/subscriptions/organizations/${organizationId}/cancel-subscription`);
+    return api.post<void>(
+      `${CONTROL_PLANE_PATH}/subscriptions/organizations/${organizationId}/cancel-subscription`,
+    );
   },
 };


### PR DESCRIPTION
### 🏷️ Ticket
https://www.notion.so/Subscription-Deployment-2918378d6a4780fba6f8edde21067f9f?v=c135b6e7f76243819caf99a83e291380&source=copy_link

### 📝 Description
Hotfix backend service base path URL
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Hotfixes the subscription API base path to use CONTROL_PLANE_PATH so requests route to the control plane. Restores subscription status, plan/seat changes, plan listing, and cancellation in Settings.

- **Bug Fixes**
  - Prefixed all subscription endpoints with CONTROL_PLANE_PATH (status, change, seat change, plan change, plans, cancel).

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal infrastructure for subscription-related API calls to enhance code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->