### PR TITLE
fix: count custom mcp server usage by org id

### DIFF
--- a/backend/aci/common/db/crud/mcp_servers.py
+++ b/backend/aci/common/db/crud/mcp_servers.py
@@ -148,3 +148,10 @@ def list_mcp_servers(
 
     servers = list(db_session.execute(statement).scalars().all())
     return servers
+
+
+def count_mcp_servers_by_organization_id(
+    db_session: Session,
+    organization_id: UUID,
+) -> int:
+    return db_session.query(MCPServer).filter(MCPServer.organization_id == organization_id).count()

--- a/backend/aci/common/entitlement_utils.py
+++ b/backend/aci/common/entitlement_utils.py
@@ -15,13 +15,13 @@ def get_organization_usage(db_session: Session, organization_id: UUID) -> Organi
         db_session=db_session,
         organization_id=organization_id,
     )
-    custom_mcp_servers_in_use = crud.mcp_servers.list_mcp_servers(
+    custom_mcp_servers_in_use = crud.mcp_servers.count_mcp_servers_by_organization_id(
         db_session=db_session,
         organization_id=organization_id,
     )
     return OrganizationUsage(
         seat_count=seat_in_use,
-        custom_mcp_servers_count=len(custom_mcp_servers_in_use),
+        custom_mcp_servers_count=custom_mcp_servers_in_use,
     )
 
 


### PR DESCRIPTION
### 🏷️ Ticket
https://www.notion.so/Subscription-Deployment-2918378d6a4780fba6f8edde21067f9f?v=c135b6e7f76243819caf99a83e291380&source=copy_link

### 📝 Description
fix: count custom mcp server usage by org id

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes custom MCP server usage counting by organization ID to return accurate totals in OrganizationUsage and avoid over/under counting.

- **Bug Fixes**
  - Added count_mcp_servers_by_organization_id and switched get_organization_usage to use it for precise counts without loading all servers.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database queries for organization resource counting to improve performance and reduce computational overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->